### PR TITLE
fix flat hash map to be consistent with initializer

### DIFF
--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -60,8 +60,8 @@ May be NULL if the user provides a allocation function. The buffer will be
 interpreted in units of type size that the user intends to store.
 @param [in] capacity the starting capacity of the provided buffer or 0 if no
 buffer is provided and an allocation function is given.
-@param [in] key_field the field of the struct used for key storage.
 @param [in] fhash_elem_field the name of the fhmap_elem field.
+@param [in] key_field the field of the struct used for key storage.
 @param [in] alloc_fn the allocation function for resizing or NULL if no
 resizing is allowed.
 @param [in] hash_fn the ccc_hash_fn function the user desires for the table.
@@ -69,9 +69,9 @@ resizing is allowed.
 @param [in] aux_data auxiliary data that is needed for hashing or comparison.
 @return the flat hash map directly initialized on the right hand side of the
 equality operator (i.e. ccc_flat_hash_map fh = ccc_fhm_init(...);) */
-#define ccc_fhm_init(memory_ptr, capacity, key_field, fhash_elem_field,        \
+#define ccc_fhm_init(memory_ptr, capacity, fhash_elem_field, key_field,        \
                      alloc_fn, hash_fn, key_eq_fn, aux_data)                   \
-    ccc_impl_fhm_init(memory_ptr, capacity, key_field, fhash_elem_field,       \
+    ccc_impl_fhm_init(memory_ptr, capacity, fhash_elem_field, key_field,       \
                       alloc_fn, hash_fn, key_eq_fn, aux_data)
 
 /** @brief Copy the map at source to destination.

--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -48,7 +48,7 @@ union ccc_fhmap_entry_
     struct ccc_fhash_entry_ impl_;
 };
 
-#define ccc_impl_fhm_init(memory_ptr, capacity, key_field, fhash_elem_field,   \
+#define ccc_impl_fhm_init(memory_ptr, capacity, fhash_elem_field, key_field,   \
                           alloc_fn, hash_fn, key_eq_fn, aux)                   \
     {                                                                          \
         .buf_                                                                  \
@@ -56,28 +56,6 @@ union ccc_fhmap_entry_
         .hash_fn_ = (hash_fn),                                                 \
         .eq_fn_ = (key_eq_fn),                                                 \
         .key_offset_ = offsetof(typeof(*(memory_ptr)), key_field),             \
-        .hash_elem_offset_                                                     \
-        = offsetof(typeof(*(memory_ptr)), fhash_elem_field),                   \
-    }
-
-#define ccc_impl_fhm_zero_init(type_name, key_field, fhash_elem_field,         \
-                               alloc_fn, hash_fn, key_eq_fn, aux)              \
-    {                                                                          \
-        .buf_ = ccc_buf_init((type_name *)NULL, alloc_fn, aux, 0),             \
-        .hash_fn_ = (hash_fn),                                                 \
-        .eq_fn_ = (key_eq_fn),                                                 \
-        .key_offset_ = (offsetof(type_name, key_field)),                       \
-        .hash_elem_offset_ = offsetof(type_name, fhash_elem_field),            \
-    }
-
-#define ccc_impl_fhm_static_init(memory_ptr, key_field, fhash_elem_field,      \
-                                 hash_fn, key_eq_fn, aux)                      \
-    {                                                                          \
-        .buf_ = ccc_buf_init(memory_ptr, NULL, aux,                            \
-                             sizeof(memory_ptr) / sizeof((memory_ptr)[0])),    \
-        .hash_fn_ = (hash_fn),                                                 \
-        .eq_fn_ = (key_eq_fn),                                                 \
-        .key_offset_ = (offsetof(typeof(*(memory_ptr)), key_field)),           \
         .hash_elem_offset_                                                     \
         = offsetof(typeof(*(memory_ptr)), fhash_elem_field),                   \
     }

--- a/samples/graph.c
+++ b/samples/graph.c
@@ -413,7 +413,7 @@ static bool
 found_dst(struct graph *const graph, struct vertex *const src)
 {
     flat_hash_map parent_map
-        = fhm_init((struct path_backtrack_cell *)NULL, 0, current, elem,
+        = fhm_init((struct path_backtrack_cell *)NULL, 0, elem, current,
                    std_alloc, hash_parent_cells, eq_parent_cells, NULL);
     flat_double_ended_queue bfs
         = fdeq_init((struct point *)NULL, std_alloc, NULL, 0);

--- a/tests/fhmap/test_fhmap_construct.c
+++ b/tests/fhmap/test_fhmap_construct.c
@@ -39,7 +39,7 @@ gen(int *to_affect)
 
 static struct val s_vals[10];
 static flat_hash_map static_fh
-    = fhm_init(s_vals, sizeof(s_vals) / sizeof(s_vals[0]), key, e, NULL,
+    = fhm_init(s_vals, sizeof(s_vals) / sizeof(s_vals[0]), e, key, NULL,
                fhmap_int_to_u64, fhmap_id_eq, NULL);
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_static_init)
@@ -84,9 +84,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_static_init)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc)
 {
-    flat_hash_map src = fhm_init((struct val[11]){}, 11, key, e, NULL,
+    flat_hash_map src = fhm_init((struct val[11]){}, 11, e, key, NULL,
                                  fhmap_int_zero, fhmap_id_eq, NULL);
-    flat_hash_map dst = fhm_init((struct val[13]){}, 13, key, e, NULL,
+    flat_hash_map dst = fhm_init((struct val[13]){}, 13, e, key, NULL,
                                  fhmap_int_zero, fhmap_id_eq, NULL);
     (void)insert(&src, &(struct val){.key = 0}.e);
     (void)insert(&src, &(struct val){.key = 1, .val = 1}.e);
@@ -109,9 +109,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc_fail)
 {
-    flat_hash_map src = fhm_init((struct val[11]){}, 11, key, e, NULL,
+    flat_hash_map src = fhm_init((struct val[11]){}, 11, e, key, NULL,
                                  fhmap_int_zero, fhmap_id_eq, NULL);
-    flat_hash_map dst = fhm_init((struct val[7]){}, 7, key, e, NULL,
+    flat_hash_map dst = fhm_init((struct val[7]){}, 7, e, key, NULL,
                                  fhmap_int_zero, fhmap_id_eq, NULL);
     (void)insert(&src, &(struct val){.key = 0}.e);
     (void)insert(&src, &(struct val){.key = 1, .val = 1}.e);
@@ -125,9 +125,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc_fail)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc)
 {
-    flat_hash_map src = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+    flat_hash_map src = fhm_init((struct val *)NULL, 0, e, key, std_alloc,
                                  fhmap_int_zero, fhmap_id_eq, NULL);
-    flat_hash_map dst = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+    flat_hash_map dst = fhm_init((struct val *)NULL, 0, e, key, std_alloc,
                                  fhmap_int_zero, fhmap_id_eq, NULL);
     (void)insert(&src, &(struct val){.key = 0}.e);
     (void)insert(&src, &(struct val){.key = 1, .val = 1}.e);
@@ -153,9 +153,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc_fail)
 {
-    flat_hash_map src = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+    flat_hash_map src = fhm_init((struct val *)NULL, 0, e, key, std_alloc,
                                  fhmap_int_zero, fhmap_id_eq, NULL);
-    flat_hash_map dst = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+    flat_hash_map dst = fhm_init((struct val *)NULL, 0, e, key, std_alloc,
                                  fhmap_int_zero, fhmap_id_eq, NULL);
     (void)insert(&src, &(struct val){.key = 0}.e);
     (void)insert(&src, &(struct val){.key = 1, .val = 1}.e);
@@ -178,7 +178,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_empty)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_functional)
 {
-    flat_hash_map fh = fhm_init((struct val[5]){}, 5, key, e, NULL,
+    flat_hash_map fh = fhm_init((struct val[5]){}, 5, e, key, NULL,
                                 fhmap_int_zero, fhmap_id_eq, NULL);
     CHECK(is_empty(&fh), true);
     struct val def = {.key = 137, .val = 0};
@@ -199,7 +199,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_functional)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_macros)
 {
-    flat_hash_map fh = fhm_init((struct val[5]){}, 5, key, e, NULL,
+    flat_hash_map fh = fhm_init((struct val[5]){}, 5, e, key, NULL,
                                 fhmap_int_zero, fhmap_id_eq, NULL);
     CHECK(is_empty(&fh), true);
     CHECK(get_key_val(&fh, &(int){137}) == NULL, true);
@@ -223,7 +223,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_functional)
 {
-    flat_hash_map fh = fhm_init((struct val[5]){}, 5, key, e, NULL,
+    flat_hash_map fh = fhm_init((struct val[5]){}, 5, e, key, NULL,
                                 fhmap_int_zero, fhmap_id_eq, NULL);
     CHECK(is_empty(&fh), true);
     struct val def = {.key = 137, .val = 0};
@@ -261,7 +261,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_functional)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_macros)
 {
-    flat_hash_map fh = fhm_init((struct val[5]){}, 5, key, e, NULL,
+    flat_hash_map fh = fhm_init((struct val[5]){}, 5, e, key, NULL,
                                 fhmap_int_zero, fhmap_id_eq, NULL);
     CHECK(is_empty(&fh), true);
 

--- a/tests/fhmap/test_fhmap_entry.c
+++ b/tests/fhmap/test_fhmap_entry.c
@@ -64,7 +64,7 @@ CHECK_BEGIN_STATIC_FN(fill_n, ccc_flat_hash_map *const fh, size_t const n,
    the user on insert. Leave this test here to always catch this. */
 CHECK_BEGIN_STATIC_FN(fhmap_test_validate)
 {
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
 
     ccc_entry ent = insert(&fh, &(struct val){.key = -1, .val = -1}.e);
@@ -86,7 +86,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_validate)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry ent = insert(&fh, &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
@@ -143,7 +143,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 CHECK_BEGIN_STATIC_FN(fhmap_test_remove)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry ent = remove(&fh, &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
@@ -212,7 +212,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_remove)
 CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry ent = try_insert(&fh, &(struct val){.key = -1, .val = -1}.e);
     CHECK(validate(&fh), true);
@@ -268,7 +268,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert)
 CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert_with)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry *ent = fhm_try_insert_w(&fh, -1, val(-1));
     CHECK(validate(&fh), true);
