### PR TITLE
simplify flat hash map initialization for compile or runtime

### DIFF
--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -50,17 +50,15 @@ union ccc_fhmap_entry_
 
 #define ccc_impl_fhm_init(memory_ptr, capacity, key_field, fhash_elem_field,   \
                           alloc_fn, hash_fn, key_eq_fn, aux)                   \
-    (__extension__({                                                           \
-        struct ccc_fhmap_ new_fhmap_ = {};                                     \
-        __auto_type fhm_mem_ptr_ = (memory_ptr);                               \
-        new_fhmap_.buf_                                                        \
-            = (ccc_buffer)ccc_buf_init(fhm_mem_ptr_, alloc_fn, aux, capacity); \
-        ccc_impl_fhm_init_buf(                                                 \
-            &new_fhmap_, offsetof(typeof(*(fhm_mem_ptr_)), key_field),         \
-            offsetof(typeof(*(fhm_mem_ptr_)), fhash_elem_field), (hash_fn),    \
-            (key_eq_fn), (aux));                                               \
-        new_fhmap_;                                                            \
-    }))
+    {                                                                          \
+        .buf_                                                                  \
+        = (ccc_buffer)ccc_buf_init((memory_ptr), (alloc_fn), (aux), capacity), \
+        .hash_fn_ = (hash_fn),                                                 \
+        .eq_fn_ = (key_eq_fn),                                                 \
+        .key_offset_ = offsetof(typeof(*(memory_ptr)), key_field),             \
+        .hash_elem_offset_                                                     \
+        = offsetof(typeof(*(memory_ptr)), fhash_elem_field),                   \
+    }
 
 #define ccc_impl_fhm_zero_init(type_name, key_field, fhash_elem_field,         \
                                alloc_fn, hash_fn, key_eq_fn, aux)              \
@@ -84,9 +82,6 @@ union ccc_fhmap_entry_
         = offsetof(typeof(*(memory_ptr)), fhash_elem_field),                   \
     }
 
-void ccc_impl_fhm_init_buf(struct ccc_fhmap_ *, size_t key_offset,
-                           size_t hash_elem_offset, ccc_hash_fn *,
-                           ccc_key_eq_fn *, void *aux);
 struct ccc_ent_ ccc_impl_fhm_find(struct ccc_fhmap_ const *, void const *key,
                                   uint64_t hash);
 void ccc_impl_fhm_insert(struct ccc_fhmap_ *h, void const *e, uint64_t hash,

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -894,12 +894,12 @@ maybe_resize(struct ccc_fhmap_ *const h)
     {
         return CCC_MEM_ERR;
     }
-    (void)ccc_buf_size_set(&new_hash.buf_, num_swap_slots);
     /* Empty is intentionally chosen as zero so every byte is just set to
        0 in this new array. */
     (void)memset(ccc_buf_begin(&new_hash.buf_), CCC_FHM_EMPTY,
                  ccc_buf_capacity(&new_hash.buf_)
                      * ccc_buf_elem_size(&new_hash.buf_));
+    (void)ccc_buf_size_set(&new_hash.buf_, num_swap_slots);
     for (void *slot = ccc_buf_begin(&h->buf_);
          slot != ccc_buf_capacity_end(&h->buf_);
          slot = ccc_buf_next(&h->buf_, slot))

--- a/tests/fhmap/test_fhmap_construct.c
+++ b/tests/fhmap/test_fhmap_construct.c
@@ -39,7 +39,8 @@ gen(int *to_affect)
 
 static struct val s_vals[10];
 static flat_hash_map static_fh
-    = fhm_static_init(s_vals, key, e, fhmap_int_to_u64, fhmap_id_eq, NULL);
+    = fhm_init(s_vals, sizeof(s_vals) / sizeof(s_vals[0]), key, e, NULL,
+               fhmap_int_to_u64, fhmap_id_eq, NULL);
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_static_init)
 {
@@ -81,38 +82,12 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_static_init)
     CHECK_END_FN();
 }
 
