### PR TITLE
fix relative pathing for bitset impl header

### DIFF
--- a/ccc/impl/impl_bitset.h
+++ b/ccc/impl/impl_bitset.h
@@ -4,7 +4,7 @@
 #include <limits.h>
 #include <stddef.h>
 
-#include "types.h"
+#include "../types.h"
 
 /** @private */
 typedef unsigned ccc_bitblock_;


### PR DESCRIPTION
Paths in impl header must assume standalone library install.