@@ -325,7 +325,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry ent
         = insert_or_assign(&fh, &(struct val){.key = -1, .val = -1}.e);
@@ -382,7 +382,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign_with)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_entry *ent = fhm_insert_or_assign_w(&fh, -1, val(-1));
     CHECK(validate(&fh), true);
@@ -438,7 +438,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_fhmap_entry *ent = entry_r(&fh, &(int){-1});
     CHECK(validate(&fh), true);
@@ -507,7 +507,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify)
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_aux)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     int aux = 1;
     ccc_fhmap_entry *ent = entry_r(&fh, &(int){-1});
@@ -573,7 +573,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_aux)
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_with)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     ccc_fhmap_entry *ent = entry_r(&fh, &(int){-1});
     ent = fhm_and_modify_w(ent, struct val, { T->val++; });
@@ -638,7 +638,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = or_insert(entry_r(&fh, &(int){-1}),
                               &(struct val){.key = -1, .val = -1}.e);
@@ -691,7 +691,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert)
 CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert_with)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = fhm_or_insert_w(entry_r(&fh, &(int){-1}), idval(-1, -1));
     CHECK(validate(&fh), true);
@@ -742,7 +742,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = insert_entry(entry_r(&fh, &(int){-1}),
                                  &(struct val){.key = -1, .val = -1}.e);