-CHECK_BEGIN_STATIC_FN(fhmap_test_zero_init)
-{
-    flat_hash_map fh = fhm_zero_init(struct val, key, e, std_alloc,
-                                     fhmap_int_zero, fhmap_id_eq, NULL);
-    CHECK(is_empty(&fh), true);
-    CHECK(fhm_capacity(&fh), 0);
-    struct val def = {.key = 137, .val = 0};
-    fhmap_entry ent = entry(&fh, &def.key);
-    CHECK(unwrap(&ent) == NULL, true);
-    struct val *v = or_insert(entry_r(&fh, &def.key), &def.e);
-    CHECK(v != NULL, true);
-    v->val += 1;
-    struct val const *const inserted = get_key_val(&fh, &def.key);
-    CHECK((inserted != NULL), true);
-    CHECK(inserted->val, 1);
-    v = or_insert(entry_r(&fh, &def.key), &def.e);
-    CHECK(v != NULL, true);
-    v->val += 1;
-    CHECK(inserted->val, 2);
-    CHECK_END_FN(fhm_clear_and_free(&fh, NULL););
-}
-
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc)
 {
-    struct val src_vals[11];
-    struct val dst_vals[13];
-    flat_hash_map src
-        = fhm_init(src_vals, sizeof(src_vals) / sizeof(src_vals[0]), key, e,
-                   NULL, fhmap_int_zero, fhmap_id_eq, NULL);
-    flat_hash_map dst
-        = fhm_init(dst_vals, sizeof(dst_vals) / sizeof(dst_vals[0]), key, e,
-                   NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map src = fhm_init((struct val[11]){}, 11, key, e, NULL,
+                                 fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map dst = fhm_init((struct val[13]){}, 13, key, e, NULL,
+                                 fhmap_int_zero, fhmap_id_eq, NULL);
     (void)insert(&src, &(struct val){.key = 0}.e);
     (void)insert(&src, &(struct val){.key = 1, .val = 1}.e);
     (void)insert(&src, &(struct val){.key = 2, .val = 2}.e);
@@ -134,14 +109,10 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc_fail)
 {
-    struct val src_vals[11];
-    struct val dst_vals[7];
-    flat_hash_map src
-        = fhm_init(src_vals, sizeof(src_vals) / sizeof(src_vals[0]), key, e,
-                   NULL, fhmap_int_zero, fhmap_id_eq, NULL);
-    flat_hash_map dst
-        = fhm_init(dst_vals, sizeof(dst_vals) / sizeof(dst_vals[0]), key, e,
-                   NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map src = fhm_init((struct val[11]){}, 11, key, e, NULL,
+                                 fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map dst = fhm_init((struct val[7]){}, 7, key, e, NULL,
+                                 fhmap_int_zero, fhmap_id_eq, NULL);
     (void)insert(&src, &(struct val){.key = 0}.e);
     (void)insert(&src, &(struct val){.key = 1, .val = 1}.e);
     (void)insert(&src, &(struct val){.key = 2, .val = 2}.e);
@@ -154,10 +125,10 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc_fail)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc)
 {
-    flat_hash_map src = fhm_zero_init(struct val, key, e, std_alloc,
-                                      fhmap_int_zero, fhmap_id_eq, NULL);
-    flat_hash_map dst = fhm_zero_init(struct val, key, e, std_alloc,
-                                      fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map src = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+                                 fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map dst = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+                                 fhmap_int_zero, fhmap_id_eq, NULL);
     (void)insert(&src, &(struct val){.key = 0}.e);
     (void)insert(&src, &(struct val){.key = 1, .val = 1}.e);
     (void)insert(&src, &(struct val){.key = 2, .val = 2}.e);
@@ -182,10 +153,10 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc_fail)
 {
-    flat_hash_map src = fhm_zero_init(struct val, key, e, std_alloc,
-                                      fhmap_int_zero, fhmap_id_eq, NULL);
-    flat_hash_map dst = fhm_zero_init(struct val, key, e, std_alloc,
-                                      fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map src = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+                                 fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map dst = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+                                 fhmap_int_zero, fhmap_id_eq, NULL);
     (void)insert(&src, &(struct val){.key = 0}.e);
     (void)insert(&src, &(struct val){.key = 1, .val = 1}.e);
     (void)insert(&src, &(struct val){.key = 2, .val = 2}.e);
@@ -207,9 +178,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_empty)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_functional)
 {
-    struct val vals[5] = {};
-    flat_hash_map fh = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e,
-                                NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map fh = fhm_init((struct val[5]){}, 5, key, e, NULL,
+                                fhmap_int_zero, fhmap_id_eq, NULL);
     CHECK(is_empty(&fh), true);
     struct val def = {.key = 137, .val = 0};
     fhmap_entry ent = entry(&fh, &def.key);
@@ -229,9 +199,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_functional)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_macros)
 {
-    struct val vals[5] = {};
-    flat_hash_map fh = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e,
-                                NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map fh = fhm_init((struct val[5]){}, 5, key, e, NULL,
+                                fhmap_int_zero, fhmap_id_eq, NULL);
     CHECK(is_empty(&fh), true);
     CHECK(get_key_val(&fh, &(int){137}) == NULL, true);
     int const key = 137;
@@ -254,9 +223,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_functional)
 {
-    struct val vals[5] = {};
-    flat_hash_map fh = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e,
-                                NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map fh = fhm_init((struct val[5]){}, 5, key, e, NULL,
+                                fhmap_int_zero, fhmap_id_eq, NULL);
     CHECK(is_empty(&fh), true);
     struct val def = {.key = 137, .val = 0};
 
@@ -293,9 +261,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_functional)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_macros)
 {
-    struct val vals[5] = {};
-    flat_hash_map fh = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e,
-                                NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    flat_hash_map fh = fhm_init((struct val[5]){}, 5, key, e, NULL,
+                                fhmap_int_zero, fhmap_id_eq, NULL);
     CHECK(is_empty(&fh), true);
 
     /* Returning a vacant entry is possible when modification is attempted. */
@@ -348,8 +315,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_macros)
 int
 main()
 {
-    return CHECK_RUN(fhmap_test_static_init(), fhmap_test_zero_init(),
-                     fhmap_test_copy_no_alloc(),
+    return CHECK_RUN(fhmap_test_static_init(), fhmap_test_copy_no_alloc(),
                      fhmap_test_copy_no_alloc_fail(), fhmap_test_copy_alloc(),
                      fhmap_test_copy_alloc_fail(), fhmap_test_empty(),
                      fhmap_test_entry_macros(), fhmap_test_entry_functional(),

--- a/tests/fhmap/test_fhmap_entry.c
+++ b/tests/fhmap/test_fhmap_entry.c
@@ -64,10 +64,8 @@ CHECK_BEGIN_STATIC_FN(fill_n, ccc_flat_hash_map *const fh, size_t const n,
    the user on insert. Leave this test here to always catch this. */
 CHECK_BEGIN_STATIC_FN(fhmap_test_validate)
 {
-    struct val vals[50] = {};
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
 
     ccc_entry ent = insert(&fh, &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
@@ -87,12 +85,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_validate)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry ent = insert(&fh, &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
     CHECK(occupied(&ent), false);
@@ -147,12 +142,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_remove)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry ent = remove(&fh, &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
     CHECK(occupied(&ent), false);
@@ -219,12 +211,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_remove)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry ent = try_insert(&fh, &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
     CHECK(occupied(&ent), false);
@@ -278,12 +267,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert_with)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry *ent = fhm_try_insert_w(&fh, -1, val(-1));
     CHECK(validate(&fh), true);
     CHECK(occupied(ent), false);
@@ -338,12 +324,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert_with)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry ent
         = insert_or_assign(&fh, &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
@@ -398,12 +381,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign_with)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry *ent = fhm_insert_or_assign_w(&fh, -1, val(-1));
     CHECK(validate(&fh), true);
     CHECK(occupied(ent), false);
@@ -457,12 +437,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign_with)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_fhmap_entry *ent = entry_r(&fh, &(int){-1});
     CHECK(validate(&fh), true);
     CHECK(occupied(ent), false);
@@ -529,13 +506,10 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_aux)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     int aux = 1;
-
     ccc_fhmap_entry *ent = entry_r(&fh, &(int){-1});
     ent = and_modify_aux(ent, plusaux, &aux);
     CHECK(occupied(ent), false);
@@ -598,12 +572,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_aux)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_with)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_fhmap_entry *ent = entry_r(&fh, &(int){-1});
     ent = fhm_and_modify_w(ent, struct val, { T->val++; });
     CHECK(size(&fh), 0);