@@ -795,7 +795,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry_with)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = fhm_insert_entry_w(entry_r(&fh, &(int){-1}), idval(-1, -1));
     CHECK(validate(&fh), true);
@@ -846,7 +846,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_remove_entry)
 {
     int size = 30;
-    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[50]){}, 50, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     struct val *v = or_insert(entry_r(&fh, &(int){-1}),
                               &(struct val){.key = -1, .val = -1}.e);

--- a/tests/fhmap/test_fhmap_erase.c
+++ b/tests/fhmap/test_fhmap_erase.c
@@ -13,7 +13,7 @@
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_erase)
 {
-    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, e, key, NULL,
                                     fhmap_int_zero, fhmap_id_eq, NULL);
 
     struct val query = {.key = 137, .val = 99};
@@ -43,7 +43,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_erase)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_insert_erase)
 {
-    ccc_flat_hash_map h = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+    ccc_flat_hash_map h = fhm_init((struct val *)NULL, 0, e, key, std_alloc,
                                    fhmap_int_to_u64, fhmap_id_eq, NULL);
 
     int const to_insert = 100;

--- a/tests/fhmap/test_fhmap_insert.c
+++ b/tests/fhmap/test_fhmap_insert.c
@@ -13,7 +13,7 @@
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 {
-    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, e, key, NULL,
                                     fhmap_int_zero, fhmap_id_eq, NULL);
 
     /* Nothing was there before so nothing is in the entry. */
@@ -26,7 +26,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_macros)
 {
-    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, e, key, NULL,
                                     fhmap_int_zero, fhmap_id_eq, NULL);
 
     struct val const *ins = ccc_fhm_or_insert_w(
@@ -70,7 +70,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_overwrite)
 {
-    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, e, key, NULL,
                                     fhmap_int_zero, fhmap_id_eq, NULL);
 
     struct val q = {.key = 137, .val = 99};
@@ -103,7 +103,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_overwrite)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_then_bad_ideas)
 {
-    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[10]){}, 10, e, key, NULL,
                                     fhmap_int_zero, fhmap_id_eq, NULL);
     struct val q = {.key = 137, .val = 99};
     ccc_entry ent = insert(&fh, &q.e);
@@ -133,7 +133,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_then_bad_ideas)
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_api_functional)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
-    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, e, key, NULL,
                                     fhmap_int_last_digit, fhmap_id_eq, NULL);
     size_t const size = 200;
 
@@ -191,7 +191,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_via_entry)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
     size_t const size = 200;