@@ -666,12 +637,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_with)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = or_insert(entry_r(&fh, &(int){-1}),
                               &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
@@ -722,12 +690,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert_with)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = fhm_or_insert_w(entry_r(&fh, &(int){-1}), idval(-1, -1));
     CHECK(validate(&fh), true);
     CHECK(v != NULL, true);
@@ -776,12 +741,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert_with)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = insert_entry(entry_r(&fh, &(int){-1}),
                                  &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
@@ -832,12 +794,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry_with)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = fhm_insert_entry_w(entry_r(&fh, &(int){-1}), idval(-1, -1));
     CHECK(validate(&fh), true);
     CHECK(v != NULL, true);
@@ -886,12 +845,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry_with)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_remove_entry)
 {
-    struct val vals[50] = {};
     int size = 30;
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = or_insert(entry_r(&fh, &(int){-1}),
                               &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);

--- a/tests/fhmap/test_fhmap_erase.c
+++ b/tests/fhmap/test_fhmap_erase.c
@@ -13,9 +13,8 @@
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_erase)
 {
-    struct val vals[10] = {};
-    ccc_flat_hash_map fh = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key,
-                                    e, NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+                                    fhmap_int_zero, fhmap_id_eq, NULL);
 
     struct val query = {.key = 137, .val = 99};
     /* Nothing was there before so nothing is in the entry. */