-    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, e, key, NULL,
                                     fhmap_int_last_digit, fhmap_id_eq, NULL);
 
     /* Test entry or insert with for all even values. Default should be
@@ -236,7 +236,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_via_entry_macros)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
     size_t const size = 200;
-    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, e, key, NULL,
                                     fhmap_int_last_digit, fhmap_id_eq, NULL);
 
     /* Test entry or insert with for all even values. Default should be
@@ -276,7 +276,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_api_macros)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
     int const size = 200;
-    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[200]){}, 200, e, key, NULL,
                                     fhmap_int_last_digit, fhmap_id_eq, NULL);
 
     /* Test entry or insert with for all even values. Default should be
@@ -328,7 +328,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_api_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_two_sum)
 {
-    ccc_flat_hash_map fh = fhm_init((struct val[20]){}, 20, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[20]){}, 20, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     int const addends[10] = {1, 3, -980, 6, 7, 13, 44, 32, 995, -1};
     int const target = 15;
@@ -356,8 +356,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize)
 {
     size_t const prime_start = 11;
     ccc_flat_hash_map fh = fhm_init(
-        (struct val *)malloc(sizeof(struct val) * prime_start), prime_start,
-        key, e, std_alloc, fhmap_int_to_u64, fhmap_id_eq, NULL);
+        (struct val *)malloc(sizeof(struct val) * prime_start), prime_start, e,
+        key, std_alloc, fhmap_int_to_u64, fhmap_id_eq, NULL);
     CHECK(fhm_data(&fh) != NULL, true);
 
     int const to_insert = 1000;
@@ -390,8 +390,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_macros)
 {
     size_t const prime_start = 11;
     ccc_flat_hash_map fh = fhm_init(
-        (struct val *)malloc(sizeof(struct val) * prime_start), prime_start,
-        key, e, std_alloc, fhmap_int_to_u64, fhmap_id_eq, NULL);
+        (struct val *)malloc(sizeof(struct val) * prime_start), prime_start, e,
+        key, std_alloc, fhmap_int_to_u64, fhmap_id_eq, NULL);
     CHECK(fhm_data(&fh) != NULL, true);
     int const to_insert = 1000;
     int const larger_prime = (int)fhm_next_prime(to_insert);
@@ -430,7 +430,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null)
 {
-    ccc_flat_hash_map fh = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+    ccc_flat_hash_map fh = fhm_init((struct val *)NULL, 0, e, key, std_alloc,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     int const to_insert = 1000;
     int const larger_prime = (int)fhm_next_prime(to_insert);
@@ -459,7 +459,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null_macros)
 {
-    ccc_flat_hash_map fh = fhm_init((struct val *)NULL, 0, key, e, std_alloc,
+    ccc_flat_hash_map fh = fhm_init((struct val *)NULL, 0, e, key, std_alloc,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
     int const to_insert = 1000;
     int const larger_prime = (int)fhm_next_prime(to_insert);
@@ -499,7 +499,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null_macros)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_limit)
 {
     int const size = 101;
-    ccc_flat_hash_map fh = fhm_init((struct val[101]){}, 101, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[101]){}, 101, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
 
     int const larger_prime = (int)fhm_next_prime(size);
@@ -559,7 +559,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_limit)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_and_find)
 {
     int const size = 101;
-    ccc_flat_hash_map fh = fhm_init((struct val[101]){}, 101, key, e, NULL,
+    ccc_flat_hash_map fh = fhm_init((struct val[101]){}, 101, e, key, NULL,
                                     fhmap_int_to_u64, fhmap_id_eq, NULL);
 
     for (int i = 0; i < size; i += 2)

--- a/tests/fhmap/test_fhmap_lru.c
+++ b/tests/fhmap/test_fhmap_lru.c
@@ -102,8 +102,8 @@ static struct lru_cache lru_cache = {
     .cap = CAP,
     .l = dll_init(lru_cache.l, struct key_val, list_elem, std_alloc, cmp_by_key,
                   NULL),
-    .fh = fhm_init(map_buf, sizeof(map_buf) / sizeof(map_buf[0]), key,
-                   hash_elem, NULL, fhmap_int_to_u64, lru_lookup_cmp, NULL),
+    .fh = fhm_init(map_buf, sizeof(map_buf) / sizeof(map_buf[0]), hash_elem,
+                   key, NULL, fhmap_int_to_u64, lru_lookup_cmp, NULL),
 };
 
 CHECK_BEGIN_STATIC_FN(lru_put, struct lru_cache *const lru, int const key,


### PR DESCRIPTION
The flat hash map was the only associative container where the initializer had the key field before the intrusive element field. Now, it has been fixed to have a consistent key and elem order as other containers. This would have been very confusing to use and subtle if incorrect with little error reporting.