--- a/tests/fhmap/test_fhmap_insert.c
+++ b/tests/fhmap/test_fhmap_insert.c
@@ -13,9 +13,8 @@
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 {
-    struct val vals[10] = {};
-    ccc_flat_hash_map fh = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key,
-                                    e, NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+                                    fhmap_int_zero, fhmap_id_eq, NULL);
 
     /* Nothing was there before so nothing is in the entry. */
     ccc_entry ent = insert(&fh, &(struct val){.key = 137, .val = 99}.e);
@@ -27,9 +26,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_macros)
 {
-    struct val vals[10] = {};
-    ccc_flat_hash_map fh = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key,
-                                    e, NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+                                    fhmap_int_zero, fhmap_id_eq, NULL);
 
     struct val const *ins = ccc_fhm_or_insert_w(
         entry_r(&fh, &(int){2}), (struct val){.key = 2, .val = 0});
@@ -72,9 +70,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_overwrite)
 {
-    struct val vals[10] = {};
-    ccc_flat_hash_map fh = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key,
-                                    e, NULL, fhmap_int_zero, fhmap_id_eq, NULL);
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+                                    fhmap_int_zero, fhmap_id_eq, NULL);
 
     struct val q = {.key = 137, .val = 99};
     ccc_entry ent = insert(&fh, &q.e);
@@ -106,10 +103,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_overwrite)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_then_bad_ideas)
 {
-    struct val vals[10] = {};
-    ccc_flat_hash_map fh = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key,
-                                    e, NULL, fhmap_int_zero, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+                                    fhmap_int_zero, fhmap_id_eq, NULL);
     struct val q = {.key = 137, .val = 99};
     ccc_entry ent = insert(&fh, &q.e);
     CHECK(occupied(&ent), false);
@@ -138,10 +133,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_then_bad_ideas)
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_api_functional)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
-    struct val vals[200];
-    size_t const size = sizeof(vals) / sizeof(vals[0]);
-    ccc_flat_hash_map fh = fhm_init(vals, size, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, key, e, NULL,
                                     fhmap_int_last_digit, fhmap_id_eq, NULL);
+    size_t const size = 200;
 
     /* Test entry or insert with for all even values. Default should be
        inserted. All entries are hashed to last digit so many spread out
@@ -197,8 +191,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_via_entry)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
     size_t const size = 200;
-    struct val vals[200];
-    ccc_flat_hash_map fh = fhm_init(vals, size, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, key, e, NULL,
                                     fhmap_int_last_digit, fhmap_id_eq, NULL);
 
     /* Test entry or insert with for all even values. Default should be
@@ -243,8 +236,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_via_entry_macros)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
     size_t const size = 200;
-    struct val vals[200];
-    ccc_flat_hash_map fh = fhm_init(vals, size, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, key, e, NULL,
                                     fhmap_int_last_digit, fhmap_id_eq, NULL);
 
     /* Test entry or insert with for all even values. Default should be
@@ -284,8 +276,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_api_macros)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
     int const size = 200;
-    struct val vals[200];
-    ccc_flat_hash_map fh = fhm_init(vals, size, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, key, e, NULL,
                                     fhmap_int_last_digit, fhmap_id_eq, NULL);
 
     /* Test entry or insert with for all even values. Default should be
@@ -337,11 +328,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_api_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_two_sum)
 {
-    struct val vals[20];
-    ccc_flat_hash_map fh
-        = fhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e, NULL,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val[20]){}, 20, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     int const addends[10] = {1, 3, -980, 6, 7, 13, 44, 32, 995, -1};
     int const target = 15;
     int solution_indices[2] = {-1, -1};
@@ -366,11 +354,11 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_two_sum)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_resize)
 {
-    size_t const prime_start = 5;
-    struct val *vals = malloc(sizeof(struct val) * prime_start);
-    CHECK(vals == NULL, false);
-    ccc_flat_hash_map fh = fhm_init(vals, prime_start, key, e, std_alloc,
-                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
+    size_t const prime_start = 11;
+    ccc_flat_hash_map fh = fhm_init(
+        (struct val *)malloc(sizeof(struct val) * prime_start), prime_start,
+        key, e, std_alloc, fhmap_int_to_u64, fhmap_id_eq, NULL);
+    CHECK(fhm_data(&fh) != NULL, true);
 
     int const to_insert = 1000;
     int const larger_prime = (int)fhm_next_prime(to_insert);
@@ -400,12 +388,11 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_resize_macros)
 {
-    size_t const prime_start = 5;
-    struct val *vals = malloc(sizeof(struct val) * prime_start);
-    CHECK(vals == NULL, false);
-    ccc_flat_hash_map fh = fhm_init(vals, prime_start, key, e, std_alloc,
-                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    size_t const prime_start = 11;
+    ccc_flat_hash_map fh = fhm_init(
+        (struct val *)malloc(sizeof(struct val) * prime_start), prime_start,
+        key, e, std_alloc, fhmap_int_to_u64, fhmap_id_eq, NULL);
+    CHECK(fhm_data(&fh) != NULL, true);
     int const to_insert = 1000;
     int const larger_prime = (int)fhm_next_prime(to_insert);
     for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
@@ -445,7 +432,6 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null)
 {
     ccc_flat_hash_map fh = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
-
     int const to_insert = 1000;
     int const larger_prime = (int)fhm_next_prime(to_insert);
     for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
@@ -473,11 +459,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null_macros)
 {
-    size_t const prime_start = 0;
-    ccc_flat_hash_map fh
-        = fhm_init((struct val *)NULL, prime_start, key, e, std_alloc,
-                   fhmap_int_to_u64, fhmap_id_eq, NULL);
-
+    ccc_flat_hash_map fh = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
     int const to_insert = 1000;
     int const larger_prime = (int)fhm_next_prime(to_insert);
     for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
@@ -516,9 +499,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null_macros)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_limit)
 {
     int const size = 101;
-    struct val vals[101];
-    ccc_flat_hash_map fh = fhm_init(vals, size, key, e, NULL, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL);
+    ccc_flat_hash_map fh = fhm_init((struct val[101]){}, 101, key, e, NULL,
+                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
 
     int const larger_prime = (int)fhm_next_prime(size);
     int last_index = 0;

--- a/tests/fhmap/test_fhmap_lru.c
+++ b/tests/fhmap/test_fhmap_lru.c
@@ -102,8 +102,8 @@ static struct lru_cache lru_cache = {
     .cap = CAP,
     .l = dll_init(lru_cache.l, struct key_val, list_elem, std_alloc, cmp_by_key,
                   NULL),
-    .fh = fhm_static_init(map_buf, key, hash_elem, fhmap_int_to_u64,
-                          lru_lookup_cmp, NULL),
+    .fh = fhm_init(map_buf, sizeof(map_buf) / sizeof(map_buf[0]), key,
+                   hash_elem, NULL, fhmap_int_to_u64, lru_lookup_cmp, NULL),
 };
 
 CHECK_BEGIN_STATIC_FN(lru_put, struct lru_cache *const lru, int const key,


### PR DESCRIPTION
flat hash map initialization should use the same lazy init techniques as other flat containers. This way the initialization can be used at compile time or runtime with no special warnings or concerns.