### PR TITLE
Handle hash map

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ lru_get(struct lru_cache *const lru, int const key)
 }
 
 int
-run_lru_cache(void)
+main(void)
 {
     QUIET_PRINT("LRU CAPACITY -> %zu\n", lru_cache.cap);
     struct lru_request requests[REQS] = {
@@ -530,12 +530,6 @@ run_lru_cache(void)
         }
     }
     return 0;
-}
-
-int
-main()
-{
-    return run_lru_cache();
 }
 ```
 

--- a/ccc/CMakeLists.txt
+++ b/ccc/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME}
         ${PROJECT_SOURCE_DIR}/src/types.c
         ${PROJECT_SOURCE_DIR}/src/buffer.c
         ${PROJECT_SOURCE_DIR}/src/flat_hash_map.c
+        ${PROJECT_SOURCE_DIR}/src/handle_hash_map.c
         ${PROJECT_SOURCE_DIR}/src/flat_double_ended_queue.c
         ${PROJECT_SOURCE_DIR}/src/flat_priority_queue.c
         ${PROJECT_SOURCE_DIR}/src/ordered_map.c
@@ -37,12 +38,14 @@ target_sources(${PROJECT_NAME}
               impl/impl_traits.h
               impl/impl_flat_double_ended_queue.h
               impl/impl_flat_hash_map.h
+              impl/impl_handle_hash_map.h
               impl/impl_buffer.h
               impl/impl_bitset.h
               types.h
               buffer.h
               bitset.h
               flat_hash_map.h
+              handle_hash_map.h
               flat_double_ended_queue.h
               flat_priority_queue.h
               ordered_map.h

--- a/ccc/handle_hash_map.h
+++ b/ccc/handle_hash_map.h
@@ -204,6 +204,15 @@ handle represents a slot that has been taken by a new element because the old
 one has been removed that new element data will be returned. */
 [[nodiscard]] void *ccc_hhm_at(ccc_handle_hash_map const *h, ccc_handle i);
 
+/** @brief Returns a reference to the user type in the table at the handle.
+@param [in] handle_hash_map_ptr a pointer to the map.
+@param [in] type_name name of the user type stored in each slot of the map.
+@param [in] handle the index handle obtained from previous map operations.
+@return a reference to the entry at handle in the map as the type the user has
+stored in the map. */
+#define ccc_hhm_as(handle_hash_map_ptr, type_name, handle...)                  \
+    ccc_impl_hhm_as(handle_hash_map_ptr, type_name, handle)
+
 /**@}*/
 
 /** @name Entry Interface
@@ -675,6 +684,7 @@ typedef ccc_hhmap_entry hhmap_entry;
 #    define hhm_contains(args...) ccc_hhm_contains(args)
 #    define hhm_get_key_val(args...) ccc_hhm_get_key_val(args)
 #    define hhm_at(args...) ccc_hhm_at(args)
+#    define hhm_as(args...) ccc_hhm_as(args)
 #    define hhm_insert(args...) ccc_hhm_insert(args)
 #    define hhm_insert_r(args...) ccc_hhm_insert_r(args)
 #    define hhm_remove(args...) ccc_hhm_remove(args)

--- a/ccc/handle_hash_map.h
+++ b/ccc/handle_hash_map.h
@@ -1,35 +1,39 @@
 /** @file
-@brief The Flat Hash Map Interface
+@brief The Handle Hash Map Interface
 
-A Flat Hash Map stores elements by hash value and allows the user to retrieve
-them by key in amortized O(1). Elements in the table may be copied and moved so
-no pointer stability is available in this implementation. If pointer stability
-is needed, store and hash pointers to those elements in this table.
+A Handle Hash Map stores elements by hash value and allows the user to retrieve
+them by key in amortized O(1) while offering handle stability. A handle is an
+index into a slot of the table where the user data is originally placed upon
+insertion. It is guaranteed to remain in the same slot until deletion; however
+if resizing is allowed and occurs any pointer to that data may become invalid.
+The handle would remain valid regardless of resizing because it is an index not
+a pointer. This comes at a slight space and implementation complexity cost when
+compared to the standard flat hash map offered in the collection.
 
-A flat hash map requires the user to provide a struct with known key and flat
-hash element fields as well as a hash function and key comparator function. The
-hash function should be well tailored to the key being stored in the table to
-prevent collisions. Currently, the flat hash map does not offer any default hash
-functions or hash strengthening algorithms so strong hash functions should be
-obtained by the user for the data set.
+A handle hash map requires the user to provide a struct with known key and
+handle hash element fields as well as a hash function and key comparator
+function. The hash function should be well tailored to the key being stored in
+the table to prevent collisions. Currently, the handle hash map does not offer
+any default hash functions or hash strengthening algorithms so strong hash
+functions should be obtained by the user for the data set.
 
 To shorten names in the interface, define the following preprocessor directive
 at the top of your file.
 
 ```
-#define FLAT_HASH_MAP_USING_NAMESPACE_CCC
+#define HANDLE_HASH_MAP_USING_NAMESPACE_CCC
 ```
 
 All types and functions can then be written without the `ccc_` prefix. */
-#ifndef CCC_FLAT_HASH_MAP_H
-#define CCC_FLAT_HASH_MAP_H
+#ifndef CCC_HANDLE_HASH_MAP_H
+#define CCC_HANDLE_HASH_MAP_H
 
 /** @cond */
+#include <stdbool.h>
 #include <stddef.h>
 /** @endcond */
 
-#include "impl/impl_flat_hash_map.h"
-#include "types.h"
+#include "impl/impl_handle_hash_map.h"
 
 /** @name Container Types
 Types available in the container interface. */
@@ -38,21 +42,29 @@ Types available in the container interface. */
 /** @brief A container for storing key-value structures defined by the user in
 a contiguous buffer.
 
-A flat hash map can be initialized on the stack, heap, or data segment at
+A handle hash map can be initialized on the stack, heap, or data segment at
 runtime or compile time. */
-typedef struct ccc_fhmap_ ccc_flat_hash_map;
+typedef struct ccc_hhmap_ ccc_handle_hash_map;
+
+/** @brief A stable reference to the user data stored in the map.
+
+A handle is valid until the element in the map is removed. Such a reference can
+be given to the appropriate interface function to obtain a reference the user
+type at that index in the map. Such a function should be used on an as needed
+basis and the handle should be stored for most cases rather than a pointer. */
+typedef size_t ccc_hhmap_handle;
 
 /** @brief An intrusive element for a user provided type.
 
 Because the hash map is flat, data is always copied from the provided type into
 the table. */
-typedef struct ccc_fhmap_elem_ ccc_fhmap_elem;
+typedef struct ccc_hhmap_elem_ ccc_hhmap_elem;
 
 /** @brief A container specific entry used to implement the Entry Interface.
 
 The Entry Interface offers efficient search and subsequent insertion, deletion,
 or value update based on the needs of the user. */
-typedef union ccc_fhmap_entry_ ccc_fhmap_entry;
+typedef union ccc_hhmap_entry_ ccc_hhmap_entry;
 
 /**@}*/
 
@@ -66,18 +78,18 @@ May be NULL if the user provides a allocation function. The buffer will be
 interpreted in units of type size that the user intends to store.
 @param [in] capacity the starting capacity of the provided buffer or 0 if no
 buffer is provided and an allocation function is given.
-@param [in] fhash_elem_field the name of the fhmap_elem field.
+@param [in] fhash_elem_field the name of the hhmap_elem field.
 @param [in] key_field the field of the struct used for key storage.
 @param [in] alloc_fn the allocation function for resizing or NULL if no
 resizing is allowed.
 @param [in] hash_fn the ccc_hash_fn function the user desires for the table.
 @param [in] key_eq_fn the ccc_key_eq_fn the user intends to use.
 @param [in] aux_data auxiliary data that is needed for hashing or comparison.
-@return the flat hash map directly initialized on the right hand side of the
-equality operator (i.e. ccc_flat_hash_map fh = ccc_fhm_init(...);) */
-#define ccc_fhm_init(memory_ptr, capacity, fhash_elem_field, key_field,        \
+@return the handle hash map directly initialized on the right hand side of the
+equality operator (i.e. ccc_handle_hash_map fh = ccc_hhm_init(...);) */
+#define ccc_hhm_init(memory_ptr, capacity, fhash_elem_field, key_field,        \
                      alloc_fn, hash_fn, key_eq_fn, aux_data)                   \
-    ccc_impl_fhm_init(memory_ptr, capacity, fhash_elem_field, key_field,       \
+    ccc_impl_hhm_init(memory_ptr, capacity, fhash_elem_field, key_field,       \
                       alloc_fn, hash_fn, key_eq_fn, aux_data)
 
 /** @brief Copy the map at source to destination.
@@ -98,42 +110,42 @@ of allocation for the copy.
 Manual memory management with no allocation function provided.
 
 ```
-#define FLAT_HASH_MAP_USING_NAMESPACE_CCC
+#define handle_hash_MAP_USING_NAMESPACE_CCC
 struct val
 {
-    fhmap_elem e;
+    hhmap_elem e;
     int key;
     int val;
 };
-static flat_hash_map src
-    = fhm_init((static struct val[11]){}, 11, e, key, fhmap_int_to_u64,
-               fhmap_id_eq, NULL);
+static handle_hash_map src
+    = hhm_init((static struct val[11]){}, 11, e, key, hhmap_int_to_u64,
+               hhmap_id_eq, NULL);
 insert_rand_vals(&src);
-static flat_hash_map dst
-    = fhm_init((static struct val[13]){}, 13, e, key, fhmap_int_to_u64,
-               fhmap_id_eq, NULL);
-ccc_result res = fhm_copy(&dst, &src, NULL);
+static handle_hash_map dst
+    = hhm_init((static struct val[13]){}, 13, e, key, hhmap_int_to_u64,
+               hhmap_id_eq, NULL);
+ccc_result res = hhm_copy(&dst, &src, NULL);
 ```
 
 The above requires dst capacity be greater than or equal to src capacity. Here
 is memory management handed over to the copy function.
 
 ```
-#define FLAT_HASH_MAP_USING_NAMESPACE_CCC
+#define handle_hash_MAP_USING_NAMESPACE_CCC
 struct val
 {
-    fhmap_elem e;
+    hhmap_elem e;
     int key;
     int val;
 };
-static flat_hash_map src
-    = fhm_init((struct val*)NULL, 0, e, key, fhmap_int_to_u64, fhmap_id_eq,
+static handle_hash_map src
+    = hhm_init((struct val*)NULL, 0, e, key, hhmap_int_to_u64, hhmap_id_eq,
                NULL);
 insert_rand_vals(&src);
-static flat_hash_map dst
-    = fhm_init((struct val*)NULL, 0, e, key, fhmap_int_to_u64, fhmap_id_eq,
+static handle_hash_map dst
+    = hhm_init((struct val*)NULL, 0, e, key, hhmap_int_to_u64, hhmap_id_eq,
                NULL);
-ccc_result res = fhm_copy(&dst, &src, std_alloc);
+ccc_result res = hhm_copy(&dst, &src, std_alloc);
 ```
 
 The above allows dst to have a capacity less than that of the src as long as
@@ -142,21 +154,21 @@ would still work if copying to a destination that the user wants as a fixed
 size map.
 
 ```
-#define FLAT_HASH_MAP_USING_NAMESPACE_CCC
+#define handle_hash_MAP_USING_NAMESPACE_CCC
 struct val
 {
-    fhmap_elem e;
+    hhmap_elem e;
     int key;
     int val;
 };
-static flat_hash_map src
-    = fhm_init((struct val*)NULL, 0, e, key, fhmap_int_to_u64, fhmap_id_eq,
+static handle_hash_map src
+    = hhm_init((struct val*)NULL, 0, e, key, hhmap_int_to_u64, hhmap_id_eq,
                NULL);
 insert_rand_vals(&src);
-static flat_hash_map dst
-    = fhm_init((struct val*)NULL, 0, e, key, fhmap_int_to_u64, fhmap_id_eq,
+static handle_hash_map dst
+    = hhm_init((struct val*)NULL, 0, e, key, hhmap_int_to_u64, hhmap_id_eq,
                NULL);
-ccc_result res = fhm_copy(&dst, &src, std_alloc);
+ccc_result res = hhm_copy(&dst, &src, std_alloc);
 ```
 
 The above sets up dst with fixed size while src is a dynamic map. Because an
@@ -168,8 +180,8 @@ copying between maps without allocation permission.
 
 These options allow users to stay consistent across containers with their
 memory management strategies. */
-ccc_result ccc_fhm_copy(ccc_flat_hash_map *dst, ccc_flat_hash_map const *src,
-                        ccc_alloc_fn *fn);
+ccc_result ccc_hhm_copy(ccc_handle_hash_map *dst,
+                        ccc_handle_hash_map const *src, ccc_alloc_fn *fn);
 
 /**@}*/
 
@@ -178,16 +190,17 @@ Test membership or obtain references to stored user types directly. */
 /**@{*/
 
 /** @brief Searches the table for the presence of key.
-@param [in] h the flat hash table to be searched.
+@param [in] h the handle hash table to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
 @return true if the struct containing key is stored, false if not. */
-[[nodiscard]] bool ccc_fhm_contains(ccc_flat_hash_map *h, void const *key);
+[[nodiscard]] bool ccc_hhm_contains(ccc_handle_hash_map *h, void const *key);
 
 /** @brief Returns a reference into the table at entry key.
-@param [in] h the flat hash map to search.
+@param [in] h the handle hash map to search.
 @param [in] key the key to search matching stored key type.
 @return a view of the table entry if it is present, else NULL. */
-[[nodiscard]] void *ccc_fhm_get_key_val(ccc_flat_hash_map *h, void const *key);
+[[nodiscard]] ccc_hhmap_handle ccc_hhm_get_key_val(ccc_handle_hash_map *h,
+                                                   void const *key);
 
 /**@}*/
 
@@ -197,7 +210,7 @@ control flow is needed. */
 /**@{*/
 
 /** @brief Invariantly inserts the key value wrapping out_handle.
-@param [in] h the pointer to the flat hash map.
+@param [in] h the pointer to the handle hash map.
 @param [out] out_handle the handle to the user type wrapping fhash elem.
 @return an entry. If Vacant, no prior element with key existed and the type
 wrapping out_handle remains unchanged. If Occupied the old value is written
@@ -206,11 +219,11 @@ is needed but allocation fails or has been forbidden, an insert error is set.
 
 Note that this function may write to the struct containing the second parameter
 and wraps it in an entry to provide information about the old value. */
-[[nodiscard]] ccc_entry ccc_fhm_insert(ccc_flat_hash_map *h,
-                                       ccc_fhmap_elem *out_handle);
+[[nodiscard]] ccc_entry ccc_hhm_insert(ccc_handle_hash_map *h,
+                                       ccc_hhmap_elem *out_handle);
 
 /** @brief Invariantly inserts the key value wrapping out_handle_ptr.
-@param [in] flat_hash_map_ptr the pointer to the flat hash map.
+@param [in] handle_hash_map_ptr the pointer to the handle hash map.
 @param [out] out_handle_ptr the handle to the user type wrapping fhash elem.
 @return a compound literal reference to the entry. If Vacant, no prior element
 with key existed and the type wrapping out_handle_ptr remains unchanged. If
@@ -220,15 +233,15 @@ forbidden, an insert error is set.
 
 Note that this function may write to the struct containing the second parameter
 and wraps it in an entry to provide information about the old value. */
-#define ccc_fhm_insert_r(flat_hash_map_ptr, out_handle_ptr)                    \
+#define ccc_hhm_insert_r(handle_hash_map_ptr, out_handle_ptr)                  \
     &(ccc_entry)                                                               \
     {                                                                          \
-        ccc_fhm_insert((flat_hash_map_ptr), (out_handle_ptr)).impl_            \
+        ccc_hhm_insert((handle_hash_map_ptr), (out_handle_ptr)).impl_          \
     }
 
 /** @brief Removes the key value in the map storing the old value, if present,
 in the struct containing out_handle provided by the user.
-@param [in] h the pointer to the flat hash map.
+@param [in] h the pointer to the handle hash map.
 @param [out] out_handle the handle to the user type wrapping fhash elem.
 @return the removed entry. If Occupied it may be unwrapped to obtain the old key
 value pair. If Vacant the key value pair was not stored in the map. If bad input
@@ -236,12 +249,12 @@ is provided an input error is set.
 
 Note that this function may write to the struct containing the second parameter
 and wraps it in an entry to provide information about the old value. */
-[[nodiscard]] ccc_entry ccc_fhm_remove(ccc_flat_hash_map *h,
-                                       ccc_fhmap_elem *out_handle);
+[[nodiscard]] ccc_entry ccc_hhm_remove(ccc_handle_hash_map *h,
+                                       ccc_hhmap_elem *out_handle);
 
 /** @brief Removes the key value in the map storing the old value, if present,
 in the struct containing out_handle_ptr provided by the user.
-@param [in] flat_hash_map_ptr the pointer to the flat hash map.
+@param [in] handle_hash_map_ptr the pointer to the handle hash map.
 @param [out] out_handle_ptr the handle to the user type wrapping fhash elem.
 @return a compound literal reference to the removed entry. If Occupied it may
 be unwrapped to obtain the old key value pair. If Vacant the key value pair
@@ -249,14 +262,14 @@ was not stored in the map. If bad input is provided an input error is set.
 
 Note that this function may write to the struct containing the second parameter
 and wraps it in an entry to provide information about the old value. */
-#define ccc_fhm_remove_r(flat_hash_map_ptr, out_handle_ptr)                    \
+#define ccc_hhm_remove_r(handle_hash_map_ptr, out_handle_ptr)                  \
     &(ccc_entry)                                                               \
     {                                                                          \
-        ccc_fhm_remove((flat_hash_map_ptr), (out_handle_ptr)).impl_            \
+        ccc_hhm_remove((handle_hash_map_ptr), (out_handle_ptr)).impl_          \
     }
 
 /** @brief Attempts to insert the key value wrapping key_val_handle
-@param [in] h the pointer to the flat hash map.
+@param [in] h the pointer to the handle hash map.
 @param [in] key_val_handle the handle to the user type wrapping fhash elem.
 @return an entry. If Occupied, the entry contains a reference to the key value
 user type in the table and may be unwrapped. If Vacant the entry contains a
@@ -264,11 +277,11 @@ reference to the newly inserted entry in the table. If more space is needed but
 allocation fails or has been forbidden, an insert error is set.
 @warning because this function returns a reference to a user type in the table
 any subsequent insertions or deletions invalidate this reference. */
-[[nodiscard]] ccc_entry ccc_fhm_try_insert(ccc_flat_hash_map *h,
-                                           ccc_fhmap_elem *key_val_handle);
+[[nodiscard]] ccc_entry ccc_hhm_try_insert(ccc_handle_hash_map *h,
+                                           ccc_hhmap_elem *key_val_handle);
 
 /** @brief Attempts to insert the key value wrapping key_val_handle_ptr.
-@param [in] flat_hash_map_ptr the pointer to the flat hash map.
+@param [in] handle_hash_map_ptr the pointer to the handle hash map.
 @param [in] key_val_handle_ptr the handle to the user type wrapping fhash elem.
 @return a compound literal reference to the entry. If Occupied, the entry
 contains a reference to the key value user type in the table and may be
@@ -277,14 +290,14 @@ entry in the table. If more space is needed but allocation fails or has been
 forbidden, an insert error is set.
 @warning because this function returns a reference to a user type in the table
 any subsequent insertions or deletions invalidate this reference. */
-#define ccc_fhm_try_insert_r(flat_hash_map_ptr, key_val_handle_ptr)            \
+#define ccc_hhm_try_insert_r(handle_hash_map_ptr, key_val_handle_ptr)          \
     &(ccc_entry)                                                               \
     {                                                                          \
-        ccc_fhm_try_insert((flat_hash_map_ptr), (key_val_handle_ptr)).impl_    \
+        ccc_hhm_try_insert((handle_hash_map_ptr), (key_val_handle_ptr)).impl_  \
     }
 
 /** @brief lazily insert lazy_value into the map at key if key is absent.
-@param [in] flat_hash_map_ptr a pointer to the flat hash map.
+@param [in] handle_hash_map_ptr a pointer to the handle hash map.
 @param [in] key the direct key r-value.
 @param [in] lazy_value the compound literal specifying the value.
 @return a compound literal reference to the entry of the existing or newly
@@ -298,14 +311,14 @@ key argument, you will overwrite adjacent bytes of your struct.
 Note that for brevity and convenience the user need not write the key to the
 lazy value compound literal as well. This function ensures the key in the
 compound literal matches the searched key. */
-#define ccc_fhm_try_insert_w(flat_hash_map_ptr, key, lazy_value...)            \
+#define ccc_hhm_try_insert_w(handle_hash_map_ptr, key, lazy_value...)          \
     &(ccc_entry)                                                               \
     {                                                                          \
-        ccc_impl_fhm_try_insert_w(flat_hash_map_ptr, key, lazy_value)          \
+        ccc_impl_hhm_try_insert_w(handle_hash_map_ptr, key, lazy_value)        \
     }
 
 /** @brief Invariantly inserts or overwrites a user struct into the table.
-@param [in] h a pointer to the flat hash map.
+@param [in] h a pointer to the handle hash map.
 @param [in] key_val_handle the handle to the wrapping user struct key value.
 @return an entry. If Occupied an entry was overwritten by the new key value. If
 Vacant no prior table entry existed.
@@ -313,24 +326,26 @@ Vacant no prior table entry existed.
 Note that this function can be used when the old user type is not needed but
 the information regarding its presence is helpful. */
 [[nodiscard]] ccc_entry
-ccc_fhm_insert_or_assign(ccc_flat_hash_map *h, ccc_fhmap_elem *key_val_handle);
+ccc_hhm_insert_or_assign(ccc_handle_hash_map *h,
+                         ccc_hhmap_elem *key_val_handle);
 
 /** @brief Invariantly inserts or overwrites a user struct into the table.
-@param [in] flat_hash_map_ptr a pointer to the flat hash map.
+@param [in] handle_hash_map_ptr a pointer to the handle hash map.
 @param [in] key_val_handle_ptr the handle to the wrapping user struct key value.
 @return a compound literal reference to the entry. If Occupied an entry was
 overwritten by the new key value. If Vacant no prior table entry existed.
 
 Note that this function can be used when the old user type is not needed but
 the information regarding its presence is helpful. */
-#define ccc_fhm_insert_or_assign_r(flat_hash_map_ptr, key_val_handle_ptr)      \
+#define ccc_hhm_insert_or_assign_r(handle_hash_map_ptr, key_val_handle_ptr)    \
     &(ccc_entry)                                                               \
     {                                                                          \
-        ccc_fhm_insert_or_assign((flat_hash_map_ptr), (key_val_handle)).impl_  \
+        ccc_hhm_insert_or_assign((handle_hash_map_ptr), (key_val_handle))      \
+            .impl_                                                             \
     }
 
 /** @brief Inserts a new key value pair or overwrites the existing entry.
-@param [in] flat_hash_map_ptr the pointer to the flat hash map.
+@param [in] handle_hash_map_ptr the pointer to the handle hash map.
 @param [in] key the key to be searched in the table.
 @param [in] lazy_value the compound literal to insert or use for overwrite.
 @return a compound literal reference to the entry of the existing or newly
@@ -341,10 +356,10 @@ occurs that prevents insertion. An insertion error will flag such a case.
 Note that for brevity and convenience the user need not write the key to the
 lazy value compound literal as well. This function ensures the key in the
 compound literal matches the searched key. */
-#define ccc_fhm_insert_or_assign_w(flat_hash_map_ptr, key, lazy_value...)      \
+#define ccc_hhm_insert_or_assign_w(handle_hash_map_ptr, key, lazy_value...)    \
     &(ccc_entry)                                                               \
     {                                                                          \
-        ccc_impl_fhm_insert_or_assign_w(flat_hash_map_ptr, key, lazy_value)    \
+        ccc_impl_hhm_insert_or_assign_w(handle_hash_map_ptr, key, lazy_value)  \
     }
 
 /** @brief Obtains an entry for the provided key in the table for future use.
@@ -362,11 +377,11 @@ where in the table such an element should be inserted.
 
 An entry is rarely useful on its own. It should be passed in a functional style
 to subsequent calls in the Entry Interface.*/
-[[nodiscard]] ccc_fhmap_entry ccc_fhm_entry(ccc_flat_hash_map *h,
+[[nodiscard]] ccc_hhmap_entry ccc_hhm_entry(ccc_handle_hash_map *h,
                                             void const *key);
 
 /** @brief Obtains an entry for the provided key in the table for future use.
-@param [in] flat_hash_map_ptr the hash table to be searched.
+@param [in] handle_hash_map_ptr the hash table to be searched.
 @param [in] key_ptr the key used to search the table matching the stored key
 type.
 @return a compound literal reference to a specialized hash entry for use with
@@ -381,10 +396,10 @@ where in the table such an element should be inserted.
 
 An entry is most often passed in a functional style to subsequent calls in the
 Entry Interface.*/
-#define ccc_fhm_entry_r(flat_hash_map_ptr, key_ptr)                            \
-    &(ccc_fhmap_entry)                                                         \
+#define ccc_hhm_entry_r(handle_hash_map_ptr, key_ptr)                          \
+    &(ccc_hhmap_entry)                                                         \
     {                                                                          \
-        ccc_fhm_entry((flat_hash_map_ptr), (key_ptr)).impl_                    \
+        ccc_hhm_entry((handle_hash_map_ptr), (key_ptr)).impl_                  \
     }
 
 /** @brief Modifies the provided entry if it is Occupied.
@@ -395,7 +410,7 @@ Entry Interface.*/
 This function is intended to make the function chaining in the Entry Interface
 more succinct if the entry will be modified in place based on its own value
 without the need of the auxiliary argument a ccc_update_fn can provide. */
-[[nodiscard]] ccc_fhmap_entry *ccc_fhm_and_modify(ccc_fhmap_entry *e,
+[[nodiscard]] ccc_hhmap_entry *ccc_hhm_and_modify(ccc_hhmap_entry *e,
                                                   ccc_update_fn *fn);
 
 /** @brief Modifies the provided entry if it is Occupied.
@@ -406,11 +421,11 @@ without the need of the auxiliary argument a ccc_update_fn can provide. */
 
 This function makes full use of a ccc_update_fn capability, meaning a complete
 ccc_update object will be passed to the update function callback. */
-[[nodiscard]] ccc_fhmap_entry *
-ccc_fhm_and_modify_aux(ccc_fhmap_entry *e, ccc_update_fn *fn, void *aux);
+[[nodiscard]] ccc_hhmap_entry *
+ccc_hhm_and_modify_aux(ccc_hhmap_entry *e, ccc_update_fn *fn, void *aux);
 
 /** @brief Modify an Occupied entry with a closure over user type T.
-@param [in] flat_hash_map_entry_ptr a pointer to the obtained entry.
+@param [in] handle_hash_map_entry_ptr a pointer to the obtained entry.
 @param [in] type_name the name of the user type stored in the container.
 @param [in] closure_over_T the code to be run on the reference to user type T,
 if Occupied. This may be a semicolon separated list of statements to execute on
@@ -422,12 +437,12 @@ or a vacant entry if it was vacant.
 non-NULL if the closure executes.
 
 ```
-#define FLAT_HASH_MAP_USING_NAMESPACE_CCC
+#define handle_hash_MAP_USING_NAMESPACE_CCC
 // Increment the key k if found otherwise do nothing.
-fhm_entry *e = fhm_and_modify_w(entry_r(&fhm, &k), word, T->cnt++;);
+hhm_entry *e = hhm_and_modify_w(entry_r(&hhm, &k), word, T->cnt++;);
 
 // Increment the key k if found otherwise insert a default value.
-word *w = fhm_or_insert_w(fhm_and_modify_w(entry_r(&fhm, &k), word,
+word *w = hhm_or_insert_w(hhm_and_modify_w(entry_r(&hhm, &k), word,
                                            { T->cnt++; }),
                           (word){.key = k, .cnt = 1});
 ```
@@ -435,11 +450,11 @@ word *w = fhm_or_insert_w(fhm_and_modify_w(entry_r(&fhm, &k), word,
 Note that any code written is only evaluated if the entry is Occupied and the
 container can deliver the user type T. This means any function calls are lazily
 evaluated in the closure scope. */
-#define ccc_fhm_and_modify_w(flat_hash_map_entry_ptr, type_name,               \
+#define ccc_hhm_and_modify_w(handle_hash_map_entry_ptr, type_name,             \
                              closure_over_T...)                                \
-    &(ccc_fhmap_entry)                                                         \
+    &(ccc_hhmap_entry)                                                         \
     {                                                                          \
-        ccc_impl_fhm_and_modify_w(flat_hash_map_entry_ptr, type_name,          \
+        ccc_impl_hhm_and_modify_w(handle_hash_map_entry_ptr, type_name,        \
                                   closure_over_T)                              \
     }
 
@@ -452,11 +467,11 @@ Because this functions takes an entry and inserts if it is Vacant, the only
 reason NULL shall be returned is when an insertion error will occur, usually
 due to a resizing memory error. This can happen if the table is not allowed
 to resize because no allocation function is provided. */
-[[nodiscard]] void *ccc_fhm_or_insert(ccc_fhmap_entry const *e,
-                                      ccc_fhmap_elem *elem);
+[[nodiscard]] ccc_hhmap_handle ccc_hhm_or_insert(ccc_hhmap_entry const *e,
+                                                 ccc_hhmap_elem *elem);
 
 /** @brief lazily insert the desired key value into the entry if it is Vacant.
-@param [in] flat_hash_map_entry_ptr a pointer to the obtained entry.
+@param [in] handle_hash_map_entry_ptr a pointer to the obtained entry.
 @param [in] lazy_key_value the compound literal to construct in place if the
 entry is Vacant.
 @return a reference to the unwrapped user type in the entry, either the
@@ -466,8 +481,8 @@ is not allowed.
 
 Note that if the compound literal uses any function calls to generate values
 or other data, such functions will not be called if the entry is Occupied. */
-#define ccc_fhm_or_insert_w(flat_hash_map_entry_ptr, lazy_key_value...)        \
-    ccc_impl_fhm_or_insert_w(flat_hash_map_entry_ptr, lazy_key_value)
+#define ccc_hhm_or_insert_w(handle_hash_map_entry_ptr, lazy_key_value...)      \
+    ccc_impl_hhm_or_insert_w(handle_hash_map_entry_ptr, lazy_key_value)
 
 /** @brief Inserts the provided entry invariantly.
 @param [in] e the entry returned from a call obtaining an entry.
@@ -480,42 +495,42 @@ This method can be used when the old value in the table does not need to
 be preserved. See the regular insert method if the old value is of interest.
 If an error occurs during the insertion process due to memory limitations
 or a search error NULL is returned. Otherwise insertion should not fail. */
-[[nodiscard]] void *ccc_fhm_insert_entry(ccc_fhmap_entry const *e,
-                                         ccc_fhmap_elem *elem);
+[[nodiscard]] ccc_hhmap_handle ccc_hhm_insert_entry(ccc_hhmap_entry const *e,
+                                                    ccc_hhmap_elem *elem);
 
 /** @brief write the contents of the compound literal lazy_key_value to a slot.
-@param [in] flat_hash_map_entry_ptr a pointer to the obtained entry.
+@param [in] handle_hash_map_entry_ptr a pointer to the obtained entry.
 @param [in] lazy_key_value the compound literal to write to a new slot.
 @return a reference to the newly inserted or overwritten user type. NULL is
 returned if resizing is required but fails or is not allowed. */
-#define ccc_fhm_insert_entry_w(flat_hash_map_entry_ptr, lazy_key_value...)     \
-    ccc_impl_fhm_insert_entry_w(flat_hash_map_entry_ptr, lazy_key_value)
+#define ccc_hhm_insert_entry_w(handle_hash_map_entry_ptr, lazy_key_value...)   \
+    ccc_impl_hhm_insert_entry_w(handle_hash_map_entry_ptr, lazy_key_value)
 
 /** @brief Remove the entry from the table if Occupied.
 @param [in] e a pointer to the table entry.
 @return an entry containing NULL. If Occupied an entry in the table existed and
 was removed. If Vacant, no prior entry existed to be removed. */
-[[nodiscard]] ccc_entry ccc_fhm_remove_entry(ccc_fhmap_entry const *e);
+[[nodiscard]] ccc_entry ccc_hhm_remove_entry(ccc_hhmap_entry const *e);
 
 /** @brief Remove the entry from the table if Occupied.
-@param [in] flat_hash_map_entry_ptr a pointer to the table entry.
+@param [in] handle_hash_map_entry_ptr a pointer to the table entry.
 @return an entry containing NULL. If Occupied an entry in the table existed and
 was removed. If Vacant, no prior entry existed to be removed. */
-#define ccc_fhm_remove_entry_r(flat_hash_map_entry_ptr)                        \
+#define ccc_hhm_remove_entry_r(handle_hash_map_entry_ptr)                      \
     &(ccc_entry)                                                               \
     {                                                                          \
-        ccc_fhm_remove_entry((flat_hash_map_entry_ptr)).impl_                  \
+        ccc_hhm_remove_entry((handle_hash_map_entry_ptr)).impl_                \
     }
 
 /** @brief Unwraps the provided entry to obtain a view into the table element.
 @param [in] e the entry from a query to the table via function or macro.
 @return an view into the table entry if one is present, or NULL. */
-[[nodiscard]] void *ccc_fhm_unwrap(ccc_fhmap_entry const *e);
+[[nodiscard]] ccc_hhmap_handle ccc_hhm_unwrap(ccc_hhmap_entry const *e);
 
 /** @brief Returns the Vacant or Occupied status of the entry.
 @param [in] e the entry from a query to the table via function or macro.
 @return true if the entry is occupied, false if not. */
-[[nodiscard]] bool ccc_fhm_occupied(ccc_fhmap_entry const *e);
+[[nodiscard]] bool ccc_hhm_occupied(ccc_hhmap_entry const *e);
 
 /** @brief Provides the status of the entry should an insertion follow.
 @param [in] e the entry from a query to the table via function or macro.
@@ -532,7 +547,7 @@ functions will indicate such a failure. One can also confirm an insertion error
 will occur from an entry with this function. For example, leaving this function
 in an assert for debug builds can be a helpful sanity check if the heap should
 correctly resize by default and errors are not usually expected. */
-[[nodiscard]] bool ccc_fhm_insert_error(ccc_fhmap_entry const *e);
+[[nodiscard]] bool ccc_hhm_insert_error(ccc_hhmap_entry const *e);
 
 /** @brief Obtain the entry status from a container entry.
 @param [in] e a pointer to the entry.
@@ -543,7 +558,7 @@ e is non-NULL to avoid an inaccurate status returned.
 Note that this function can be useful for debugging or if more detailed
 messages are needed for logging purposes. See ccc_entry_status_msg() in
 ccc/types.h for more information on detailed entry statuses. */
-[[nodiscard]] ccc_entry_status ccc_fhm_entry_status(ccc_fhmap_entry const *e);
+[[nodiscard]] ccc_entry_status ccc_hhm_entry_status(ccc_hhmap_entry const *e);
 
 /**@}*/
 
@@ -558,7 +573,7 @@ maintenance is required on the elements in the table before their slots are
 forfeit.
 
 If NULL is passed as the destructor function time is O(1), else O(capacity). */
-ccc_result ccc_fhm_clear(ccc_flat_hash_map *h, ccc_destructor_fn *fn);
+ccc_result ccc_hhm_clear(ccc_handle_hash_map *h, ccc_destructor_fn *fn);
 
 /** @brief Frees all slots in the table and frees the underlying buffer.
 @param [in] h the table to be cleared.
@@ -568,7 +583,8 @@ forfeit.
 @return the result of free operation. If no alloc function is provided it is
 an error to attempt to free the buffer and a memory error is returned.
 Otherwise, an OK result is returned. */
-ccc_result ccc_fhm_clear_and_free(ccc_flat_hash_map *h, ccc_destructor_fn *fn);
+ccc_result ccc_hhm_clear_and_free(ccc_handle_hash_map *h,
+                                  ccc_destructor_fn *fn);
 
 /**@}*/
 
@@ -584,7 +600,7 @@ resizing occurs which would lead to undefined behavior. O(capacity).
 
 Iteration starts from index 0 by capacity of the table so iteration order is
 not obvious to the user, nor should any specific order be relied on. */
-[[nodiscard]] void *ccc_fhm_begin(ccc_flat_hash_map const *h);
+[[nodiscard]] void *ccc_hhm_begin(ccc_handle_hash_map const *h);
 
 /** @brief Advances the iterator to the next occupied table slot.
 @param [in] h the table being iterated upon.
@@ -592,14 +608,14 @@ not obvious to the user, nor should any specific order be relied on. */
 @return a pointer that can be cast directly to the user type that is stored.
 @warning erasing or inserting during iteration may invalidate iterators if
 resizing occurs which would lead to undefined behavior. O(capacity). */
-[[nodiscard]] void *ccc_fhm_next(ccc_flat_hash_map const *h,
-                                 ccc_fhmap_elem const *iter);
+[[nodiscard]] void *ccc_hhm_next(ccc_handle_hash_map const *h,
+                                 ccc_hhmap_elem const *iter);
 
 /** @brief Check the current iterator against the end for loop termination.
 @param [in] h the table being iterated upon.
 @return the end address of the hash table.
 @warning It is undefined behavior to access or modify the end address. */
-[[nodiscard]] void *ccc_fhm_end(ccc_flat_hash_map const *h);
+[[nodiscard]] void *ccc_hhm_end(ccc_handle_hash_map const *h);
 
 /**@}*/
 
@@ -610,12 +626,12 @@ Obtain the container state. */
 /** @brief Returns the size status of the table.
 @param [in] h the hash table.
 @return true if empty else false. */
-[[nodiscard]] bool ccc_fhm_is_empty(ccc_flat_hash_map const *h);
+[[nodiscard]] bool ccc_hhm_is_empty(ccc_handle_hash_map const *h);
 
 /** @brief Returns the size of the table.
 @param [in] h the hash table.
 @return the size_t size. */
-[[nodiscard]] size_t ccc_fhm_size(ccc_flat_hash_map const *h);
+[[nodiscard]] size_t ccc_hhm_size(ccc_handle_hash_map const *h);
 
 /** @brief Helper to find a prime number if needed.
 @param [in] n the input that may or may not be prime.
@@ -625,12 +641,12 @@ It is possible to use this hash table without an allocator by providing the
 buffer to be used for the underlying storage and preventing allocation.
 If such a backing store is used it would be best to ensure it is a prime number
 size to mitigate hash collisions. */
-[[nodiscard]] size_t ccc_fhm_next_prime(size_t n);
+[[nodiscard]] size_t ccc_hhm_next_prime(size_t n);
 
 /** @brief Return the full capacity of the backing storage.
 @param [in] h the hash table.
 @return the capacity. */
-[[nodiscard]] size_t ccc_fhm_capacity(ccc_flat_hash_map const *h);
+[[nodiscard]] size_t ccc_hhm_capacity(ccc_handle_hash_map const *h);
 
 /** @brief Return a reference to the base of backing array. O(1).
 @param [in] h a pointer to the map.
@@ -639,62 +655,13 @@ size to mitigate hash collisions. */
 consideration for the organization of map.
 @warning it is the users responsibility to ensure that access to any data is
 within the capacity of the backing buffer. */
-[[nodiscard]] void *ccc_fhm_data(ccc_flat_hash_map const *h);
+[[nodiscard]] void *ccc_hhm_data(ccc_handle_hash_map const *h);
 
 /** @brief Validation of invariants for the hash table.
 @param [in] h the table to validate.
 @return true if all invariants hold, false if corruption occurs. */
-[[nodiscard]] bool ccc_fhm_validate(ccc_flat_hash_map const *h);
+[[nodiscard]] bool ccc_hhm_validate(ccc_handle_hash_map const *h);
 
 /**@}*/
 
-/** Define this preprocessor directive if shorter names are helpful. Ensure
- no namespace clashes occur before shortening. */
-#ifdef FLAT_HASH_MAP_USING_NAMESPACE_CCC
-typedef ccc_fhmap_elem fhmap_elem;
-typedef ccc_flat_hash_map flat_hash_map;
-typedef ccc_fhmap_entry fhmap_entry;
-#    define fhm_init(args...) ccc_fhm_init(args)
-#    define fhm_static_init(args...) ccc_fhm_static_init(args)
-#    define fhm_zero_init(args...) ccc_fhm_zero_init(args)
-#    define fhm_copy(args...) ccc_fhm_copy(args)
-#    define fhm_and_modify_w(args...) ccc_fhm_and_modify_w(args)
-#    define fhm_or_insert_w(args...) ccc_fhm_or_insert_w(args)
-#    define fhm_insert_entry_w(args...) ccc_fhm_insert_entry_w(args)
-#    define fhm_try_insert_w(args...) ccc_fhm_try_insert_w(args)
-#    define fhm_insert_or_assign_w(args...) ccc_fhm_insert_or_assign_w(args)
-#    define fhm_contains(args...) ccc_fhm_contains(args)
-#    define fhm_get_key_val(args...) ccc_fhm_get_key_val(args)
-#    define fhm_remove_r(args...) ccc_fhm_remove_r(args)
-#    define fhm_insert_r(args...) ccc_fhm_insert_r(args)
-#    define fhm_try_insert_r(args...) ccc_fhm_try_insert_r(args)
-#    define fhm_insert_or_assign_r(args...) ccc_fhm_insert_or_assign_r(args)
-#    define fhm_remove_entry_r(args...) ccc_fhm_remove_entry_r(args)
-#    define fhm_remove(args...) ccc_fhm_remove(args)
-#    define fhm_insert(args...) ccc_fhm_insert(args)
-#    define fhm_try_insert(args...) ccc_fhm_try_insert(args)
-#    define fhm_insert_or_assign(args...) ccc_fhm_insert_or_assign(args)
-#    define fhm_remove_entry(args...) ccc_fhm_remove_entry(args)
-#    define fhm_entry_r(args...) ccc_fhm_entry_r(args)
-#    define fhm_entry(args...) ccc_fhm_entry(args)
-#    define fhm_and_modify(args...) ccc_fhm_and_modify(args)
-#    define fhm_and_modify_aux(args...) ccc_fhm_and_modify_aux(args)
-#    define fhm_or_insert(args...) ccc_fhm_or_insert(args)
-#    define fhm_insert_entry(args...) ccc_fhm_insert_entry(args)
-#    define fhm_unwrap(args...) ccc_fhm_unwrap(args)
-#    define fhm_occupied(args...) ccc_fhm_occupied(args)
-#    define fhm_insert_error(args...) ccc_fhm_insert_error(args)
-#    define fhm_begin(args...) ccc_fhm_begin(args)
-#    define fhm_next(args...) ccc_fhm_next(args)
-#    define fhm_end(args...) ccc_fhm_end(args)
-#    define fhm_data(args...) ccc_fhm_data(args)
-#    define fhm_is_empty(args...) ccc_fhm_is_empty(args)
-#    define fhm_size(args...) ccc_fhm_size(args)
-#    define fhm_clear(args...) ccc_fhm_clear(args)
-#    define fhm_clear_and_free(args...) ccc_fhm_clear_and_free(args)
-#    define fhm_next_prime(args...) ccc_fhm_next_prime(args)
-#    define fhm_capacity(args...) ccc_fhm_capacity(args)
-#    define fhm_validate(args...) ccc_fhm_validate(args)
-#endif
-
-#endif /* CCC_FLAT_HASH_MAP_H */
+#endif /* CCC_HANDLE_HASH_MAP_H */

--- a/ccc/handle_hash_map.h
+++ b/ccc/handle_hash_map.h
@@ -34,6 +34,7 @@ All types and functions can then be written without the `ccc_` prefix. */
 /** @endcond */
 
 #include "impl/impl_handle_hash_map.h"
+#include "types.h"
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/handle_hash_map.h
+++ b/ccc/handle_hash_map.h
@@ -53,11 +53,11 @@ Because the hash map is flat, data is always copied from the provided type into
 the table. */
 typedef struct ccc_hhmap_elem_ ccc_hhmap_elem;
 
-/** @brief A container specific entry used to implement the Entry Interface.
+/** @brief A container specific handle used to implement the Handle Interface.
 
-The Entry Interface offers efficient search and subsequent insertion, deletion,
+The Handle Interface offers efficient search and subsequent insertion, deletion,
 or value update based on the needs of the user. */
-typedef union ccc_hhmap_entry_ ccc_hhmap_entry;
+typedef union ccc_hhmap_handle_ ccc_hhmap_handle;
 
 /**@}*/
 
@@ -188,35 +188,35 @@ Test membership or obtain references to stored user types directly. */
 @return true if the struct containing key is stored, false if not. */
 [[nodiscard]] bool ccc_hhm_contains(ccc_handle_hash_map *h, void const *key);
 
-/** @brief Returns a reference into the table at entry key.
+/** @brief Returns a reference into the table at handle key.
 @param [in] h the handle hash map to search.
 @param [in] key the key to search matching stored key type.
-@return a view of the table entry if it is present, else NULL. */
-[[nodiscard]] ccc_handle ccc_hhm_get_key_val(ccc_handle_hash_map *h,
-                                             void const *key);
+@return a view of the table handle if it is present, else NULL. */
+[[nodiscard]] ccc_handle_i ccc_hhm_get_key_val(ccc_handle_hash_map *h,
+                                               void const *key);
 
 /** @brief Returns a reference to the user data at the provided handle.
 @param [in] h a pointer to the map.
 @param [in] i the stable handle obtained by the user.
 @return a pointer to the user type stored at the specified handle or NULL if
 an out of range handle or handle representing no data is provided.
-@warning this function can only check if the entry at the handle is valid. If a
+@warning this function can only check if the handle at the handle is valid. If a
 handle represents a slot that has been taken by a new element because the old
 one has been removed that new element data will be returned. */
-[[nodiscard]] void *ccc_hhm_at(ccc_handle_hash_map const *h, ccc_handle i);
+[[nodiscard]] void *ccc_hhm_at(ccc_handle_hash_map const *h, ccc_handle_i i);
 
 /** @brief Returns a reference to the user type in the table at the handle.
 @param [in] handle_hash_map_ptr a pointer to the map.
 @param [in] type_name name of the user type stored in each slot of the map.
 @param [in] handle the index handle obtained from previous map operations.
-@return a reference to the entry at handle in the map as the type the user has
+@return a reference to the handle at handle in the map as the type the user has
 stored in the map. */
 #define ccc_hhm_as(handle_hash_map_ptr, type_name, handle...)                  \
     ccc_impl_hhm_as(handle_hash_map_ptr, type_name, handle)
 
 /**@}*/
 
-/** @name Entry Interface
+/** @name Handle Interface
 Obtain and operate on container entries for efficient queries when non-trivial
 control flow is needed. */
 /**@{*/
@@ -224,29 +224,29 @@ control flow is needed. */
 /** @brief Invariantly inserts the key value wrapping out_handle.
 @param [in] h the pointer to the handle hash map.
 @param [out] out_handle the handle to the user type wrapping fhash elem.
-@return an entry. If Vacant, no prior element with key existed and the type
+@return an handle. If Vacant, no prior element with key existed and the type
 wrapping out_handle remains unchanged. If Occupied the old value is written
 to the type wrapping out_handle and may be unwrapped to view. If more space
 is needed but allocation fails or has been forbidden, an insert error is set.
 
 Note that this function may write to the struct containing the second parameter
-and wraps it in an entry to provide information about the old value. */
-[[nodiscard]] ccc_entry ccc_hhm_insert(ccc_handle_hash_map *h,
-                                       ccc_hhmap_elem *out_handle);
+and wraps it in an handle to provide information about the old value. */
+[[nodiscard]] ccc_handle ccc_hhm_insert(ccc_handle_hash_map *h,
+                                        ccc_hhmap_elem *out_handle);
 
 /** @brief Invariantly inserts the key value wrapping out_handle_ptr.
 @param [in] handle_hash_map_ptr the pointer to the handle hash map.
 @param [out] out_handle_ptr the handle to the user type wrapping fhash elem.
-@return a compound literal reference to the entry. If Vacant, no prior element
+@return a compound literal reference to the handle. If Vacant, no prior element
 with key existed and the type wrapping out_handle_ptr remains unchanged. If
 Occupied the old value is written to the type wrapping out_handle_ptr and may
 be unwrapped to view. If more space is needed but allocation fails or has been
 forbidden, an insert error is set.
 
 Note that this function may write to the struct containing the second parameter
-and wraps it in an entry to provide information about the old value. */
+and wraps it in an handle to provide information about the old value. */
 #define ccc_hhm_insert_r(handle_hash_map_ptr, out_handle_ptr)                  \
-    &(ccc_entry)                                                               \
+    &(ccc_handle)                                                              \
     {                                                                          \
         ccc_hhm_insert((handle_hash_map_ptr), (out_handle_ptr)).impl_          \
     }
@@ -255,27 +255,27 @@ and wraps it in an entry to provide information about the old value. */
 in the struct containing out_handle provided by the user.
 @param [in] h the pointer to the handle hash map.
 @param [out] out_handle the handle to the user type wrapping fhash elem.
-@return the removed entry. If Occupied it may be unwrapped to obtain the old key
-value pair. If Vacant the key value pair was not stored in the map. If bad input
-is provided an input error is set.
+@return the removed handle. If Occupied it may be unwrapped to obtain the old
+key value pair. If Vacant the key value pair was not stored in the map. If bad
+input is provided an input error is set.
 
 Note that this function may write to the struct containing the second parameter
-and wraps it in an entry to provide information about the old value. */
-[[nodiscard]] ccc_entry ccc_hhm_remove(ccc_handle_hash_map *h,
-                                       ccc_hhmap_elem *out_handle);
+and wraps it in an handle to provide information about the old value. */
+[[nodiscard]] ccc_handle ccc_hhm_remove(ccc_handle_hash_map *h,
+                                        ccc_hhmap_elem *out_handle);
 
 /** @brief Removes the key value in the map storing the old value, if present,
 in the struct containing out_handle_ptr provided by the user.
 @param [in] handle_hash_map_ptr the pointer to the handle hash map.
 @param [out] out_handle_ptr the handle to the user type wrapping fhash elem.
-@return a compound literal reference to the removed entry. If Occupied it may
+@return a compound literal reference to the removed handle. If Occupied it may
 be unwrapped to obtain the old key value pair. If Vacant the key value pair
 was not stored in the map. If bad input is provided an input error is set.
 
 Note that this function may write to the struct containing the second parameter
-and wraps it in an entry to provide information about the old value. */
+and wraps it in an handle to provide information about the old value. */
 #define ccc_hhm_remove_r(handle_hash_map_ptr, out_handle_ptr)                  \
-    &(ccc_entry)                                                               \
+    &(ccc_handle)                                                              \
     {                                                                          \
         ccc_hhm_remove((handle_hash_map_ptr), (out_handle_ptr)).impl_          \
     }
@@ -283,27 +283,27 @@ and wraps it in an entry to provide information about the old value. */
 /** @brief Attempts to insert the key value wrapping key_val_handle
 @param [in] h the pointer to the handle hash map.
 @param [in] key_val_handle the handle to the user type wrapping fhash elem.
-@return an entry. If Occupied, the entry contains a reference to the key value
-user type in the table and may be unwrapped. If Vacant the entry contains a
-reference to the newly inserted entry in the table. If more space is needed but
+@return an handle. If Occupied, the handle contains a reference to the key value
+user type in the table and may be unwrapped. If Vacant the handle contains a
+reference to the newly inserted handle in the table. If more space is needed but
 allocation fails or has been forbidden, an insert error is set.
 @warning because this function returns a reference to a user type in the table
 any subsequent insertions or deletions invalidate this reference. */
-[[nodiscard]] ccc_entry ccc_hhm_try_insert(ccc_handle_hash_map *h,
-                                           ccc_hhmap_elem *key_val_handle);
+[[nodiscard]] ccc_handle ccc_hhm_try_insert(ccc_handle_hash_map *h,
+                                            ccc_hhmap_elem *key_val_handle);
 
 /** @brief Attempts to insert the key value wrapping key_val_handle_ptr.
 @param [in] handle_hash_map_ptr the pointer to the handle hash map.
 @param [in] key_val_handle_ptr the handle to the user type wrapping fhash elem.
-@return a compound literal reference to the entry. If Occupied, the entry
+@return a compound literal reference to the handle. If Occupied, the handle
 contains a reference to the key value user type in the table and may be
-unwrapped. If Vacant the entry contains a reference to the newly inserted
-entry in the table. If more space is needed but allocation fails or has been
+unwrapped. If Vacant the handle contains a reference to the newly inserted
+handle in the table. If more space is needed but allocation fails or has been
 forbidden, an insert error is set.
 @warning because this function returns a reference to a user type in the table
 any subsequent insertions or deletions invalidate this reference. */
 #define ccc_hhm_try_insert_r(handle_hash_map_ptr, key_val_handle_ptr)          \
-    &(ccc_entry)                                                               \
+    &(ccc_handle)                                                              \
     {                                                                          \
         ccc_hhm_try_insert((handle_hash_map_ptr), (key_val_handle_ptr)).impl_  \
     }
@@ -312,7 +312,7 @@ any subsequent insertions or deletions invalidate this reference. */
 @param [in] handle_hash_map_ptr a pointer to the handle hash map.
 @param [in] key the direct key r-value.
 @param [in] lazy_value the compound literal specifying the value.
-@return a compound literal reference to the entry of the existing or newly
+@return a compound literal reference to the handle of the existing or newly
 inserted value. Occupied indicates the key existed, Vacant indicates the key
 was absent. Unwrapping in any case provides the current value unless an error
 occurs that prevents insertion. An insertion error will flag such a case.
@@ -324,7 +324,7 @@ Note that for brevity and convenience the user need not write the key to the
 lazy value compound literal as well. This function ensures the key in the
 compound literal matches the searched key. */
 #define ccc_hhm_try_insert_w(handle_hash_map_ptr, key, lazy_value...)          \
-    &(ccc_entry)                                                               \
+    &(ccc_handle)                                                              \
     {                                                                          \
         ccc_impl_hhm_try_insert_w(handle_hash_map_ptr, key, lazy_value)        \
     }
@@ -332,35 +332,35 @@ compound literal matches the searched key. */
 /** @brief Invariantly inserts or overwrites a user struct into the table.
 @param [in] h a pointer to the handle hash map.
 @param [in] key_val_handle the handle to the wrapping user struct key value.
-@return an entry. If Occupied an entry was overwritten by the new key value. If
-Vacant no prior table entry existed.
+@return an handle. If Occupied an handle was overwritten by the new key value.
+If Vacant no prior table handle existed.
 
 Note that this function can be used when the old user type is not needed but
 the information regarding its presence is helpful. */
-[[nodiscard]] ccc_entry
+[[nodiscard]] ccc_handle
 ccc_hhm_insert_or_assign(ccc_handle_hash_map *h,
                          ccc_hhmap_elem *key_val_handle);
 
 /** @brief Invariantly inserts or overwrites a user struct into the table.
 @param [in] handle_hash_map_ptr a pointer to the handle hash map.
 @param [in] key_val_handle_ptr the handle to the wrapping user struct key value.
-@return a compound literal reference to the entry. If Occupied an entry was
-overwritten by the new key value. If Vacant no prior table entry existed.
+@return a compound literal reference to the handle. If Occupied an handle was
+overwritten by the new key value. If Vacant no prior table handle existed.
 
 Note that this function can be used when the old user type is not needed but
 the information regarding its presence is helpful. */
 #define ccc_hhm_insert_or_assign_r(handle_hash_map_ptr, key_val_handle_ptr)    \
-    &(ccc_entry)                                                               \
+    &(ccc_handle)                                                              \
     {                                                                          \
         ccc_hhm_insert_or_assign((handle_hash_map_ptr), (key_val_handle))      \
             .impl_                                                             \
     }
 
-/** @brief Inserts a new key value pair or overwrites the existing entry.
+/** @brief Inserts a new key value pair or overwrites the existing handle.
 @param [in] handle_hash_map_ptr the pointer to the handle hash map.
 @param [in] key the key to be searched in the table.
 @param [in] lazy_value the compound literal to insert or use for overwrite.
-@return a compound literal reference to the entry of the existing or newly
+@return a compound literal reference to the handle of the existing or newly
 inserted value. Occupied indicates the key existed, Vacant indicates the key
 was absent. Unwrapping in any case provides the current value unless an error
 occurs that prevents insertion. An insertion error will flag such a case.
@@ -369,135 +369,135 @@ Note that for brevity and convenience the user need not write the key to the
 lazy value compound literal as well. This function ensures the key in the
 compound literal matches the searched key. */
 #define ccc_hhm_insert_or_assign_w(handle_hash_map_ptr, key, lazy_value...)    \
-    &(ccc_entry)                                                               \
+    &(ccc_handle)                                                              \
     {                                                                          \
         ccc_impl_hhm_insert_or_assign_w(handle_hash_map_ptr, key, lazy_value)  \
     }
 
-/** @brief Obtains an entry for the provided key in the table for future use.
+/** @brief Obtains an handle for the provided key in the table for future use.
 @param [in] h the hash table to be searched.
 @param [in] key the key used to search the table matching the stored key type.
-@return a specialized hash entry for use with other functions in the Entry
+@return a specialized hash handle for use with other functions in the handle
 Interface.
-@warning the contents of an entry should not be examined or modified. Use the
+@warning the contents of an handle should not be examined or modified. Use the
 provided functions, only.
 
-An entry is a search result that provides either an Occupied or Vacant entry
-in the table. An occupied entry signifies that the search was successful. A
-Vacant entry means the search was not successful but we now have a handle to
+An handle is a search result that provides either an Occupied or Vacant handle
+in the table. An occupied handle signifies that the search was successful. A
+Vacant handle means the search was not successful but we now have a handle to
 where in the table such an element should be inserted.
 
-An entry is rarely useful on its own. It should be passed in a functional style
-to subsequent calls in the Entry Interface.*/
-[[nodiscard]] ccc_hhmap_entry ccc_hhm_entry(ccc_handle_hash_map *h,
-                                            void const *key);
+An handle is rarely useful on its own. It should be passed in a functional style
+to subsequent calls in the Handle Interface.*/
+[[nodiscard]] ccc_hhmap_handle ccc_hhm_handle(ccc_handle_hash_map *h,
+                                              void const *key);
 
-/** @brief Obtains an entry for the provided key in the table for future use.
+/** @brief Obtains an handle for the provided key in the table for future use.
 @param [in] handle_hash_map_ptr the hash table to be searched.
 @param [in] key_ptr the key used to search the table matching the stored key
 type.
-@return a compound literal reference to a specialized hash entry for use with
-other functions in the Entry Interface.
-@warning the contents of an entry should not be examined or modified. Use the
+@return a compound literal reference to a specialized hash handle for use with
+other functions in the Handle Interface.
+@warning the contents of an handle should not be examined or modified. Use the
 provided functions, only.
 
-An entry is a search result that provides either an Occupied or Vacant entry
-in the table. An occupied entry signifies that the search was successful. A
-Vacant entry means the search was not successful but we now have a handle to
+An handle is a search result that provides either an Occupied or Vacant handle
+in the table. An occupied handle signifies that the search was successful. A
+Vacant handle means the search was not successful but we now have a handle to
 where in the table such an element should be inserted.
 
-An entry is most often passed in a functional style to subsequent calls in the
-Entry Interface.*/
-#define ccc_hhm_entry_r(handle_hash_map_ptr, key_ptr)                          \
-    &(ccc_hhmap_entry)                                                         \
+An handle is most often passed in a functional style to subsequent calls in the
+Handle Interface.*/
+#define ccc_hhm_handle_r(handle_hash_map_ptr, key_ptr)                         \
+    &(ccc_hhmap_handle)                                                        \
     {                                                                          \
-        ccc_hhm_entry((handle_hash_map_ptr), (key_ptr)).impl_                  \
+        ccc_hhm_handle((handle_hash_map_ptr), (key_ptr)).impl_                 \
     }
 
-/** @brief Modifies the provided entry if it is Occupied.
-@param [in] e the entry obtained from an entry function or macro.
+/** @brief Modifies the provided handle if it is Occupied.
+@param [in] e the handle obtained from an handle function or macro.
 @param [in] fn an update function in which the auxiliary argument is unused.
-@return the updated entry if it was Occupied or the unmodified vacant entry.
+@return the updated handle if it was Occupied or the unmodified vacant handle.
 
-This function is intended to make the function chaining in the Entry Interface
-more succinct if the entry will be modified in place based on its own value
+This function is intended to make the function chaining in the Handle Interface
+more succinct if the handle will be modified in place based on its own value
 without the need of the auxiliary argument a ccc_update_fn can provide. */
-[[nodiscard]] ccc_hhmap_entry *ccc_hhm_and_modify(ccc_hhmap_entry *e,
-                                                  ccc_update_fn *fn);
+[[nodiscard]] ccc_hhmap_handle *ccc_hhm_and_modify(ccc_hhmap_handle *e,
+                                                   ccc_update_fn *fn);
 
-/** @brief Modifies the provided entry if it is Occupied.
-@param [in] e the entry obtained from an entry function or macro.
+/** @brief Modifies the provided handle if it is Occupied.
+@param [in] e the handle obtained from an handle function or macro.
 @param [in] fn an update function that requires auxiliary data.
 @param [in] aux auxiliary data required for the update.
-@return the updated entry if it was Occupied or the unmodified vacant entry.
+@return the updated handle if it was Occupied or the unmodified vacant handle.
 
 This function makes full use of a ccc_update_fn capability, meaning a complete
 ccc_update object will be passed to the update function callback. */
-[[nodiscard]] ccc_hhmap_entry *
-ccc_hhm_and_modify_aux(ccc_hhmap_entry *e, ccc_update_fn *fn, void *aux);
+[[nodiscard]] ccc_hhmap_handle *
+ccc_hhm_and_modify_aux(ccc_hhmap_handle *e, ccc_update_fn *fn, void *aux);
 
-/** @brief Modify an Occupied entry with a closure over user type T.
-@param [in] handle_hash_map_entry_ptr a pointer to the obtained entry.
+/** @brief Modify an Occupied handle with a closure over user type T.
+@param [in] handle_hash_map_handle_ptr a pointer to the obtained handle.
 @param [in] type_name the name of the user type stored in the container.
 @param [in] closure_over_T the code to be run on the reference to user type T,
 if Occupied. This may be a semicolon separated list of statements to execute on
 T or a section of code wrapped in braces {code here} which may be preferred
 for formatting.
-@return a compound literal reference to the modified entry if it was occupied
-or a vacant entry if it was vacant.
-@note T is a reference to the user type stored in the entry guaranteed to be
+@return a compound literal reference to the modified handle if it was occupied
+or a vacant handle if it was vacant.
+@note T is a reference to the user type stored in the handle guaranteed to be
 non-NULL if the closure executes.
 
 ```
 #define handle_hash_MAP_USING_NAMESPACE_CCC
 // Increment the key k if found otherwise do nothing.
-hhm_entry *e = hhm_and_modify_w(entry_r(&hhm, &k), word, T->cnt++;);
+hhm_handle *e = hhm_and_modify_w(handle_r(&hhm, &k), word, T->cnt++;);
 
 // Increment the key k if found otherwise insert a default value.
-word *w = hhm_or_insert_w(hhm_and_modify_w(entry_r(&hhm, &k), word,
+word *w = hhm_or_insert_w(hhm_and_modify_w(handle_r(&hhm, &k), word,
                                            { T->cnt++; }),
                           (word){.key = k, .cnt = 1});
 ```
 
-Note that any code written is only evaluated if the entry is Occupied and the
+Note that any code written is only evaluated if the handle is Occupied and the
 container can deliver the user type T. This means any function calls are lazily
 evaluated in the closure scope. */
-#define ccc_hhm_and_modify_w(handle_hash_map_entry_ptr, type_name,             \
+#define ccc_hhm_and_modify_w(handle_hash_map_handle_ptr, type_name,            \
                              closure_over_T...)                                \
-    &(ccc_hhmap_entry)                                                         \
+    &(ccc_hhmap_handle)                                                        \
     {                                                                          \
-        ccc_impl_hhm_and_modify_w(handle_hash_map_entry_ptr, type_name,        \
+        ccc_impl_hhm_and_modify_w(handle_hash_map_handle_ptr, type_name,       \
                                   closure_over_T)                              \
     }
 
-/** @brief Inserts the struct with handle elem if the entry is Vacant.
-@param [in] e the entry obtained via function or macro call.
-@param [in] elem the handle to the struct to be inserted to a Vacant entry.
-@return a pointer to entry in the table invariantly. NULL on error.
+/** @brief Inserts the struct with handle elem if the handle is Vacant.
+@param [in] e the handle obtained via function or macro call.
+@param [in] elem the handle to the struct to be inserted to a Vacant handle.
+@return a pointer to handle in the table invariantly. NULL on error.
 
-Because this functions takes an entry and inserts if it is Vacant, the only
+Because this functions takes an handle and inserts if it is Vacant, the only
 reason NULL shall be returned is when an insertion error will occur, usually
 due to a resizing memory error. This can happen if the table is not allowed
 to resize because no allocation function is provided. */
-[[nodiscard]] ccc_handle ccc_hhm_or_insert(ccc_hhmap_entry const *e,
-                                           ccc_hhmap_elem *elem);
+[[nodiscard]] ccc_handle_i ccc_hhm_or_insert(ccc_hhmap_handle const *e,
+                                             ccc_hhmap_elem *elem);
 
-/** @brief lazily insert the desired key value into the entry if it is Vacant.
-@param [in] handle_hash_map_entry_ptr a pointer to the obtained entry.
+/** @brief lazily insert the desired key value into the handle if it is Vacant.
+@param [in] handle_hash_map_handle_ptr a pointer to the obtained handle.
 @param [in] lazy_key_value the compound literal to construct in place if the
-entry is Vacant.
-@return a reference to the unwrapped user type in the entry, either the
-unmodified reference if the entry was Occupied or the newly inserted element
-if the entry was Vacant. NULL is returned if resizing is required but fails or
+handle is Vacant.
+@return a reference to the unwrapped user type in the handle, either the
+unmodified reference if the handle was Occupied or the newly inserted element
+if the handle was Vacant. NULL is returned if resizing is required but fails or
 is not allowed.
 
 Note that if the compound literal uses any function calls to generate values
-or other data, such functions will not be called if the entry is Occupied. */
-#define ccc_hhm_or_insert_w(handle_hash_map_entry_ptr, lazy_key_value...)      \
-    ccc_impl_hhm_or_insert_w(handle_hash_map_entry_ptr, lazy_key_value)
+or other data, such functions will not be called if the handle is Occupied. */
+#define ccc_hhm_or_insert_w(handle_hash_map_handle_ptr, lazy_key_value...)     \
+    ccc_impl_hhm_or_insert_w(handle_hash_map_handle_ptr, lazy_key_value)
 
-/** @brief Inserts the provided entry invariantly.
-@param [in] e the entry returned from a call obtaining an entry.
+/** @brief Inserts the provided handle invariantly.
+@param [in] e the handle returned from a call obtaining an handle.
 @param [in] elem a handle to the struct the user intends to insert.
 @return a pointer to the inserted element or NULL upon a memory error in which
 the load factor would be exceeded when no allocation policy is defined or
@@ -507,70 +507,71 @@ This method can be used when the old value in the table does not need to
 be preserved. See the regular insert method if the old value is of interest.
 If an error occurs during the insertion process due to memory limitations
 or a search error NULL is returned. Otherwise insertion should not fail. */
-[[nodiscard]] ccc_handle ccc_hhm_insert_entry(ccc_hhmap_entry const *e,
-                                              ccc_hhmap_elem *elem);
+[[nodiscard]] ccc_handle_i ccc_hhm_insert_handle(ccc_hhmap_handle const *e,
+                                                 ccc_hhmap_elem *elem);
 
 /** @brief write the contents of the compound literal lazy_key_value to a slot.
-@param [in] handle_hash_map_entry_ptr a pointer to the obtained entry.
+@param [in] handle_hash_map_handle_ptr a pointer to the obtained handle.
 @param [in] lazy_key_value the compound literal to write to a new slot.
 @return a reference to the newly inserted or overwritten user type. NULL is
 returned if resizing is required but fails or is not allowed. */
-#define ccc_hhm_insert_entry_w(handle_hash_map_entry_ptr, lazy_key_value...)   \
-    ccc_impl_hhm_insert_entry_w(handle_hash_map_entry_ptr, lazy_key_value)
+#define ccc_hhm_insert_handle_w(handle_hash_map_handle_ptr, lazy_key_value...) \
+    ccc_impl_hhm_insert_handle_w(handle_hash_map_handle_ptr, lazy_key_value)
 
-/** @brief Remove the entry from the table if Occupied.
-@param [in] e a pointer to the table entry.
-@return an entry containing NULL. If Occupied an entry in the table existed and
-was removed. If Vacant, no prior entry existed to be removed. */
-[[nodiscard]] ccc_entry ccc_hhm_remove_entry(ccc_hhmap_entry const *e);
+/** @brief Remove the handle from the table if Occupied.
+@param [in] e a pointer to the table handle.
+@return an handle containing NULL. If Occupied an handle in the table existed
+and was removed. If Vacant, no prior handle existed to be removed. */
+[[nodiscard]] ccc_handle ccc_hhm_remove_handle(ccc_hhmap_handle const *e);
 
-/** @brief Remove the entry from the table if Occupied.
-@param [in] handle_hash_map_entry_ptr a pointer to the table entry.
-@return an entry containing NULL. If Occupied an entry in the table existed and
-was removed. If Vacant, no prior entry existed to be removed. */
-#define ccc_hhm_remove_entry_r(handle_hash_map_entry_ptr)                      \
-    &(ccc_entry)                                                               \
+/** @brief Remove the handle from the table if Occupied.
+@param [in] handle_hash_map_handle_ptr a pointer to the table handle.
+@return an handle containing NULL. If Occupied an handle in the table existed
+and was removed. If Vacant, no prior handle existed to be removed. */
+#define ccc_hhm_remove_handle_r(handle_hash_map_handle_ptr)                    \
+    &(ccc_handle)                                                              \
     {                                                                          \
-        ccc_hhm_remove_entry((handle_hash_map_entry_ptr)).impl_                \
+        ccc_hhm_remove_handle((handle_hash_map_handle_ptr)).impl_              \
     }
 
-/** @brief Unwraps the provided entry to obtain a view into the table element.
-@param [in] e the entry from a query to the table via function or macro.
-@return an view into the table entry if one is present, or NULL. */
-[[nodiscard]] ccc_handle ccc_hhm_unwrap(ccc_hhmap_entry const *e);
+/** @brief Unwraps the provided handle to obtain a view into the table element.
+@param [in] e the handle from a query to the table via function or macro.
+@return an view into the table handle if one is present, or NULL. */
+[[nodiscard]] ccc_handle_i ccc_hhm_unwrap(ccc_hhmap_handle const *e);
 
-/** @brief Returns the Vacant or Occupied status of the entry.
-@param [in] e the entry from a query to the table via function or macro.
-@return true if the entry is occupied, false if not. */
-[[nodiscard]] bool ccc_hhm_occupied(ccc_hhmap_entry const *e);
+/** @brief Returns the Vacant or Occupied status of the handle.
+@param [in] e the handle from a query to the table via function or macro.
+@return true if the handle is occupied, false if not. */
+[[nodiscard]] bool ccc_hhm_occupied(ccc_hhmap_handle const *e);
 
-/** @brief Provides the status of the entry should an insertion follow.
-@param [in] e the entry from a query to the table via function or macro.
+/** @brief Provides the status of the handle should an insertion follow.
+@param [in] e the handle from a query to the table via function or macro.
 @return true if the next insertion of a new element will cause an error.
 
-Table resizing occurs upon calls to entry functions/macros or when trying
+Table resizing occurs upon calls to handle functions/macros or when trying
 to insert a new element directly. This is to provide stable entries from the
 time they are obtained to the time they are used in functions they are passed
-to (i.e. the idiomatic or_insert(entry(...)...)).
+to (i.e. the idiomatic or_insert(handle(...)...)).
 
-However, if a Vacant entry is returned and then a subsequent insertion function
+However, if a Vacant handle is returned and then a subsequent insertion function
 is used, it will not work if resizing has failed and the return of those
 functions will indicate such a failure. One can also confirm an insertion error
-will occur from an entry with this function. For example, leaving this function
+will occur from an handle with this function. For example, leaving this function
 in an assert for debug builds can be a helpful sanity check if the heap should
 correctly resize by default and errors are not usually expected. */
-[[nodiscard]] bool ccc_hhm_insert_error(ccc_hhmap_entry const *e);
+[[nodiscard]] bool ccc_hhm_insert_error(ccc_hhmap_handle const *e);
 
-/** @brief Obtain the entry status from a container entry.
-@param [in] e a pointer to the entry.
-@return the status stored in the entry after the required action on the
-container completes. If e is NULL an entry input error is returned so ensure
+/** @brief Obtain the handle status from a container handle.
+@param [in] e a pointer to the handle.
+@return the status stored in the handle after the required action on the
+container completes. If e is NULL an handle input error is returned so ensure
 e is non-NULL to avoid an inaccurate status returned.
 
 Note that this function can be useful for debugging or if more detailed
-messages are needed for logging purposes. See ccc_entry_status_msg() in
-ccc/types.h for more information on detailed entry statuses. */
-[[nodiscard]] ccc_entry_status ccc_hhm_entry_status(ccc_hhmap_entry const *e);
+messages are needed for logging purposes. See ccc_handle_status_msg() in
+ccc/types.h for more information on detailed handle statuses. */
+[[nodiscard]] ccc_handle_status
+ccc_hhm_handle_status(ccc_hhmap_handle const *e);
 
 /**@}*/
 
@@ -612,7 +613,7 @@ resizing occurs which would lead to undefined behavior. O(capacity).
 
 Iteration starts from index 0 by capacity of the table so iteration order is
 not obvious to the user, nor should any specific order be relied on. */
-[[nodiscard]] ccc_handle ccc_hhm_begin(ccc_handle_hash_map const *h);
+[[nodiscard]] ccc_handle_i ccc_hhm_begin(ccc_handle_hash_map const *h);
 
 /** @brief Advances the iterator to the next occupied table slot.
 @param [in] h the table being iterated upon.
@@ -620,14 +621,14 @@ not obvious to the user, nor should any specific order be relied on. */
 @return a pointer that can be cast directly to the user type that is stored.
 @warning erasing or inserting during iteration may invalidate iterators if
 resizing occurs which would lead to undefined behavior. O(capacity). */
-[[nodiscard]] ccc_handle ccc_hhm_next(ccc_handle_hash_map const *h,
-                                      ccc_handle iter);
+[[nodiscard]] ccc_handle_i ccc_hhm_next(ccc_handle_hash_map const *h,
+                                        ccc_handle_i iter);
 
 /** @brief Check the current iterator against the end for loop termination.
 @param [in] h the table being iterated upon.
 @return the end address of the hash table.
 @warning It is undefined behavior to access or modify the end address. */
-[[nodiscard]] ccc_handle ccc_hhm_end(ccc_handle_hash_map const *h);
+[[nodiscard]] ccc_handle_i ccc_hhm_end(ccc_handle_hash_map const *h);
 
 /**@}*/
 
@@ -679,7 +680,7 @@ within the capacity of the backing buffer. */
 #ifdef HANDLE_HASH_MAP_USING_NAMESPACE_CCC
 typedef ccc_handle_hash_map handle_hash_map;
 typedef ccc_hhmap_elem hhmap_elem;
-typedef ccc_hhmap_entry hhmap_entry;
+typedef ccc_hhmap_handle hhmap_handle;
 #    define hhm_init(args...) ccc_hhm_init(args)
 #    define hhm_copy(args...) ccc_hhm_copy(args)
 #    define hhm_contains(args...) ccc_hhm_contains(args)
@@ -696,21 +697,21 @@ typedef ccc_hhmap_entry hhmap_entry;
 #    define hhm_insert_or_assign(args...) ccc_hhm_insert_or_assign(args)
 #    define hhm_insert_or_assign_r(args...) ccc_hhm_insert_or_assign_r(args)
 #    define hhm_insert_or_assign_w(args...) ccc_hhm_insert_or_assign_w(args)
-#    define hhm_entry(args...) ccc_hhm_entry(args)
-#    define hhm_entry_r(args...) ccc_hhm_entry_r(args)
+#    define hhm_handle(args...) ccc_hhm_handle(args)
+#    define hhm_handle_r(args...) ccc_hhm_handle_r(args)
 #    define hhm_and_modify(args...) ccc_hhm_and_modify(args)
 #    define hhm_and_modify_aux(args...) ccc_hhm_and_modify_aux(args)
 #    define hhm_and_modify_w(args...) ccc_hhm_and_modify_w(args)
 #    define hhm_or_insert(args...) ccc_hhm_or_insert(args)
 #    define hhm_or_insert_w(args...) ccc_hhm_or_insert_w(args)
-#    define hhm_insert_entry(args...) ccc_hhm_insert_entry(args)
-#    define hhm_insert_entry_w(args...) ccc_hhm_insert_entry_w(args)
-#    define hhm_remove_entry(args...) ccc_hhm_remove_entry(args)
-#    define hhm_remove_entry_r(args...) ccc_hhm_remove_entry_r(args)
+#    define hhm_insert_handle(args...) ccc_hhm_insert_handle(args)
+#    define hhm_insert_handle_w(args...) ccc_hhm_insert_handle_w(args)
+#    define hhm_remove_handle(args...) ccc_hhm_remove_handle(args)
+#    define hhm_remove_handle_r(args...) ccc_hhm_remove_handle_r(args)
 #    define hhm_unwrap(args...) ccc_hhm_unwrap(args)
 #    define hhm_occupied(args...) ccc_hhm_occupied(args)
 #    define hhm_insert_error(args...) ccc_hhm_insert_error(args)
-#    define hhm_entry_status(args...) ccc_hhm_entry_status(args)
+#    define hhm_handle_status(args...) ccc_hhm_handle_status(args)
 #    define hhm_clear(args...) ccc_hhm_clear(args)
 #    define hhm_clear_and_free(args...) ccc_hhm_clear_and_free(args)
 #    define hhm_begin(args...) ccc_hhm_begin(args)

--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -125,11 +125,11 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
     (__extension__({                                                           \
         __auto_type fhm_mod_ent_ptr_ = (flat_hash_map_entry_ptr);              \
         struct ccc_fhash_entry_ fhm_mod_with_ent_                              \
-            = {.entry_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}};                   \
+            = {.entry_ = {.stats_ = CCC_INPUT_ERROR}};                         \
         if (fhm_mod_ent_ptr_)                                                  \
         {                                                                      \
             fhm_mod_with_ent_ = fhm_mod_ent_ptr_->impl_;                       \
-            if (fhm_mod_with_ent_.entry_.stats_ == CCC_ENTRY_OCCUPIED)         \
+            if (fhm_mod_with_ent_.entry_.stats_ == CCC_OCCUPIED)               \
             {                                                                  \
                 type_name *const T = fhm_mod_with_ent_.entry_.e_;              \
                 if (T)                                                         \
@@ -149,9 +149,9 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
         {                                                                      \
             struct ccc_fhash_entry_ *fhm_or_ins_entry_                         \
                 = &fhm_or_ins_ent_ptr_->impl_;                                 \
-            if (!(fhm_or_ins_entry_->entry_.stats_ & CCC_ENTRY_INSERT_ERROR))  \
+            if (!(fhm_or_ins_entry_->entry_.stats_ & CCC_INSERT_ERROR))        \
             {                                                                  \
-                if (fhm_or_ins_entry_->entry_.stats_ & CCC_ENTRY_OCCUPIED)     \
+                if (fhm_or_ins_entry_->entry_.stats_ & CCC_OCCUPIED)           \
                 {                                                              \
                     fhm_or_ins_res_ = fhm_or_ins_entry_->entry_.e_;            \
                 }                                                              \
@@ -173,11 +173,11 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
         if (fhm_ins_ent_ptr_)                                                  \
         {                                                                      \
             struct ccc_fhash_entry_ *fhm_ins_ent_ = &fhm_ins_ent_ptr_->impl_;  \
-            if (!(fhm_ins_ent_->entry_.stats_ & CCC_ENTRY_INSERT_ERROR))       \
+            if (!(fhm_ins_ent_->entry_.stats_ & CCC_INSERT_ERROR))             \
             {                                                                  \
-                if (fhm_ins_ent_->entry_.stats_ & CCC_ENTRY_OCCUPIED)          \
+                if (fhm_ins_ent_->entry_.stats_ & CCC_OCCUPIED)                \
                 {                                                              \
-                    fhm_ins_ent_->entry_.stats_ = CCC_ENTRY_OCCUPIED;          \
+                    fhm_ins_ent_->entry_.stats_ = CCC_OCCUPIED;                \
                     *((typeof(fhm_res_))fhm_ins_ent_->entry_.e_)               \
                         = lazy_key_value;                                      \
                     ccc_impl_fhm_in_slot(fhm_ins_ent_->h_,                     \
@@ -199,15 +199,14 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
 #define ccc_impl_fhm_try_insert_w(flat_hash_map_ptr, key, lazy_value...)       \
     (__extension__({                                                           \
         struct ccc_fhmap_ *flat_hash_map_ptr_ = (flat_hash_map_ptr);           \
-        struct ccc_ent_ fhm_try_insert_res_                                    \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ent_ fhm_try_insert_res_ = {.stats_ = CCC_INPUT_ERROR};     \
         if (flat_hash_map_ptr_)                                                \
         {                                                                      \
             __auto_type fhm_key_ = key;                                        \
             struct ccc_fhash_entry_ fhm_try_ins_ent_                           \
                 = ccc_impl_fhm_entry(flat_hash_map_ptr_, (void *)&fhm_key_);   \
-            if ((fhm_try_ins_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED)          \
-                || (fhm_try_ins_ent_.entry_.stats_ & CCC_ENTRY_INSERT_ERROR))  \
+            if ((fhm_try_ins_ent_.entry_.stats_ & CCC_OCCUPIED)                \
+                || (fhm_try_ins_ent_.entry_.stats_ & CCC_INSERT_ERROR))        \
             {                                                                  \
                 fhm_try_insert_res_ = fhm_try_ins_ent_.entry_;                 \
             }                                                                  \
@@ -215,7 +214,7 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
             {                                                                  \
                 fhm_try_insert_res_ = (struct ccc_ent_){                       \
                     ccc_impl_fhm_swaps((&fhm_try_ins_ent_), lazy_value),       \
-                    CCC_ENTRY_VACANT,                                          \
+                    CCC_VACANT,                                                \
                 };                                                             \
                 *((typeof(fhm_key_) *)ccc_impl_fhm_key_in_slot(                \
                     flat_hash_map_ptr_, fhm_try_insert_res_.e_))               \
@@ -228,14 +227,13 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
 #define ccc_impl_fhm_insert_or_assign_w(flat_hash_map_ptr, key, lazy_value...) \
     (__extension__({                                                           \
         struct ccc_fhmap_ *flat_hash_map_ptr_ = (flat_hash_map_ptr);           \
-        struct ccc_ent_ fhm_ins_or_assign_res_                                 \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ent_ fhm_ins_or_assign_res_ = {.stats_ = CCC_INPUT_ERROR};  \
         if (flat_hash_map_ptr_)                                                \
         {                                                                      \
             __auto_type fhm_key_ = key;                                        \
             struct ccc_fhash_entry_ fhm_ins_or_assign_ent_                     \
                 = ccc_impl_fhm_entry(flat_hash_map_ptr_, (void *)&fhm_key_);   \
-            if (fhm_ins_or_assign_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED)     \
+            if (fhm_ins_or_assign_ent_.entry_.stats_ & CCC_OCCUPIED)           \
             {                                                                  \
                 fhm_ins_or_assign_res_ = fhm_ins_or_assign_ent_.entry_;        \
                 *((typeof(lazy_value) *)fhm_ins_or_assign_res_.e_)             \
@@ -248,17 +246,16 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
                     ->hash_                                                    \
                     = fhm_ins_or_assign_ent_.hash_;                            \
             }                                                                  \
-            else if (fhm_ins_or_assign_ent_.entry_.stats_                      \
-                     & CCC_ENTRY_INSERT_ERROR)                                 \
+            else if (fhm_ins_or_assign_ent_.entry_.stats_ & CCC_INSERT_ERROR)  \
             {                                                                  \
                 fhm_ins_or_assign_res_.e_ = NULL;                              \
-                fhm_ins_or_assign_res_.stats_ = CCC_ENTRY_INSERT_ERROR;        \
+                fhm_ins_or_assign_res_.stats_ = CCC_INSERT_ERROR;              \
             }                                                                  \
             else                                                               \
             {                                                                  \
                 fhm_ins_or_assign_res_ = (struct ccc_ent_){                    \
                     ccc_impl_fhm_swaps((&fhm_ins_or_assign_ent_), lazy_value), \
-                    CCC_ENTRY_VACANT,                                          \
+                    CCC_VACANT,                                                \
                 };                                                             \
                 *((typeof(fhm_key_) *)ccc_impl_fhm_key_in_slot(                \
                     flat_hash_map_ptr_, fhm_ins_or_assign_res_.e_))            \

--- a/ccc/impl/impl_flat_ordered_map.h
+++ b/ccc/impl/impl_flat_ordered_map.h
@@ -70,12 +70,11 @@ void *ccc_impl_fom_alloc_back(struct ccc_fomap_ *fom);
                                   closure_over_T...)                           \
     (__extension__({                                                           \
         __auto_type fom_mod_ent_ptr_ = (flat_ordered_map_entry_ptr);           \
-        struct ccc_ftree_entry_ fom_mod_ent_                                   \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ftree_entry_ fom_mod_ent_ = {.stats_ = CCC_INPUT_ERROR};    \
         if (fom_mod_ent_ptr_)                                                  \
         {                                                                      \
             fom_mod_ent_ = fom_mod_ent_ptr_->impl_;                            \
-            if (fom_mod_ent_.stats_ & CCC_ENTRY_OCCUPIED)                      \
+            if (fom_mod_ent_.stats_ & CCC_OCCUPIED)                            \
             {                                                                  \
                 type_name *const T                                             \
                     = ccc_buf_at(&fom_mod_ent_.fom_->buf_, fom_mod_ent_.i_);   \
@@ -97,7 +96,7 @@ void *ccc_impl_fom_alloc_back(struct ccc_fomap_ *fom);
         {                                                                      \
             struct ccc_ftree_entry_ *fom_or_ins_ent_                           \
                 = &fom_or_ins_ent_ptr_->impl_;                                 \
-            if (fom_or_ins_ent_->stats_ == CCC_ENTRY_OCCUPIED)                 \
+            if (fom_or_ins_ent_->stats_ == CCC_OCCUPIED)                       \
             {                                                                  \
                 fom_or_ins_ret_ = ccc_buf_at(&fom_or_ins_ent_->fom_->buf_,     \
                                              fom_or_ins_ent_->i_);             \
@@ -126,7 +125,7 @@ void *ccc_impl_fom_alloc_back(struct ccc_fomap_ *fom);
         if (fom_ins_ent_ptr_)                                                  \
         {                                                                      \
             struct ccc_ftree_entry_ *fom_ins_ent_ = &fom_ins_ent_ptr_->impl_;  \
-            if (!(fom_ins_ent_->stats_ & CCC_ENTRY_OCCUPIED))                  \
+            if (!(fom_ins_ent_->stats_ & CCC_OCCUPIED))                        \
             {                                                                  \
                 fom_ins_ent_ret_                                               \
                     = ccc_impl_fom_alloc_back(fom_ins_ent_->fom_);             \
@@ -138,7 +137,7 @@ void *ccc_impl_fom_alloc_back(struct ccc_fomap_ *fom);
                         ccc_buf_size(&fom_ins_ent_->fom_->buf_) - 1);          \
                 }                                                              \
             }                                                                  \
-            else if (fom_ins_ent_->stats_ == CCC_ENTRY_OCCUPIED)               \
+            else if (fom_ins_ent_->stats_ == CCC_OCCUPIED)                     \
             {                                                                  \
                 fom_ins_ent_ret_                                               \
                     = ccc_buf_at(&fom_ins_ent_->fom_->buf_, fom_ins_ent_->i_); \
@@ -157,18 +156,17 @@ void *ccc_impl_fom_alloc_back(struct ccc_fomap_ *fom);
 #define ccc_impl_fom_try_insert_w(flat_ordered_map_ptr, key, lazy_value...)    \
     (__extension__({                                                           \
         __auto_type fom_try_ins_map_ptr_ = (flat_ordered_map_ptr);             \
-        struct ccc_ent_ fom_try_ins_ent_ret_                                   \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ent_ fom_try_ins_ent_ret_ = {.stats_ = CCC_INPUT_ERROR};    \
         if (fom_try_ins_map_ptr_)                                              \
         {                                                                      \
             __auto_type fom_key_ = (key);                                      \
             struct ccc_ftree_entry_ fom_try_ins_ent_                           \
                 = ccc_impl_fom_entry(fom_try_ins_map_ptr_, (void *)&fom_key_); \
-            if (!(fom_try_ins_ent_.stats_ & CCC_ENTRY_OCCUPIED))               \
+            if (!(fom_try_ins_ent_.stats_ & CCC_OCCUPIED))                     \
             {                                                                  \
                 fom_try_ins_ent_ret_ = (struct ccc_ent_){                      \
                     .e_ = ccc_impl_fom_alloc_back(fom_try_ins_ent_.fom_),      \
-                    .stats_ = CCC_ENTRY_INSERT_ERROR};                         \
+                    .stats_ = CCC_INSERT_ERROR};                               \
                 if (fom_try_ins_ent_ret_.e_)                                   \
                 {                                                              \
                     *((typeof(lazy_value) *)fom_try_ins_ent_ret_.e_)           \
@@ -180,10 +178,10 @@ void *ccc_impl_fom_alloc_back(struct ccc_fomap_ *fom);
                         fom_try_ins_ent_.fom_,                                 \
                         ccc_buf_i(&fom_try_ins_ent_.fom_->buf_,                \
                                   fom_try_ins_ent_ret_.e_));                   \
-                    fom_try_ins_ent_ret_.stats_ = CCC_ENTRY_VACANT;            \
+                    fom_try_ins_ent_ret_.stats_ = CCC_VACANT;                  \
                 }                                                              \
             }                                                                  \
-            else if (fom_try_ins_ent_.stats_ == CCC_ENTRY_OCCUPIED)            \
+            else if (fom_try_ins_ent_.stats_ == CCC_OCCUPIED)                  \
             {                                                                  \
                 fom_try_ins_ent_ret_ = (struct ccc_ent_){                      \
                     ccc_buf_at(&fom_try_ins_ent_.fom_->buf_,                   \
@@ -199,19 +197,19 @@ void *ccc_impl_fom_alloc_back(struct ccc_fomap_ *fom);
     (__extension__({                                                           \
         __auto_type fom_ins_or_assign_map_ptr_ = (flat_ordered_map_ptr);       \
         struct ccc_ent_ fom_ins_or_assign_ent_ret_                             \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+            = {.stats_ = CCC_INPUT_ERROR};                                     \
         if (fom_ins_or_assign_map_ptr_)                                        \
         {                                                                      \
             __auto_type fom_key_ = (key);                                      \
             struct ccc_ftree_entry_ fom_ins_or_assign_ent_                     \
                 = ccc_impl_fom_entry((flat_ordered_map_ptr),                   \
                                      (void *)&fom_key_);                       \
-            if (!(fom_ins_or_assign_ent_.stats_ & CCC_ENTRY_OCCUPIED))         \
+            if (!(fom_ins_or_assign_ent_.stats_ & CCC_OCCUPIED))               \
             {                                                                  \
                 fom_ins_or_assign_ent_ret_                                     \
                     = (struct ccc_ent_){.e_ = ccc_impl_fom_alloc_back(         \
                                             fom_ins_or_assign_ent_.fom_),      \
-                                        .stats_ = CCC_ENTRY_INSERT_ERROR};     \
+                                        .stats_ = CCC_INSERT_ERROR};           \
                 if (fom_ins_or_assign_ent_ret_.e_)                             \
                 {                                                              \
                     *((typeof(lazy_value) *)fom_ins_or_assign_ent_ret_.e_)     \
@@ -224,10 +222,10 @@ void *ccc_impl_fom_alloc_back(struct ccc_fomap_ *fom);
                         fom_ins_or_assign_ent_.fom_,                           \
                         ccc_buf_i(&fom_ins_or_assign_ent_.fom_->buf_,          \
                                   fom_ins_or_assign_ent_ret_.e_));             \
-                    fom_ins_or_assign_ent_ret_.stats_ = CCC_ENTRY_VACANT;      \
+                    fom_ins_or_assign_ent_ret_.stats_ = CCC_VACANT;            \
                 }                                                              \
             }                                                                  \
-            else if (fom_ins_or_assign_ent_.stats_ == CCC_ENTRY_OCCUPIED)      \
+            else if (fom_ins_or_assign_ent_.stats_ == CCC_OCCUPIED)            \
             {                                                                  \
                 void *fom_ins_or_assign_slot_                                  \
                     = ccc_buf_at(&fom_ins_or_assign_ent_.fom_->buf_,           \

--- a/ccc/impl/impl_flat_realtime_ordered_map.h
+++ b/ccc/impl/impl_flat_realtime_ordered_map.h
@@ -75,12 +75,11 @@ void *ccc_impl_frm_alloc_back(struct ccc_fromap_ *frm);
                                   type_name, closure_over_T...)                \
     (__extension__({                                                           \
         __auto_type frm_ent_ptr_ = (flat_realtime_ordered_map_entry_ptr);      \
-        struct ccc_frtree_entry_ frm_mod_ent_                                  \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_frtree_entry_ frm_mod_ent_ = {.stats_ = CCC_INPUT_ERROR};   \
         if (frm_ent_ptr_)                                                      \
         {                                                                      \
             frm_mod_ent_ = frm_ent_ptr_->impl_;                                \
-            if (frm_mod_ent_.stats_ & CCC_ENTRY_OCCUPIED)                      \
+            if (frm_mod_ent_.stats_ & CCC_OCCUPIED)                            \
             {                                                                  \
                 type_name *const T                                             \
                     = ccc_buf_at(&frm_mod_ent_.frm_->buf_, frm_mod_ent_.i_);   \
@@ -102,7 +101,7 @@ void *ccc_impl_frm_alloc_back(struct ccc_fromap_ *frm);
         {                                                                      \
             struct ccc_frtree_entry_ *frm_or_ins_ent_                          \
                 = &or_ins_entry_ptr_->impl_;                                   \
-            if (frm_or_ins_ent_->stats_ == CCC_ENTRY_OCCUPIED)                 \
+            if (frm_or_ins_ent_->stats_ == CCC_OCCUPIED)                       \
             {                                                                  \
                 frm_or_ins_ret_ = ccc_buf_at(&frm_or_ins_ent_->frm_->buf_,     \
                                              frm_or_ins_ent_->i_);             \
@@ -132,7 +131,7 @@ void *ccc_impl_frm_alloc_back(struct ccc_fromap_ *frm);
         if (ins_entry_ptr_)                                                    \
         {                                                                      \
             struct ccc_frtree_entry_ *frm_ins_ent_ = &ins_entry_ptr_->impl_;   \
-            if (!(frm_ins_ent_->stats_ & CCC_ENTRY_OCCUPIED))                  \
+            if (!(frm_ins_ent_->stats_ & CCC_OCCUPIED))                        \
             {                                                                  \
                 frm_ins_ent_ret_                                               \
                     = ccc_impl_frm_alloc_back(frm_ins_ent_->frm_);             \
@@ -145,7 +144,7 @@ void *ccc_impl_frm_alloc_back(struct ccc_fromap_ *frm);
                         ccc_buf_size(&frm_ins_ent_->frm_->buf_) - 1);          \
                 }                                                              \
             }                                                                  \
-            else if (frm_ins_ent_->stats_ == CCC_ENTRY_OCCUPIED)               \
+            else if (frm_ins_ent_->stats_ == CCC_OCCUPIED)                     \
             {                                                                  \
                 frm_ins_ent_ret_                                               \
                     = ccc_buf_at(&frm_ins_ent_->frm_->buf_, frm_ins_ent_->i_); \
@@ -165,18 +164,17 @@ void *ccc_impl_frm_alloc_back(struct ccc_fromap_ *frm);
                                   lazy_value...)                               \
     (__extension__({                                                           \
         __auto_type try_ins_map_ptr_ = (flat_realtime_ordered_map_ptr);        \
-        struct ccc_ent_ frm_try_ins_ent_ret_                                   \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ent_ frm_try_ins_ent_ret_ = {.stats_ = CCC_INPUT_ERROR};    \
         if (try_ins_map_ptr_)                                                  \
         {                                                                      \
             __auto_type frm_key_ = (key);                                      \
             struct ccc_frtree_entry_ frm_try_ins_ent_                          \
                 = ccc_impl_frm_entry(try_ins_map_ptr_, (void *)&frm_key_);     \
-            if (!(frm_try_ins_ent_.stats_ & CCC_ENTRY_OCCUPIED))               \
+            if (!(frm_try_ins_ent_.stats_ & CCC_OCCUPIED))                     \
             {                                                                  \
                 frm_try_ins_ent_ret_ = (struct ccc_ent_){                      \
                     .e_ = ccc_impl_frm_alloc_back(frm_try_ins_ent_.frm_),      \
-                    .stats_ = CCC_ENTRY_INSERT_ERROR};                         \
+                    .stats_ = CCC_INSERT_ERROR};                               \
                 if (frm_try_ins_ent_ret_.e_)                                   \
                 {                                                              \
                     *((typeof(lazy_value) *)frm_try_ins_ent_ret_.e_)           \
@@ -189,10 +187,10 @@ void *ccc_impl_frm_alloc_back(struct ccc_fromap_ *frm);
                         frm_try_ins_ent_.last_cmp_,                            \
                         ccc_buf_i(&frm_try_ins_ent_.frm_->buf_,                \
                                   frm_try_ins_ent_ret_.e_));                   \
-                    frm_try_ins_ent_ret_.stats_ = CCC_ENTRY_VACANT;            \
+                    frm_try_ins_ent_ret_.stats_ = CCC_VACANT;                  \
                 }                                                              \
             }                                                                  \
-            else if (frm_try_ins_ent_.stats_ == CCC_ENTRY_OCCUPIED)            \
+            else if (frm_try_ins_ent_.stats_ == CCC_OCCUPIED)                  \
             {                                                                  \
                 frm_try_ins_ent_ret_ = (struct ccc_ent_){                      \
                     ccc_buf_at(&frm_try_ins_ent_.frm_->buf_,                   \
@@ -208,19 +206,19 @@ void *ccc_impl_frm_alloc_back(struct ccc_fromap_ *frm);
     (__extension__({                                                           \
         __auto_type ins_or_assign_map_ptr_ = (flat_realtime_ordered_map_ptr);  \
         struct ccc_ent_ frm_ins_or_assign_ent_ret_                             \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+            = {.stats_ = CCC_INPUT_ERROR};                                     \
         if (ins_or_assign_map_ptr_)                                            \
         {                                                                      \
             __auto_type frm_key_ = (key);                                      \
             struct ccc_frtree_entry_ frm_ins_or_assign_ent_                    \
                 = ccc_impl_frm_entry(ins_or_assign_map_ptr_,                   \
                                      (void *)&frm_key_);                       \
-            if (!(frm_ins_or_assign_ent_.stats_ & CCC_ENTRY_OCCUPIED))         \
+            if (!(frm_ins_or_assign_ent_.stats_ & CCC_OCCUPIED))               \
             {                                                                  \
                 frm_ins_or_assign_ent_ret_                                     \
                     = (struct ccc_ent_){.e_ = ccc_impl_frm_alloc_back(         \
                                             frm_ins_or_assign_ent_.frm_),      \
-                                        .stats_ = CCC_ENTRY_INSERT_ERROR};     \
+                                        .stats_ = CCC_INSERT_ERROR};           \
                 if (frm_ins_or_assign_ent_ret_.e_)                             \
                 {                                                              \
                     *((typeof(lazy_value) *)frm_ins_or_assign_ent_ret_.e_)     \
@@ -235,10 +233,10 @@ void *ccc_impl_frm_alloc_back(struct ccc_fromap_ *frm);
                         frm_ins_or_assign_ent_.last_cmp_,                      \
                         ccc_buf_i(&frm_ins_or_assign_ent_.frm_->buf_,          \
                                   frm_ins_or_assign_ent_ret_.e_));             \
-                    frm_ins_or_assign_ent_ret_.stats_ = CCC_ENTRY_VACANT;      \
+                    frm_ins_or_assign_ent_ret_.stats_ = CCC_VACANT;            \
                 }                                                              \
             }                                                                  \
-            else if (frm_ins_or_assign_ent_.stats_ == CCC_ENTRY_OCCUPIED)      \
+            else if (frm_ins_or_assign_ent_.stats_ == CCC_OCCUPIED)            \
             {                                                                  \
                 void *frm_ins_or_assign_slot_                                  \
                     = ccc_buf_at(&frm_ins_or_assign_ent_.frm_->buf_,           \

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -109,7 +109,7 @@ struct ccc_hhash_entry_ *ccc_impl_hhm_and_modify(struct ccc_hhash_entry_ *e,
                                                  ccc_update_fn *fn);
 struct ccc_hhmap_elem_ *ccc_impl_hhm_in_slot(struct ccc_hhmap_ const *h,
                                              void const *slot);
-void *ccc_impl_hhm_key_in_slot(struct ccc_hhmap_ const *h, void const *slot);
+void *ccc_impl_hhm_key_at(struct ccc_hhmap_ const *h, size_t i);
 uint64_t *ccc_impl_hhm_hash_at(struct ccc_hhmap_ const *h, size_t i);
 size_t ccc_impl_hhm_distance(size_t capacity, size_t i, size_t j);
 ccc_result ccc_impl_hhm_maybe_resize(struct ccc_hhmap_ *);
@@ -145,11 +145,8 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
         }                                                                      \
         else                                                                   \
         {                                                                      \
-            hhm_i_ = ccc_impl_hhm_insert_meta(                                 \
-                (swap_entry)->h_,                                              \
-                *ccc_impl_hhm_hash_at((swap_entry)->h_,                        \
-                                      hhm_slot_elem_->meta_i_),                \
-                hhm_slot_elem_->meta_i_);                                      \
+            hhm_i_ = ccc_impl_hhm_insert_meta((swap_entry)->h_,                \
+                                              (swap_entry)->hash_, hhm_i_);    \
             struct ccc_hhmap_elem_ const save_elem                             \
                 = *ccc_impl_hhm_elem_at((swap_entry)->h_, hhm_i_);             \
             *((typeof(lazy_key_value) *)ccc_buf_at(&((swap_entry)->h_->buf_),  \
@@ -264,6 +261,9 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                     ccc_impl_hhm_swaps((&hhm_try_ins_ent_), lazy_value),       \
                     CCC_ENTRY_VACANT,                                          \
                 };                                                             \
+                *((typeof(hhm_key_) *)ccc_impl_hhm_key_at(                     \
+                    handle_hash_map_ptr_, hhm_try_insert_res_.i_))             \
+                    = hhm_key_;                                                \
             }                                                                  \
             if (hhm_try_insert_res_.i_)                                        \
             {                                                                  \
@@ -299,6 +299,9 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                 *ccc_impl_hhm_elem_at(handle_hash_map_ptr_,                    \
                                       hhm_ins_or_assign_ent_.entry_.i_)        \
                     = save_elem_;                                              \
+                *((typeof(hhm_key_) *)ccc_impl_hhm_key_at(                     \
+                    handle_hash_map_ptr_, hhm_ins_or_assign_ent_.entry_.i_))   \
+                    = hhm_key_;                                                \
             }                                                                  \
             else if (hhm_ins_or_assign_ent_.entry_.stats_                      \
                      & CCC_ENTRY_INSERT_ERROR)                                 \
@@ -312,6 +315,9 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                     ccc_impl_hhm_swaps((&hhm_ins_or_assign_ent_), lazy_value), \
                     CCC_ENTRY_VACANT,                                          \
                 };                                                             \
+                *((typeof(hhm_key_) *)ccc_impl_hhm_key_at(                     \
+                    handle_hash_map_ptr_, hhm_ins_or_assign_ent_.entry_.i_))   \
+                    = hhm_key_;                                                \
             }                                                                  \
             if (hhm_ins_or_assign_res_.i_)                                     \
             {                                                                  \

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -252,11 +252,7 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
             if ((hhm_try_ins_handl_.handle_.stats_ & CCC_OCCUPIED)             \
                 || (hhm_try_ins_handl_.handle_.stats_ & CCC_INSERT_ERROR))     \
             {                                                                  \
-                hhm_try_insert_res_ = (struct ccc_handl_){                     \
-                    .i_ = ccc_impl_hhm_elem_at(handle_hash_map_ptr_,           \
-                                               hhm_try_ins_handl_.handle_.i_)  \
-                              ->slot_i_,                                       \
-                    .stats_ = hhm_try_ins_handl_.handle_.stats_};              \
+                hhm_try_insert_res_ = hhm_try_ins_handl_.handle_;              \
             }                                                                  \
             else                                                               \
             {                                                                  \

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -223,8 +223,8 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                     hhm_ins_ent_->entry_.stats_ = CCC_ENTRY_OCCUPIED;          \
                     struct ccc_hhmap_elem_ save_elem_ = *ccc_impl_hhm_elem_at( \
                         hhm_ins_ent_->h_, hhm_ins_ent_->entry_.i_);            \
-                    *((typeof(hhm_res_))ccc_buf_at(hhm_ins_ent_->h_->buf_,     \
-                                                   hhm_ins_ent_->entry_.i_))   \
+                    *((typeof(lazy_key_value) *)ccc_buf_at(                    \
+                        &hhm_ins_ent_->h_->buf_, hhm_ins_ent_->entry_.i_))     \
                         = lazy_key_value;                                      \
                     *ccc_impl_hhm_elem_at(hhm_ins_ent_->h_,                    \
                                           hhm_ins_ent_->entry_.i_)             \
@@ -244,8 +244,10 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
 #define ccc_impl_hhm_try_insert_w(handle_hash_map_ptr, key, lazy_value...)     \
     (__extension__({                                                           \
         struct ccc_hhmap_ *handle_hash_map_ptr_ = (handle_hash_map_ptr);       \
-        struct ccc_ent_ hhm_try_insert_res_                                    \
+        struct ccc_handle_ hhm_try_insert_res_                                 \
             = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ent_ hhm_pointer_entry_                                     \
+            = {.stats_ = hhm_try_insert_res_.stats_};                          \
         if (handle_hash_map_ptr_)                                              \
         {                                                                      \
             __auto_type hhm_key_ = key;                                        \
@@ -258,21 +260,28 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
             }                                                                  \
             else                                                               \
             {                                                                  \
-                hhm_try_insert_res_ = (struct ccc_ent_){                       \
+                hhm_try_insert_res_ = (struct ccc_handle_){                    \
                     ccc_impl_hhm_swaps((&hhm_try_ins_ent_), lazy_value),       \
                     CCC_ENTRY_VACANT,                                          \
                 };                                                             \
             }                                                                  \
+            if (hhm_try_insert_res_.i_)                                        \
+            {                                                                  \
+                hhm_pointer_entry_.e_ = ccc_buf_at(                            \
+                    &handle_hash_map_ptr_->buf_, hhm_try_insert_res_.i_);      \
+            }                                                                  \
         }                                                                      \
-        hhm_try_insert_res_;                                                   \
+        hhm_pointer_entry_;                                                    \
     }))
 
 #define ccc_impl_hhm_insert_or_assign_w(handle_hash_map_ptr, key,              \
                                         lazy_value...)                         \
     (__extension__({                                                           \
         struct ccc_hhmap_ *handle_hash_map_ptr_ = (handle_hash_map_ptr);       \
-        struct ccc_ent_ hhm_ins_or_assign_res_                                 \
+        struct ccc_handle_ hhm_ins_or_assign_res_                              \
             = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ent_ hhm_pointer_entry_                                     \
+            = {.stats_ = hhm_ins_or_assign_res_.stats_};                       \
         if (handle_hash_map_ptr_)                                              \
         {                                                                      \
             __auto_type hhm_key_ = key;                                        \
@@ -299,13 +308,18 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
             }                                                                  \
             else                                                               \
             {                                                                  \
-                hhm_ins_or_assign_res_ = (struct ccc_ent_){                    \
+                hhm_ins_or_assign_res_ = (struct ccc_handle_){                 \
                     ccc_impl_hhm_swaps((&hhm_ins_or_assign_ent_), lazy_value), \
                     CCC_ENTRY_VACANT,                                          \
                 };                                                             \
             }                                                                  \
+            if (hhm_ins_or_assign_res_.i_)                                     \
+            {                                                                  \
+                hhm_pointer_entry_.e_ = ccc_buf_at(                            \
+                    &handle_hash_map_ptr_->buf_, hhm_ins_or_assign_res_.i_);   \
+            }                                                                  \
         }                                                                      \
-        hhm_ins_or_assign_res_;                                                \
+        hhm_pointer_entry_;                                                    \
     }))
 
 /* NOLINTEND(readability-identifier-naming) */

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -86,6 +86,18 @@ union ccc_hhmap_entry_
         = offsetof(typeof(*(memory_ptr)), hhash_elem_field),                   \
     }
 
+#define ccc_impl_hhm_as(handle_hash_map_ptr, type_name, handle...)             \
+    (__extension__({                                                           \
+        struct ccc_hhmap_ const *const hhm_ptr_ = (handle_hash_map_ptr);       \
+        typeof(type_name) *hhm_as_ = NULL;                                     \
+        ccc_handle const hhm_handle_ = (handle);                               \
+        if (hhm_ptr_ && hhm_handle_)                                           \
+        {                                                                      \
+            hhm_as_ = ccc_buf_at(&hhm_ptr_->buf_, hhm_handle_);                \
+        }                                                                      \
+        hhm_as_;                                                               \
+    }))
+
 struct ccc_handle_ ccc_impl_hhm_find(struct ccc_hhmap_ const *, void const *key,
                                      uint64_t hash);
 ccc_handle ccc_impl_hhm_insert_meta(struct ccc_hhmap_ *h, uint64_t hash,
@@ -108,6 +120,7 @@ void ccc_impl_hhm_copy_to_slot(struct ccc_hhmap_ *h, void *slot_dst,
                                void const *slot_src);
 struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                                              size_t i);
+/* NOLINTBEGIN(readability-identifier-naming) */
 
 /*==================   Helper Macros for Repeated Logic     =================*/
 
@@ -132,11 +145,10 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
         }                                                                      \
         else                                                                   \
         {                                                                      \
-            __auto_type hhm_to_insert_ = (lazy_key_value);                     \
-            hhm_i_ = ccc_impl_hhm_insert(                                      \
-                (swap_entry)->h_, &hhm_to_insert_,                             \
-                ccc_impl_hhm_hash_at((swap_entry)->h_,                         \
-                                     hhm_slot_elem_->meta_i_),                 \
+            hhm_i_ = ccc_impl_hhm_insert_meta(                                 \
+                (swap_entry)->h_,                                              \
+                *ccc_impl_hhm_hash_at((swap_entry)->h_,                        \
+                                      hhm_slot_elem_->meta_i_),                \
                 hhm_slot_elem_->meta_i_);                                      \
             struct ccc_hhmap_elem_ const save_elem                             \
                 = *ccc_impl_hhm_elem_at((swap_entry)->h_, hhm_i_);             \
@@ -161,7 +173,7 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
             hhm_mod_with_ent_ = hhm_mod_ent_ptr_->impl_;                       \
             if (hhm_mod_with_ent_.entry_.stats_ == CCC_ENTRY_OCCUPIED)         \
             {                                                                  \
-                type_name *const T = ccc_buf_at(hhm_mod_with_ent_.h->buf_,     \
+                type_name *const T = ccc_buf_at(&hhm_mod_with_ent_.h_->buf_,   \
                                                 hhm_mod_with_ent_.entry_.i_);  \
                 if (T)                                                         \
                 {                                                              \

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -171,8 +171,11 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
             hhm_mod_with_ent_ = hhm_mod_ent_ptr_->impl_;                       \
             if (hhm_mod_with_ent_.entry_.stats_ == CCC_ENTRY_OCCUPIED)         \
             {                                                                  \
-                type_name *const T = ccc_buf_at(&hhm_mod_with_ent_.h_->buf_,   \
-                                                hhm_mod_with_ent_.entry_.i_);  \
+                type_name *const T = ccc_buf_at(                               \
+                    &hhm_mod_with_ent_.h_->buf_,                               \
+                    ccc_impl_hhm_elem_at(hhm_mod_with_ent_.h_,                 \
+                                         hhm_mod_with_ent_.entry_.i_)          \
+                        ->slot_i_);                                            \
                 if (T)                                                         \
                 {                                                              \
                     closure_over_T                                             \

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -1,0 +1,89 @@
+#ifndef CCC_IMPL_HANDLE_HASH_MAP_H
+#define CCC_IMPL_HANDLE_HASH_MAP_H
+
+/** @cond */
+#include <stddef.h>
+#include <stdint.h>
+/** @endcond */
+
+#include "../buffer.h"
+#include "../types.h"
+#include "impl_types.h"
+
+/** @private */
+enum : uint64_t
+{
+    CCC_HHM_EMPTY = 0,
+};
+
+/** @private To offer handle "stability," similar to pointer stability except
+with indices rather than pointers, we will run the robin hood hash table
+algorithm with backshift deletions on only the metadata field of the intrusive
+element. The metadata will be swapped across user entries in the table while
+the user meta index tracking stays in the same slot with arbitrary sized user
+data. Both the meta and user fields will need to point to each other so that
+each can be updated on swaps, back shifts, deletions, and insertions. The home
+slot in the table never changes for a metadata entry. However, the metadata
+tracking must be updated every time a back shift or swap occurs. */
+struct ccc_hhmap_elem_
+{
+    /* The struct that swaps during the robin hood algo. Caching the full hash
+       here to avoid using pointer to user data for full comparison callback. */
+    struct
+    {
+        /* The full hash of the user data. Reduces callbacks and rehashing. */
+        uint64_t hash_;
+        /* Index of the permanent home of the data associated with this hash.
+           Does not change once initialized even when an element is removed. */
+        size_t slot_i_;
+    } meta_;
+    /* This field stays at original slot. Updated whenever meta moves. */
+    size_t meta_i_;
+};
+
+/** @private */
+struct ccc_hhmap_
+{
+    ccc_buffer buf_;          /* Buffer of types with size, cap, and aux. */
+    ccc_hash_fn *hash_fn_;    /* Hashing callback. */
+    ccc_key_eq_fn *eq_fn_;    /* Equality callback. */
+    size_t key_offset_;       /* Key in user defined type offset. */
+    size_t hash_elem_offset_; /* Intrusive element offset. */
+};
+
+/** @private */
+struct ccc_handle_
+{
+    /* The types.h entry is not quite suitable for this container so change. */
+    size_t i_;
+    /* Keep these types in sync in cases status reporting changes. */
+    typeof((ccc_entry){}.impl_.stats_) stats_;
+};
+
+/** @private */
+struct ccc_hhash_entry_
+{
+    struct ccc_hhmap_ *h_;
+    uint64_t hash_;
+    struct ccc_handle_ entry_;
+};
+
+/** @private */
+union ccc_hhmap_entry_
+{
+    struct ccc_hhash_entry_ impl_;
+};
+
+#define ccc_impl_hhm_init(memory_ptr, capacity, hhash_elem_field, key_field,   \
+                          alloc_fn, hash_fn, key_eq_fn, aux)                   \
+    {                                                                          \
+        .buf_                                                                  \
+        = (ccc_buffer)ccc_buf_init((memory_ptr), (alloc_fn), (aux), capacity), \
+        .hash_fn_ = (hash_fn),                                                 \
+        .eq_fn_ = (key_eq_fn),                                                 \
+        .key_offset_ = offsetof(typeof(*(memory_ptr)), key_field),             \
+        .hash_elem_offset_                                                     \
+        = offsetof(typeof(*(memory_ptr)), hhash_elem_field),                   \
+    }
+
+#endif /* CCC_IMPL_HANDLE_HASH_MAP_H */

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -47,26 +47,17 @@ struct ccc_hhmap_
 };
 
 /** @private */
-struct ccc_handle_
-{
-    /* The types.h entry is not quite suitable for this container so change. */
-    size_t i_;
-    /* Keep these types in sync in cases status reporting changes. */
-    typeof((ccc_entry){}.impl_.stats_) stats_;
-};
-
-/** @private */
-struct ccc_hhash_entry_
+struct ccc_hhash_handle_
 {
     struct ccc_hhmap_ *h_;
     uint64_t hash_;
-    struct ccc_handle_ entry_;
+    struct ccc_handl_ handle_;
 };
 
 /** @private */
-union ccc_hhmap_entry_
+union ccc_hhmap_handle_
 {
-    struct ccc_hhash_entry_ impl_;
+    struct ccc_hhash_handle_ impl_;
 };
 
 #define ccc_impl_hhm_init(memory_ptr, capacity, hhash_elem_field, key_field,   \
@@ -85,7 +76,7 @@ union ccc_hhmap_entry_
     (__extension__({                                                           \
         struct ccc_hhmap_ const *const hhm_ptr_ = (handle_hash_map_ptr);       \
         typeof(type_name) *hhm_as_ = NULL;                                     \
-        ccc_handle const hhm_handle_ = (handle);                               \
+        ccc_handle_i const hhm_handle_ = (handle);                             \
         if (hhm_ptr_ && hhm_handle_)                                           \
         {                                                                      \
             hhm_as_ = ccc_buf_at(&hhm_ptr_->buf_, hhm_handle_);                \
@@ -93,15 +84,15 @@ union ccc_hhmap_entry_
         hhm_as_;                                                               \
     }))
 
-struct ccc_handle_ ccc_impl_hhm_find(struct ccc_hhmap_ const *, void const *key,
-                                     uint64_t hash);
-ccc_handle ccc_impl_hhm_insert_meta(struct ccc_hhmap_ *h, uint64_t hash,
-                                    size_t cur_i);
+struct ccc_handl_ ccc_impl_hhm_find(struct ccc_hhmap_ const *, void const *key,
+                                    uint64_t hash);
+ccc_handle_i ccc_impl_hhm_insert_meta(struct ccc_hhmap_ *h, uint64_t hash,
+                                      size_t cur_i);
 
-struct ccc_hhash_entry_ ccc_impl_hhm_entry(struct ccc_hhmap_ *h,
-                                           void const *key);
-struct ccc_hhash_entry_ *ccc_impl_hhm_and_modify(struct ccc_hhash_entry_ *e,
-                                                 ccc_update_fn *fn);
+struct ccc_hhash_handle_ ccc_impl_hhm_handle(struct ccc_hhmap_ *h,
+                                             void const *key);
+struct ccc_hhash_handle_ *ccc_impl_hhm_and_modify(struct ccc_hhash_handle_ *e,
+                                                  ccc_update_fn *fn);
 struct ccc_hhmap_elem_ *ccc_impl_hhm_in_slot(struct ccc_hhmap_ const *h,
                                              void const *slot);
 void *ccc_impl_hhm_key_at(struct ccc_hhmap_ const *h, size_t i);
@@ -121,60 +112,60 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
 
 /* Internal helper assumes that swap_entry has already been evaluated once
    which it must have to make it to this point. */
-#define ccc_impl_hhm_swaps(swap_entry, lazy_key_value...)                      \
+#define ccc_impl_hhm_swaps(swap_handle, lazy_key_value...)                     \
     (__extension__({                                                           \
-        size_t hhm_i_ = (swap_entry)->entry_.i_;                               \
+        size_t hhm_i_ = (swap_handle)->handle_.i_;                             \
         struct ccc_hhmap_elem_ *hhm_slot_elem_                                 \
-            = ccc_impl_hhm_elem_at((swap_entry)->h_, hhm_i_);                  \
+            = ccc_impl_hhm_elem_at((swap_handle)->h_, hhm_i_);                 \
         if (hhm_slot_elem_->hash_ == CCC_HHM_EMPTY)                            \
         {                                                                      \
             struct ccc_hhmap_elem_ const save_elem_ = *ccc_impl_hhm_elem_at(   \
-                (swap_entry)->h_, hhm_slot_elem_->slot_i_);                    \
-            *((typeof(lazy_key_value) *)ccc_buf_at(&((swap_entry)->h_->buf_),  \
+                (swap_handle)->h_, hhm_slot_elem_->slot_i_);                   \
+            *((typeof(lazy_key_value) *)ccc_buf_at(&((swap_handle)->h_->buf_), \
                                                    save_elem_.slot_i_))        \
                 = lazy_key_value;                                              \
-            *ccc_impl_hhm_elem_at((swap_entry)->h_, save_elem_.slot_i_)        \
+            *ccc_impl_hhm_elem_at((swap_handle)->h_, save_elem_.slot_i_)       \
                 = save_elem_;                                                  \
-            *ccc_impl_hhm_hash_at((swap_entry)->h_, save_elem_.slot_i_)        \
-                = (swap_entry)->hash_;                                         \
-            (void)ccc_buf_size_plus(&(swap_entry)->h_->buf_, 1);               \
+            *ccc_impl_hhm_hash_at((swap_handle)->h_, save_elem_.slot_i_)       \
+                = (swap_handle)->hash_;                                        \
+            (void)ccc_buf_size_plus(&(swap_handle)->h_->buf_, 1);              \
         }                                                                      \
         else                                                                   \
         {                                                                      \
-            hhm_i_ = ccc_impl_hhm_insert_meta((swap_entry)->h_,                \
-                                              (swap_entry)->hash_, hhm_i_);    \
+            hhm_i_ = ccc_impl_hhm_insert_meta((swap_handle)->h_,               \
+                                              (swap_handle)->hash_, hhm_i_);   \
             struct ccc_hhmap_elem_ const save_elem_ = *ccc_impl_hhm_elem_at(   \
-                (swap_entry)->h_,                                              \
-                ccc_impl_hhm_elem_at((swap_entry)->h_, hhm_i_)->slot_i_);      \
+                (swap_handle)->h_,                                             \
+                ccc_impl_hhm_elem_at((swap_handle)->h_, hhm_i_)->slot_i_);     \
             *((typeof(lazy_key_value) *)ccc_buf_at(                            \
-                &((swap_entry)->h_->buf_),                                     \
-                ccc_impl_hhm_elem_at((swap_entry)->h_, hhm_i_)->slot_i_))      \
+                &((swap_handle)->h_->buf_),                                    \
+                ccc_impl_hhm_elem_at((swap_handle)->h_, hhm_i_)->slot_i_))     \
                 = lazy_key_value;                                              \
-            *ccc_impl_hhm_elem_at((swap_entry)->h_, save_elem_.slot_i_)        \
+            *ccc_impl_hhm_elem_at((swap_handle)->h_, save_elem_.slot_i_)       \
                 = save_elem_;                                                  \
-            *ccc_impl_hhm_hash_at((swap_entry)->h_, save_elem_.slot_i_)        \
-                = (swap_entry)->hash_;                                         \
+            *ccc_impl_hhm_hash_at((swap_handle)->h_, save_elem_.slot_i_)       \
+                = (swap_handle)->hash_;                                        \
         }                                                                      \
         hhm_i_;                                                                \
     }))
 
 /*=====================     Core Macro Implementations     ==================*/
 
-#define ccc_impl_hhm_and_modify_w(handle_hash_map_entry_ptr, type_name,        \
+#define ccc_impl_hhm_and_modify_w(handle_hash_map_handle_ptr, type_name,       \
                                   closure_over_T...)                           \
     (__extension__({                                                           \
-        __auto_type hhm_mod_ent_ptr_ = (handle_hash_map_entry_ptr);            \
-        struct ccc_hhash_entry_ hhm_mod_with_ent_                              \
-            = {.entry_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}};                   \
-        if (hhm_mod_ent_ptr_)                                                  \
+        __auto_type hhm_mod_handl_ptr_ = (handle_hash_map_handle_ptr);         \
+        struct ccc_hhash_handle_ hhm_mod_with_handl_                           \
+            = {.handle_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}};                  \
+        if (hhm_mod_handl_ptr_)                                                \
         {                                                                      \
-            hhm_mod_with_ent_ = hhm_mod_ent_ptr_->impl_;                       \
-            if (hhm_mod_with_ent_.entry_.stats_ == CCC_ENTRY_OCCUPIED)         \
+            hhm_mod_with_handl_ = hhm_mod_handl_ptr_->impl_;                   \
+            if (hhm_mod_with_handl_.handle_.stats_ == CCC_ENTRY_OCCUPIED)      \
             {                                                                  \
                 type_name *const T = ccc_buf_at(                               \
-                    &hhm_mod_with_ent_.h_->buf_,                               \
-                    ccc_impl_hhm_elem_at(hhm_mod_with_ent_.h_,                 \
-                                         hhm_mod_with_ent_.entry_.i_)          \
+                    &hhm_mod_with_handl_.h_->buf_,                             \
+                    ccc_impl_hhm_elem_at(hhm_mod_with_handl_.h_,               \
+                                         hhm_mod_with_handl_.handle_.i_)       \
                         ->slot_i_);                                            \
                 if (T)                                                         \
                 {                                                              \
@@ -182,26 +173,28 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                 }                                                              \
             }                                                                  \
         }                                                                      \
-        hhm_mod_with_ent_;                                                     \
+        hhm_mod_with_handl_;                                                   \
     }))
 
-#define ccc_impl_hhm_or_insert_w(handle_hash_map_entry_ptr, lazy_key_value...) \
+#define ccc_impl_hhm_or_insert_w(handle_hash_map_handle_ptr,                   \
+                                 lazy_key_value...)                            \
     (__extension__({                                                           \
-        __auto_type hhm_or_ins_ent_ptr_ = (handle_hash_map_entry_ptr);         \
-        ccc_handle hhm_or_ins_res_ = 0;                                        \
-        if (hhm_or_ins_ent_ptr_)                                               \
+        __auto_type hhm_or_ins_handl_ptr_ = (handle_hash_map_handle_ptr);      \
+        ccc_handle_i hhm_or_ins_res_ = 0;                                      \
+        if (hhm_or_ins_handl_ptr_)                                             \
         {                                                                      \
-            struct ccc_hhash_entry_ *hhm_or_ins_entry_                         \
-                = &hhm_or_ins_ent_ptr_->impl_;                                 \
-            if (!(hhm_or_ins_entry_->entry_.stats_ & CCC_ENTRY_INSERT_ERROR))  \
+            struct ccc_hhash_handle_ *hhm_or_ins_handle_                       \
+                = &hhm_or_ins_handl_ptr_->impl_;                               \
+            if (!(hhm_or_ins_handle_->handle_.stats_                           \
+                  & CCC_ENTRY_INSERT_ERROR))                                   \
             {                                                                  \
-                if (hhm_or_ins_entry_->entry_.stats_ & CCC_ENTRY_OCCUPIED)     \
+                if (hhm_or_ins_handle_->handle_.stats_ & CCC_ENTRY_OCCUPIED)   \
                 {                                                              \
-                    hhm_or_ins_res_ = hhm_or_ins_entry_->entry_.i_;            \
+                    hhm_or_ins_res_ = hhm_or_ins_handle_->handle_.i_;          \
                 }                                                              \
                 else                                                           \
                 {                                                              \
-                    hhm_or_ins_res_ = ccc_impl_hhm_swaps(hhm_or_ins_entry_,    \
+                    hhm_or_ins_res_ = ccc_impl_hhm_swaps(hhm_or_ins_handle_,   \
                                                          lazy_key_value);      \
                 }                                                              \
             }                                                                  \
@@ -209,42 +202,43 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
         hhm_or_ins_res_;                                                       \
     }))
 
-#define ccc_impl_hhm_insert_entry_w(handle_hash_map_entry_ptr,                 \
-                                    lazy_key_value...)                         \
+#define ccc_impl_hhm_insert_handle_w(handle_hash_map_handle_ptr,               \
+                                     lazy_key_value...)                        \
     (__extension__({                                                           \
-        __auto_type hhm_ins_ent_ptr_ = (handle_hash_map_entry_ptr);            \
-        ccc_handle hhm_res_ = 0;                                               \
-        if (hhm_ins_ent_ptr_)                                                  \
+        __auto_type hhm_ins_handl_ptr_ = (handle_hash_map_handle_ptr);         \
+        ccc_handle_i hhm_res_ = 0;                                             \
+        if (hhm_ins_handl_ptr_)                                                \
         {                                                                      \
-            struct ccc_hhash_entry_ *hhm_ins_ent_ = &hhm_ins_ent_ptr_->impl_;  \
-            if (!(hhm_ins_ent_->entry_.stats_ & CCC_ENTRY_INSERT_ERROR))       \
+            struct ccc_hhash_handle_ *hhm_ins_handl_                           \
+                = &hhm_ins_handl_ptr_->impl_;                                  \
+            if (!(hhm_ins_handl_->handle_.stats_ & CCC_ENTRY_INSERT_ERROR))    \
             {                                                                  \
-                if (hhm_ins_ent_->entry_.stats_ & CCC_ENTRY_OCCUPIED)          \
+                if (hhm_ins_handl_->handle_.stats_ & CCC_ENTRY_OCCUPIED)       \
                 {                                                              \
-                    hhm_ins_ent_->entry_.stats_ = CCC_ENTRY_OCCUPIED;          \
+                    hhm_ins_handl_->handle_.stats_ = CCC_ENTRY_OCCUPIED;       \
                     struct ccc_hhmap_elem_ save_elem_ = *ccc_impl_hhm_elem_at( \
-                        hhm_ins_ent_->h_,                                      \
-                        ccc_impl_hhm_elem_at(hhm_ins_ent_->h_,                 \
-                                             hhm_ins_ent_->entry_.i_)          \
+                        hhm_ins_handl_->h_,                                    \
+                        ccc_impl_hhm_elem_at(hhm_ins_handl_->h_,               \
+                                             hhm_ins_handl_->handle_.i_)       \
                             ->slot_i_);                                        \
                     *((typeof(lazy_key_value) *)ccc_buf_at(                    \
-                        &hhm_ins_ent_->h_->buf_,                               \
-                        ccc_impl_hhm_elem_at(hhm_ins_ent_->h_,                 \
-                                             hhm_ins_ent_->entry_.i_)          \
+                        &hhm_ins_handl_->h_->buf_,                             \
+                        ccc_impl_hhm_elem_at(hhm_ins_handl_->h_,               \
+                                             hhm_ins_handl_->handle_.i_)       \
                             ->slot_i_))                                        \
                         = lazy_key_value;                                      \
                     *ccc_impl_hhm_elem_at(                                     \
-                        hhm_ins_ent_->h_,                                      \
-                        ccc_impl_hhm_elem_at(hhm_ins_ent_->h_,                 \
-                                             hhm_ins_ent_->entry_.i_)          \
+                        hhm_ins_handl_->h_,                                    \
+                        ccc_impl_hhm_elem_at(hhm_ins_handl_->h_,               \
+                                             hhm_ins_handl_->handle_.i_)       \
                             ->slot_i_)                                         \
                         = save_elem_;                                          \
-                    hhm_res_ = hhm_ins_ent_->entry_.i_;                        \
+                    hhm_res_ = hhm_ins_handl_->handle_.i_;                     \
                 }                                                              \
                 else                                                           \
                 {                                                              \
                     hhm_res_                                                   \
-                        = ccc_impl_hhm_swaps(hhm_ins_ent_, lazy_key_value);    \
+                        = ccc_impl_hhm_swaps(hhm_ins_handl_, lazy_key_value);  \
                 }                                                              \
             }                                                                  \
         }                                                                      \
@@ -254,31 +248,29 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
 #define ccc_impl_hhm_try_insert_w(handle_hash_map_ptr, key, lazy_value...)     \
     (__extension__({                                                           \
         struct ccc_hhmap_ *handle_hash_map_ptr_ = (handle_hash_map_ptr);       \
-        struct ccc_handle_ hhm_try_insert_res_                                 \
+        struct ccc_handl_ hhm_try_insert_res_                                  \
             = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
-        struct ccc_ent_ hhm_pointer_entry_                                     \
-            = {.stats_ = hhm_try_insert_res_.stats_};                          \
         if (handle_hash_map_ptr_)                                              \
         {                                                                      \
             __auto_type hhm_key_ = key;                                        \
-            struct ccc_hhash_entry_ hhm_try_ins_ent_                           \
-                = ccc_impl_hhm_entry(handle_hash_map_ptr_, (void *)&hhm_key_); \
-            if ((hhm_try_ins_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED)          \
-                || (hhm_try_ins_ent_.entry_.stats_ & CCC_ENTRY_INSERT_ERROR))  \
+            struct ccc_hhash_handle_ hhm_try_ins_handl_ = ccc_impl_hhm_handle( \
+                handle_hash_map_ptr_, (void *)&hhm_key_);                      \
+            if ((hhm_try_ins_handl_.handle_.stats_ & CCC_ENTRY_OCCUPIED)       \
+                || (hhm_try_ins_handl_.handle_.stats_                          \
+                    & CCC_ENTRY_INSERT_ERROR))                                 \
             {                                                                  \
-                hhm_pointer_entry_ = (struct ccc_ent_){                        \
-                    .e_ = ccc_buf_at(                                          \
-                        &handle_hash_map_ptr_->buf_,                           \
-                        ccc_impl_hhm_elem_at(handle_hash_map_ptr_,             \
-                                             hhm_try_ins_ent_.entry_.i_)       \
-                            ->slot_i_),                                        \
-                    .stats_ = hhm_try_ins_ent_.entry_.stats_};                 \
+                hhm_try_insert_res_ = (struct ccc_handl_){                     \
+                    .i_ = ccc_impl_hhm_elem_at(handle_hash_map_ptr_,           \
+                                               hhm_try_ins_handl_.handle_.i_)  \
+                              ->slot_i_,                                       \
+                    .stats_ = hhm_try_ins_handl_.handle_.stats_};              \
             }                                                                  \
             else                                                               \
             {                                                                  \
-                hhm_try_insert_res_ = (struct ccc_handle_){                    \
-                    ccc_impl_hhm_swaps((&hhm_try_ins_ent_), lazy_value),       \
-                    CCC_ENTRY_VACANT,                                          \
+                hhm_try_insert_res_ = (struct ccc_handl_){                     \
+                    .i_                                                        \
+                    = ccc_impl_hhm_swaps((&hhm_try_ins_handl_), lazy_value),   \
+                    .stats_ = CCC_ENTRY_VACANT,                                \
                 };                                                             \
                 *((typeof(hhm_key_) *)ccc_impl_hhm_key_at(                     \
                     handle_hash_map_ptr_,                                      \
@@ -287,48 +279,43 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                         ->slot_i_))                                            \
                     = hhm_key_;                                                \
             }                                                                  \
-            if (hhm_try_insert_res_.i_)                                        \
-            {                                                                  \
-                hhm_pointer_entry_.e_ = ccc_buf_at(                            \
-                    &handle_hash_map_ptr_->buf_, hhm_try_insert_res_.i_);      \
-            }                                                                  \
         }                                                                      \
-        hhm_pointer_entry_;                                                    \
+        hhm_try_insert_res_;                                                   \
     }))
 
 #define ccc_impl_hhm_insert_or_assign_w(handle_hash_map_ptr, key,              \
                                         lazy_value...)                         \
     (__extension__({                                                           \
         struct ccc_hhmap_ *handle_hash_map_ptr_ = (handle_hash_map_ptr);       \
-        struct ccc_handle_ hhm_ins_or_assign_res_                              \
+        struct ccc_handl_ hhm_ins_or_assign_res_                               \
             = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
-        struct ccc_ent_ hhm_pointer_entry_                                     \
-            = {.stats_ = hhm_ins_or_assign_res_.stats_};                       \
         if (handle_hash_map_ptr_)                                              \
         {                                                                      \
             __auto_type hhm_key_ = key;                                        \
-            struct ccc_hhash_entry_ hhm_ins_or_assign_ent_                     \
-                = ccc_impl_hhm_entry(handle_hash_map_ptr_, (void *)&hhm_key_); \
-            if (hhm_ins_or_assign_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED)     \
+            struct ccc_hhash_handle_ hhm_ins_or_assign_handl_                  \
+                = ccc_impl_hhm_handle(handle_hash_map_ptr_,                    \
+                                      (void *)&hhm_key_);                      \
+            if (hhm_ins_or_assign_handl_.handle_.stats_ & CCC_ENTRY_OCCUPIED)  \
             {                                                                  \
                 struct ccc_hhmap_elem_ const save_elem_                        \
-                    = *ccc_impl_hhm_elem_at(handle_hash_map_ptr_,              \
-                                            hhm_ins_or_assign_ent_.entry_.i_); \
-                hhm_ins_or_assign_res_ = hhm_ins_or_assign_ent_.entry_;        \
+                    = *ccc_impl_hhm_elem_at(                                   \
+                        handle_hash_map_ptr_,                                  \
+                        hhm_ins_or_assign_handl_.handle_.i_);                  \
+                hhm_ins_or_assign_res_ = hhm_ins_or_assign_handl_.handle_;     \
                 *((typeof(lazy_value) *)ccc_buf_at(                            \
                     &handle_hash_map_ptr_->buf_, hhm_ins_or_assign_res_.i_))   \
                     = lazy_value;                                              \
                 *ccc_impl_hhm_elem_at(handle_hash_map_ptr_,                    \
-                                      hhm_ins_or_assign_ent_.entry_.i_)        \
+                                      hhm_ins_or_assign_handl_.handle_.i_)     \
                     = save_elem_;                                              \
                 *((typeof(hhm_key_) *)ccc_impl_hhm_key_at(                     \
                     handle_hash_map_ptr_,                                      \
                     ccc_impl_hhm_elem_at(handle_hash_map_ptr_,                 \
-                                         hhm_ins_or_assign_ent_.entry_.i_)     \
+                                         hhm_ins_or_assign_handl_.handle_.i_)  \
                         ->slot_i_))                                            \
                     = hhm_key_;                                                \
             }                                                                  \
-            else if (hhm_ins_or_assign_ent_.entry_.stats_                      \
+            else if (hhm_ins_or_assign_handl_.handle_.stats_                   \
                      & CCC_ENTRY_INSERT_ERROR)                                 \
             {                                                                  \
                 hhm_ins_or_assign_res_.i_ = 0;                                 \
@@ -336,24 +323,20 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
             }                                                                  \
             else                                                               \
             {                                                                  \
-                hhm_ins_or_assign_res_ = (struct ccc_handle_){                 \
-                    ccc_impl_hhm_swaps((&hhm_ins_or_assign_ent_), lazy_value), \
-                    CCC_ENTRY_VACANT,                                          \
+                hhm_ins_or_assign_res_ = (struct ccc_handl_){                  \
+                    .i_ = ccc_impl_hhm_swaps((&hhm_ins_or_assign_handl_),      \
+                                             lazy_value),                      \
+                    .stats_ = CCC_ENTRY_VACANT,                                \
                 };                                                             \
                 *((typeof(hhm_key_) *)ccc_impl_hhm_key_at(                     \
                     handle_hash_map_ptr_,                                      \
                     ccc_impl_hhm_elem_at(handle_hash_map_ptr_,                 \
-                                         hhm_ins_or_assign_ent_.entry_.i_)     \
+                                         hhm_ins_or_assign_handl_.handle_.i_)  \
                         ->slot_i_))                                            \
                     = hhm_key_;                                                \
             }                                                                  \
-            if (hhm_ins_or_assign_res_.i_)                                     \
-            {                                                                  \
-                hhm_pointer_entry_.e_ = ccc_buf_at(                            \
-                    &handle_hash_map_ptr_->buf_, hhm_ins_or_assign_res_.i_);   \
-            }                                                                  \
         }                                                                      \
-        hhm_pointer_entry_;                                                    \
+        hhm_ins_or_assign_res_;                                                \
     }))
 
 /* NOLINTEND(readability-identifier-naming) */

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -156,11 +156,11 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
     (__extension__({                                                           \
         __auto_type hhm_mod_handl_ptr_ = (handle_hash_map_handle_ptr);         \
         struct ccc_hhash_handle_ hhm_mod_with_handl_                           \
-            = {.handle_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}};                  \
+            = {.handle_ = {.stats_ = CCC_INPUT_ERROR}};                        \
         if (hhm_mod_handl_ptr_)                                                \
         {                                                                      \
             hhm_mod_with_handl_ = hhm_mod_handl_ptr_->impl_;                   \
-            if (hhm_mod_with_handl_.handle_.stats_ == CCC_ENTRY_OCCUPIED)      \
+            if (hhm_mod_with_handl_.handle_.stats_ == CCC_OCCUPIED)            \
             {                                                                  \
                 type_name *const T = ccc_buf_at(                               \
                     &hhm_mod_with_handl_.h_->buf_,                             \
@@ -185,10 +185,9 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
         {                                                                      \
             struct ccc_hhash_handle_ *hhm_or_ins_handle_                       \
                 = &hhm_or_ins_handl_ptr_->impl_;                               \
-            if (!(hhm_or_ins_handle_->handle_.stats_                           \
-                  & CCC_ENTRY_INSERT_ERROR))                                   \
+            if (!(hhm_or_ins_handle_->handle_.stats_ & CCC_INSERT_ERROR))      \
             {                                                                  \
-                if (hhm_or_ins_handle_->handle_.stats_ & CCC_ENTRY_OCCUPIED)   \
+                if (hhm_or_ins_handle_->handle_.stats_ & CCC_OCCUPIED)         \
                 {                                                              \
                     hhm_or_ins_res_ = hhm_or_ins_handle_->handle_.i_;          \
                 }                                                              \
@@ -211,11 +210,11 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
         {                                                                      \
             struct ccc_hhash_handle_ *hhm_ins_handl_                           \
                 = &hhm_ins_handl_ptr_->impl_;                                  \
-            if (!(hhm_ins_handl_->handle_.stats_ & CCC_ENTRY_INSERT_ERROR))    \
+            if (!(hhm_ins_handl_->handle_.stats_ & CCC_INSERT_ERROR))          \
             {                                                                  \
-                if (hhm_ins_handl_->handle_.stats_ & CCC_ENTRY_OCCUPIED)       \
+                if (hhm_ins_handl_->handle_.stats_ & CCC_OCCUPIED)             \
                 {                                                              \
-                    hhm_ins_handl_->handle_.stats_ = CCC_ENTRY_OCCUPIED;       \
+                    hhm_ins_handl_->handle_.stats_ = CCC_OCCUPIED;             \
                     struct ccc_hhmap_elem_ save_elem_ = *ccc_impl_hhm_elem_at( \
                         hhm_ins_handl_->h_,                                    \
                         ccc_impl_hhm_elem_at(hhm_ins_handl_->h_,               \
@@ -248,16 +247,14 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
 #define ccc_impl_hhm_try_insert_w(handle_hash_map_ptr, key, lazy_value...)     \
     (__extension__({                                                           \
         struct ccc_hhmap_ *handle_hash_map_ptr_ = (handle_hash_map_ptr);       \
-        struct ccc_handl_ hhm_try_insert_res_                                  \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_handl_ hhm_try_insert_res_ = {.stats_ = CCC_INPUT_ERROR};   \
         if (handle_hash_map_ptr_)                                              \
         {                                                                      \
             __auto_type hhm_key_ = key;                                        \
             struct ccc_hhash_handle_ hhm_try_ins_handl_ = ccc_impl_hhm_handle( \
                 handle_hash_map_ptr_, (void *)&hhm_key_);                      \
-            if ((hhm_try_ins_handl_.handle_.stats_ & CCC_ENTRY_OCCUPIED)       \
-                || (hhm_try_ins_handl_.handle_.stats_                          \
-                    & CCC_ENTRY_INSERT_ERROR))                                 \
+            if ((hhm_try_ins_handl_.handle_.stats_ & CCC_OCCUPIED)             \
+                || (hhm_try_ins_handl_.handle_.stats_ & CCC_INSERT_ERROR))     \
             {                                                                  \
                 hhm_try_insert_res_ = (struct ccc_handl_){                     \
                     .i_ = ccc_impl_hhm_elem_at(handle_hash_map_ptr_,           \
@@ -270,7 +267,7 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                 hhm_try_insert_res_ = (struct ccc_handl_){                     \
                     .i_                                                        \
                     = ccc_impl_hhm_swaps((&hhm_try_ins_handl_), lazy_value),   \
-                    .stats_ = CCC_ENTRY_VACANT,                                \
+                    .stats_ = CCC_VACANT,                                      \
                 };                                                             \
                 *((typeof(hhm_key_) *)ccc_impl_hhm_key_at(                     \
                     handle_hash_map_ptr_,                                      \
@@ -288,14 +285,14 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
     (__extension__({                                                           \
         struct ccc_hhmap_ *handle_hash_map_ptr_ = (handle_hash_map_ptr);       \
         struct ccc_handl_ hhm_ins_or_assign_res_                               \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+            = {.stats_ = CCC_INPUT_ERROR};                                     \
         if (handle_hash_map_ptr_)                                              \
         {                                                                      \
             __auto_type hhm_key_ = key;                                        \
             struct ccc_hhash_handle_ hhm_ins_or_assign_handl_                  \
                 = ccc_impl_hhm_handle(handle_hash_map_ptr_,                    \
                                       (void *)&hhm_key_);                      \
-            if (hhm_ins_or_assign_handl_.handle_.stats_ & CCC_ENTRY_OCCUPIED)  \
+            if (hhm_ins_or_assign_handl_.handle_.stats_ & CCC_OCCUPIED)        \
             {                                                                  \
                 struct ccc_hhmap_elem_ const save_elem_                        \
                     = *ccc_impl_hhm_elem_at(                                   \
@@ -316,17 +313,17 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                     = hhm_key_;                                                \
             }                                                                  \
             else if (hhm_ins_or_assign_handl_.handle_.stats_                   \
-                     & CCC_ENTRY_INSERT_ERROR)                                 \
+                     & CCC_INSERT_ERROR)                                       \
             {                                                                  \
                 hhm_ins_or_assign_res_.i_ = 0;                                 \
-                hhm_ins_or_assign_res_.stats_ = CCC_ENTRY_INSERT_ERROR;        \
+                hhm_ins_or_assign_res_.stats_ = CCC_INSERT_ERROR;              \
             }                                                                  \
             else                                                               \
             {                                                                  \
                 hhm_ins_or_assign_res_ = (struct ccc_handl_){                  \
                     .i_ = ccc_impl_hhm_swaps((&hhm_ins_or_assign_handl_),      \
                                              lazy_value),                      \
-                    .stats_ = CCC_ENTRY_VACANT,                                \
+                    .stats_ = CCC_VACANT,                                      \
                 };                                                             \
                 *((typeof(hhm_key_) *)ccc_impl_hhm_key_at(                     \
                     handle_hash_map_ptr_,                                      \

--- a/ccc/impl/impl_ordered_map.h
+++ b/ccc/impl/impl_ordered_map.h
@@ -74,7 +74,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
             = ccc_impl_om_new((&om_insert_entry));                             \
         om_insert_entry_ret = (struct ccc_ent_){                               \
             .e_ = om_new_ins_base_,                                            \
-            .stats_ = CCC_ENTRY_INSERT_ERROR,                                  \
+            .stats_ = CCC_INSERT_ERROR,                                        \
         };                                                                     \
         if (om_new_ins_base_)                                                  \
         {                                                                      \
@@ -96,11 +96,11 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
     (__extension__({                                                           \
         __auto_type om_ent_ptr_ = (ordered_map_entry_ptr);                     \
         struct ccc_tree_entry_ om_mod_ent_                                     \
-            = {.entry_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}};                   \
+            = {.entry_ = {.stats_ = CCC_INPUT_ERROR}};                         \
         if (om_ent_ptr_)                                                       \
         {                                                                      \
             om_mod_ent_ = om_ent_ptr_->impl_;                                  \
-            if (om_mod_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED)                \
+            if (om_mod_ent_.entry_.stats_ & CCC_OCCUPIED)                      \
             {                                                                  \
                 type_name *const T = om_mod_ent_.entry_.e_;                    \
                 if (T)                                                         \
@@ -120,7 +120,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
         {                                                                      \
             struct ccc_tree_entry_ *om_or_ins_ent_                             \
                 = &or_ins_entry_ptr_->impl_;                                   \
-            if (om_or_ins_ent_->entry_.stats_ == CCC_ENTRY_OCCUPIED)           \
+            if (om_or_ins_ent_->entry_.stats_ == CCC_OCCUPIED)                 \
             {                                                                  \
                 or_ins_ret_ = om_or_ins_ent_->entry_.e_;                       \
             }                                                                  \
@@ -141,13 +141,13 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
         if (ins_entry_ptr_)                                                    \
         {                                                                      \
             struct ccc_tree_entry_ *om_ins_ent_ = &ins_entry_ptr_->impl_;      \
-            if (!(om_ins_ent_->entry_.stats_ & CCC_ENTRY_OCCUPIED))            \
+            if (!(om_ins_ent_->entry_.stats_ & CCC_OCCUPIED))                  \
             {                                                                  \
                 om_ins_ent_ret_ = ccc_impl_om_new(om_ins_ent_);                \
                 ccc_impl_om_insert_key_val(om_ins_ent_, om_ins_ent_ret_,       \
                                            lazy_key_value);                    \
             }                                                                  \
-            else if (om_ins_ent_->entry_.stats_ == CCC_ENTRY_OCCUPIED)         \
+            else if (om_ins_ent_->entry_.stats_ == CCC_OCCUPIED)               \
             {                                                                  \
                 struct ccc_node_ ins_ent_saved_ = *ccc_impl_omap_elem_in_slot( \
                     om_ins_ent_->t_, om_ins_ent_->entry_.e_);                  \
@@ -165,21 +165,20 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
 #define ccc_impl_om_try_insert_w(ordered_map_ptr, key, lazy_value...)          \
     (__extension__({                                                           \
         __auto_type try_ins_map_ptr_ = (ordered_map_ptr);                      \
-        struct ccc_ent_ om_try_ins_ent_ret_                                    \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ent_ om_try_ins_ent_ret_ = {.stats_ = CCC_INPUT_ERROR};     \
         if (try_ins_map_ptr_)                                                  \
         {                                                                      \
             __auto_type om_key_ = (key);                                       \
             struct ccc_tree_ *om_try_ins_map_ptr_ = &try_ins_map_ptr_->impl_;  \
             struct ccc_tree_entry_ om_try_ins_ent_                             \
                 = ccc_impl_om_entry(om_try_ins_map_ptr_, (void *)&om_key_);    \
-            if (!(om_try_ins_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED))         \
+            if (!(om_try_ins_ent_.entry_.stats_ & CCC_OCCUPIED))               \
             {                                                                  \
                 ccc_impl_om_insert_and_copy_key(om_try_ins_ent_,               \
                                                 om_try_ins_ent_ret_, om_key_,  \
                                                 lazy_value);                   \
             }                                                                  \
-            else if (om_try_ins_ent_.entry_.stats_ == CCC_ENTRY_OCCUPIED)      \
+            else if (om_try_ins_ent_.entry_.stats_ == CCC_OCCUPIED)            \
             {                                                                  \
                 om_try_ins_ent_ret_ = om_try_ins_ent_.entry_;                  \
             }                                                                  \
@@ -191,7 +190,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
     (__extension__({                                                           \
         __auto_type ins_or_assign_map_ptr_ = (ordered_map_ptr);                \
         struct ccc_ent_ om_ins_or_assign_ent_ret_                              \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+            = {.stats_ = CCC_INPUT_ERROR};                                     \
         if (ins_or_assign_map_ptr_)                                            \
         {                                                                      \
             __auto_type om_key_ = (key);                                       \
@@ -199,14 +198,13 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
                 = &ins_or_assign_map_ptr_->impl_;                              \
             struct ccc_tree_entry_ om_ins_or_assign_ent_                       \
                 = ccc_impl_om_entry(ordered_map_ptr_, (void *)&om_key_);       \
-            if (!(om_ins_or_assign_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED))   \
+            if (!(om_ins_or_assign_ent_.entry_.stats_ & CCC_OCCUPIED))         \
             {                                                                  \
                 ccc_impl_om_insert_and_copy_key(om_ins_or_assign_ent_,         \
                                                 om_ins_or_assign_ent_ret_,     \
                                                 om_key_, lazy_value);          \
             }                                                                  \
-            else if (om_ins_or_assign_ent_.entry_.stats_                       \
-                     == CCC_ENTRY_OCCUPIED)                                    \
+            else if (om_ins_or_assign_ent_.entry_.stats_ == CCC_OCCUPIED)      \
             {                                                                  \
                 struct ccc_node_ ins_ent_saved_ = *ccc_impl_omap_elem_in_slot( \
                     om_ins_or_assign_ent_.t_,                                  \

--- a/ccc/impl/impl_ordered_multimap.h
+++ b/ccc/impl/impl_ordered_multimap.h
@@ -74,7 +74,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
             = ccc_impl_omm_new((&omm_insert_entry));                           \
         omm_insert_entry_ret = (struct ccc_ent_){                              \
             .e_ = omm_new_ins_base_,                                           \
-            .stats_ = CCC_ENTRY_INSERT_ERROR,                                  \
+            .stats_ = CCC_INSERT_ERROR,                                        \
         };                                                                     \
         if (omm_new_ins_base_)                                                 \
         {                                                                      \
@@ -96,11 +96,11 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
     (__extension__({                                                           \
         __auto_type omm_ent_ptr_ = (ordered_map_entry_ptr);                    \
         struct ccc_tree_entry_ omm_mod_ent_                                    \
-            = {.entry_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}};                   \
+            = {.entry_ = {.stats_ = CCC_INPUT_ERROR}};                         \
         if (omm_ent_ptr_)                                                      \
         {                                                                      \
             omm_mod_ent_ = omm_ent_ptr_->impl_;                                \
-            if (omm_mod_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED)               \
+            if (omm_mod_ent_.entry_.stats_ & CCC_OCCUPIED)                     \
             {                                                                  \
                 type_name *const T = omm_mod_ent_.entry_.e_;                   \
                 if (T)                                                         \
@@ -120,7 +120,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
         {                                                                      \
             struct ccc_tree_entry_ *omm_or_ins_ent_                            \
                 = &omm_or_ins_ent_ptr_->impl_;                                 \
-            if (omm_or_ins_ent_->entry_.stats_ == CCC_ENTRY_OCCUPIED)          \
+            if (omm_or_ins_ent_->entry_.stats_ == CCC_OCCUPIED)                \
             {                                                                  \
                 or_ins_ret_ = omm_or_ins_ent_->entry_.e_;                      \
             }                                                                  \
@@ -151,21 +151,20 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
 #define ccc_impl_omm_try_insert_w(ordered_map_ptr, key, lazy_value...)         \
     (__extension__({                                                           \
         __auto_type omm_try_ins_ptr_ = (ordered_map_ptr);                      \
-        struct ccc_ent_ omm_try_ins_ent_ret_                                   \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ent_ omm_try_ins_ent_ret_ = {.stats_ = CCC_INPUT_ERROR};    \
         if (omm_try_ins_ptr_)                                                  \
         {                                                                      \
             __auto_type omm_key_ = (key);                                      \
             struct ccc_tree_ *omm_try_ins_map_ptr_ = &omm_try_ins_ptr_->impl_; \
             struct ccc_tree_entry_ omm_try_ins_ent_                            \
                 = ccc_impl_omm_entry(omm_try_ins_map_ptr_, (void *)&omm_key_); \
-            if (!(omm_try_ins_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED))        \
+            if (!(omm_try_ins_ent_.entry_.stats_ & CCC_OCCUPIED))              \
             {                                                                  \
                 ccc_impl_omm_insert_and_copy_key(omm_try_ins_ent_,             \
                                                  omm_try_ins_ent_ret_,         \
                                                  omm_key_, lazy_value);        \
             }                                                                  \
-            else if (omm_try_ins_ent_.entry_.stats_ == CCC_ENTRY_OCCUPIED)     \
+            else if (omm_try_ins_ent_.entry_.stats_ == CCC_OCCUPIED)           \
             {                                                                  \
                 omm_try_ins_ent_ret_ = omm_try_ins_ent_.entry_;                \
             }                                                                  \
@@ -177,7 +176,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
     (__extension__({                                                           \
         __auto_type omm_ins_or_assign_ptr_ = (ordered_map_ptr);                \
         struct ccc_ent_ omm_ins_or_assign_ent_ret_                             \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+            = {.stats_ = CCC_INPUT_ERROR};                                     \
         if (omm_ins_or_assign_ptr_)                                            \
         {                                                                      \
             __auto_type omm_key_ = (key);                                      \
@@ -185,14 +184,13 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
                 = &omm_ins_or_assign_ptr_->impl_;                              \
             struct ccc_tree_entry_ omm_ins_or_assign_ent_                      \
                 = ccc_impl_omm_entry(ordered_map_ptr_, (void *)&omm_key_);     \
-            if (!(omm_ins_or_assign_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED))  \
+            if (!(omm_ins_or_assign_ent_.entry_.stats_ & CCC_OCCUPIED))        \
             {                                                                  \
                 ccc_impl_omm_insert_and_copy_key(omm_ins_or_assign_ent_,       \
                                                  omm_ins_or_assign_ent_ret_,   \
                                                  omm_key_, lazy_value);        \
             }                                                                  \
-            else if (omm_ins_or_assign_ent_.entry_.stats_                      \
-                     == CCC_ENTRY_OCCUPIED)                                    \
+            else if (omm_ins_or_assign_ent_.entry_.stats_ == CCC_OCCUPIED)     \
             {                                                                  \
                 struct ccc_node_ ins_ent_saved_                                \
                     = *ccc_impl_ommap_elem_in_slot(                            \

--- a/ccc/impl/impl_realtime_ordered_map.h
+++ b/ccc/impl/impl_realtime_ordered_map.h
@@ -115,7 +115,7 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
             = ccc_impl_rom_new((&rom_insert_entry));                           \
         rom_insert_entry_ret = (struct ccc_ent_){                              \
             .e_ = rom_new_ins_base_,                                           \
-            .stats_ = CCC_ENTRY_INSERT_ERROR,                                  \
+            .stats_ = CCC_INSERT_ERROR,                                        \
         };                                                                     \
         if (rom_new_ins_base_)                                                 \
         {                                                                      \
@@ -140,11 +140,11 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
     (__extension__({                                                           \
         __auto_type rom_ent_ptr_ = (realtime_ordered_map_entry_ptr);           \
         struct ccc_rtree_entry_ rom_mod_ent_                                   \
-            = {.entry_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}};                   \
+            = {.entry_ = {.stats_ = CCC_INPUT_ERROR}};                         \
         if (rom_ent_ptr_)                                                      \
         {                                                                      \
             rom_mod_ent_ = rom_ent_ptr_->impl_;                                \
-            if (rom_mod_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED)               \
+            if (rom_mod_ent_.entry_.stats_ & CCC_OCCUPIED)                     \
             {                                                                  \
                 type_name *const T = rom_mod_ent_.entry_.e_;                   \
                 if (T)                                                         \
@@ -165,7 +165,7 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
         {                                                                      \
             struct ccc_rtree_entry_ *rom_or_ins_ent_                           \
                 = &or_ins_entry_ptr_->impl_;                                   \
-            if (rom_or_ins_ent_->entry_.stats_ == CCC_ENTRY_OCCUPIED)          \
+            if (rom_or_ins_ent_->entry_.stats_ == CCC_OCCUPIED)                \
             {                                                                  \
                 rom_or_ins_ret_ = rom_or_ins_ent_->entry_.e_;                  \
             }                                                                  \
@@ -187,13 +187,13 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
         if (ins_entry_ptr_)                                                    \
         {                                                                      \
             struct ccc_rtree_entry_ *rom_ins_ent_ = &ins_entry_ptr_->impl_;    \
-            if (!(rom_ins_ent_->entry_.stats_ & CCC_ENTRY_OCCUPIED))           \
+            if (!(rom_ins_ent_->entry_.stats_ & CCC_OCCUPIED))                 \
             {                                                                  \
                 rom_ins_ent_ret_ = ccc_impl_rom_new(rom_ins_ent_);             \
                 ccc_impl_rom_insert_key_val(rom_ins_ent_, rom_ins_ent_ret_,    \
                                             lazy_key_value);                   \
             }                                                                  \
-            else if (rom_ins_ent_->entry_.stats_ == CCC_ENTRY_OCCUPIED)        \
+            else if (rom_ins_ent_->entry_.stats_ == CCC_OCCUPIED)              \
             {                                                                  \
                 struct ccc_romap_elem_ ins_ent_saved_                          \
                     = *ccc_impl_romap_elem_in_slot(rom_ins_ent_->rom_,         \
@@ -214,19 +214,18 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
     (__extension__({                                                           \
         struct ccc_romap_ *const try_ins_map_ptr_                              \
             = (realtime_ordered_map_ptr);                                      \
-        struct ccc_ent_ rom_try_ins_ent_ret_                                   \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+        struct ccc_ent_ rom_try_ins_ent_ret_ = {.stats_ = CCC_INPUT_ERROR};    \
         if (try_ins_map_ptr_)                                                  \
         {                                                                      \
             __auto_type rom_key_ = (key);                                      \
             struct ccc_rtree_entry_ rom_try_ins_ent_                           \
                 = ccc_impl_rom_entry(try_ins_map_ptr_, (void *)&rom_key_);     \
-            if (!(rom_try_ins_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED))        \
+            if (!(rom_try_ins_ent_.entry_.stats_ & CCC_OCCUPIED))              \
             {                                                                  \
                 ccc_impl_rom_insert_and_copy_key(                              \
                     rom_try_ins_ent_, rom_try_ins_ent_ret_, key, lazy_value);  \
             }                                                                  \
-            else if (rom_try_ins_ent_.entry_.stats_ == CCC_ENTRY_OCCUPIED)     \
+            else if (rom_try_ins_ent_.entry_.stats_ == CCC_OCCUPIED)           \
             {                                                                  \
                 rom_try_ins_ent_ret_ = rom_try_ins_ent_.entry_;                \
             }                                                                  \
@@ -240,21 +239,20 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
         struct ccc_romap_ *const ins_or_assign_map_ptr_                        \
             = (realtime_ordered_map_ptr);                                      \
         struct ccc_ent_ rom_ins_or_assign_ent_ret_                             \
-            = {.stats_ = CCC_ENTRY_INPUT_ERROR};                               \
+            = {.stats_ = CCC_INPUT_ERROR};                                     \
         if (ins_or_assign_map_ptr_)                                            \
         {                                                                      \
             __auto_type rom_key_ = (key);                                      \
             struct ccc_rtree_entry_ rom_ins_or_assign_ent_                     \
                 = ccc_impl_rom_entry(ins_or_assign_map_ptr_,                   \
                                      (void *)&rom_key_);                       \
-            if (!(rom_ins_or_assign_ent_.entry_.stats_ & CCC_ENTRY_OCCUPIED))  \
+            if (!(rom_ins_or_assign_ent_.entry_.stats_ & CCC_OCCUPIED))        \
             {                                                                  \
                 ccc_impl_rom_insert_and_copy_key(rom_ins_or_assign_ent_,       \
                                                  rom_ins_or_assign_ent_ret_,   \
                                                  key, lazy_value);             \
             }                                                                  \
-            else if (rom_ins_or_assign_ent_.entry_.stats_                      \
-                     == CCC_ENTRY_OCCUPIED)                                    \
+            else if (rom_ins_or_assign_ent_.entry_.stats_ == CCC_OCCUPIED)     \
             {                                                                  \
                 struct ccc_romap_elem_ ins_ent_saved_                          \
                     = *ccc_impl_romap_elem_in_slot(                            \

--- a/ccc/impl/impl_traits.h
+++ b/ccc/impl/impl_traits.h
@@ -91,14 +91,12 @@
 #define ccc_impl_remove_entry(container_entry_ptr)                             \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_remove_entry,                               \
-        ccc_hhmap_entry *: ccc_hhm_remove_entry,                               \
         ccc_omap_entry *: ccc_om_remove_entry,                                 \
         ccc_ommap_entry *: ccc_omm_remove_entry,                               \
         ccc_fomap_entry *: ccc_fom_remove_entry,                               \
         ccc_fromap_entry *: ccc_frm_remove_entry,                              \
         ccc_romap_entry *: ccc_rom_remove_entry,                               \
         ccc_fhmap_entry const *: ccc_fhm_remove_entry,                         \
-        ccc_hhmap_entry const *: ccc_hhm_remove_entry,                         \
         ccc_fromap_entry const *: ccc_frm_remove_entry,                        \
         ccc_omap_entry const *: ccc_om_remove_entry,                           \
         ccc_fomap_entry const *: ccc_fom_remove_entry,                         \
@@ -110,12 +108,22 @@
         ccc_impl_remove_entry(container_entry_ptr).impl_                       \
     }
 
+#define ccc_impl_remove_handle(container_handle_ptr)                           \
+    _Generic((container_handle_ptr),                                           \
+        ccc_hhmap_handle *: ccc_hhm_remove_handle,                             \
+        ccc_hhmap_handle const *: ccc_hhm_remove_handle)(                      \
+        (container_handle_ptr))
+
+#define ccc_impl_remove_handle_r(container_handle_ptr)                         \
+    &(ccc_handle)                                                              \
+    {                                                                          \
+        ccc_impl_remove_handle(container_handle_ptr).impl_                     \
+    }
+
 #define ccc_impl_entry(container_ptr, key_ptr...)                              \
     _Generic((container_ptr),                                                  \
         ccc_flat_hash_map *: ccc_fhm_entry,                                    \
         ccc_flat_hash_map const *: ccc_fhm_entry,                              \
-        ccc_handle_hash_map *: ccc_hhm_entry,                                  \
-        ccc_handle_hash_map const *: ccc_hhm_entry,                            \
         ccc_ordered_map *: ccc_om_entry,                                       \
         ccc_ordered_multimap *: ccc_omm_entry,                                 \
         ccc_flat_ordered_map *: ccc_fom_entry,                                 \
@@ -135,16 +143,6 @@
         ccc_flat_hash_map const *: &(                                          \
                  ccc_fhmap_entry){ccc_fhm_entry(                               \
                                       (ccc_flat_hash_map *)(container_ptr),    \
-                                      key_ptr)                                 \
-                                      .impl_},                                 \
-        ccc_handle_hash_map *: &(                                              \
-                 ccc_hhmap_entry){ccc_hhm_entry(                               \
-                                      (ccc_handle_hash_map *)(container_ptr),  \
-                                      key_ptr)                                 \
-                                      .impl_},                                 \
-        ccc_handle_hash_map const *: &(                                        \
-                 ccc_hhmap_entry){ccc_hhm_entry(                               \
-                                      (ccc_handle_hash_map *)(container_ptr),  \
                                       key_ptr)                                 \
                                       .impl_},                                 \
         ccc_ordered_map *: &(                                                  \
@@ -184,17 +182,33 @@
                           key_ptr)                                             \
                 .impl_})
 
+#define ccc_impl_handle(container_ptr, key_ptr...)                             \
+    _Generic((container_ptr),                                                  \
+        ccc_handle_hash_map *: ccc_hhm_handle,                                 \
+        ccc_handle_hash_map const *: ccc_hhm_handle)((container_ptr), key_ptr)
+
+#define ccc_impl_handle_r(container_ptr, key_ptr...)                           \
+    _Generic((container_ptr),                                                  \
+        ccc_handle_hash_map                                                    \
+            *: &(ccc_hhmap_handle){ccc_hhm_handle(                             \
+                                       (ccc_handle_hash_map *)(container_ptr), \
+                                       key_ptr)                                \
+                                       .impl_},                                \
+        ccc_handle_hash_map const *: &(ccc_hhmap_handle){                      \
+            ccc_hhm_handle((ccc_handle_hash_map *)(container_ptr), key_ptr)    \
+                .impl_})
+
 #define ccc_impl_and_modify(container_entry_ptr, mod_fn)                       \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_and_modify,                                 \
-        ccc_hhmap_entry *: ccc_hhm_and_modify,                                 \
+        ccc_hhmap_handle *: ccc_hhm_and_modify,                                \
         ccc_omap_entry *: ccc_om_and_modify,                                   \
         ccc_ommap_entry *: ccc_omm_and_modify,                                 \
         ccc_fomap_entry *: ccc_fom_and_modify,                                 \
         ccc_romap_entry *: ccc_rom_and_modify,                                 \
         ccc_fromap_entry *: ccc_frm_and_modify,                                \
         ccc_fhmap_entry const *: ccc_fhm_and_modify,                           \
-        ccc_hhmap_entry const *: ccc_hhm_and_modify,                           \
+        ccc_hhmap_handle const *: ccc_hhm_and_modify,                          \
         ccc_fromap_entry const *: ccc_frm_and_modify,                          \
         ccc_omap_entry const *: ccc_om_and_modify,                             \
         ccc_ommap_entry const *: ccc_omm_and_modify,                           \
@@ -205,14 +219,14 @@
 #define ccc_impl_and_modify_aux(container_entry_ptr, mod_fn, aux_data_ptr...)  \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_and_modify_aux,                             \
-        ccc_hhmap_entry *: ccc_hhm_and_modify_aux,                             \
+        ccc_hhmap_handle *: ccc_hhm_and_modify_aux,                            \
         ccc_omap_entry *: ccc_om_and_modify_aux,                               \
         ccc_ommap_entry *: ccc_omm_and_modify_aux,                             \
         ccc_fomap_entry *: ccc_fom_and_modify_aux,                             \
         ccc_fromap_entry *: ccc_frm_and_modify_aux,                            \
         ccc_romap_entry *: ccc_rom_and_modify_aux,                             \
         ccc_fhmap_entry const *: ccc_fhm_and_modify_aux,                       \
-        ccc_hhmap_entry const *: ccc_hhm_and_modify_aux,                       \
+        ccc_hhmap_handle const *: ccc_hhm_and_modify_aux,                      \
         ccc_omap_entry const *: ccc_om_and_modify_aux,                         \
         ccc_ommap_entry const *: ccc_omm_and_modify_aux,                       \
         ccc_fromap_entry const *: ccc_frm_and_modify_aux,                      \
@@ -224,14 +238,12 @@
                               key_val_container_handle_ptr...)                 \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_insert_entry,                               \
-        ccc_hhmap_entry *: ccc_hhm_insert_entry,                               \
         ccc_omap_entry *: ccc_om_insert_entry,                                 \
         ccc_ommap_entry *: ccc_omm_insert_entry,                               \
         ccc_fomap_entry *: ccc_fom_insert_entry,                               \
         ccc_romap_entry *: ccc_rom_insert_entry,                               \
         ccc_fromap_entry *: ccc_frm_insert_entry,                              \
         ccc_fhmap_entry const *: ccc_fhm_insert_entry,                         \
-        ccc_hhmap_entry const *: ccc_hhm_insert_entry,                         \
         ccc_omap_entry const *: ccc_om_insert_entry,                           \
         ccc_ommap_entry const *: ccc_omm_insert_entry,                         \
         ccc_fomap_entry const *: ccc_fom_insert_entry,                         \
@@ -239,18 +251,25 @@
         ccc_romap_entry const *: ccc_rom_insert_entry)(                        \
         (container_entry_ptr), key_val_container_handle_ptr)
 
+#define ccc_impl_insert_handle(container_handle_ptr,                           \
+                               key_val_container_handle_ptr...)                \
+    _Generic((container_handle_ptr),                                           \
+        ccc_hhmap_handle *: ccc_hhm_insert_handle,                             \
+        ccc_hhmap_handle const *: ccc_hhm_insert_handle)(                      \
+        (container_handle_ptr), key_val_container_handle_ptr)
+
 #define ccc_impl_or_insert(container_entry_ptr,                                \
                            key_val_container_handle_ptr...)                    \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_or_insert,                                  \
-        ccc_hhmap_entry *: ccc_hhm_or_insert,                                  \
+        ccc_hhmap_handle *: ccc_hhm_or_insert,                                 \
         ccc_omap_entry *: ccc_om_or_insert,                                    \
         ccc_ommap_entry *: ccc_omm_or_insert,                                  \
         ccc_fomap_entry *: ccc_fom_or_insert,                                  \
         ccc_romap_entry *: ccc_rom_or_insert,                                  \
         ccc_fromap_entry *: ccc_frm_or_insert,                                 \
         ccc_fhmap_entry const *: ccc_fhm_or_insert,                            \
-        ccc_hhmap_entry const *: ccc_hhm_or_insert,                            \
+        ccc_hhmap_handle const *: ccc_hhm_or_insert,                           \
         ccc_omap_entry const *: ccc_om_or_insert,                              \
         ccc_ommap_entry const *: ccc_omm_or_insert,                            \
         ccc_fromap_entry const *: ccc_frm_or_insert,                           \
@@ -262,10 +281,12 @@
     _Generic((container_entry_ptr),                                            \
         ccc_entry *: ccc_entry_unwrap,                                         \
         ccc_entry const *: ccc_entry_unwrap,                                   \
+        ccc_handle *: ccc_handle_unwrap,                                       \
+        ccc_handle const *: ccc_handle_unwrap,                                 \
         ccc_fhmap_entry *: ccc_fhm_unwrap,                                     \
         ccc_fhmap_entry const *: ccc_fhm_unwrap,                               \
-        ccc_hhmap_entry *: ccc_hhm_unwrap,                                     \
-        ccc_hhmap_entry const *: ccc_hhm_unwrap,                               \
+        ccc_hhmap_handle *: ccc_hhm_unwrap,                                    \
+        ccc_hhmap_handle const *: ccc_hhm_unwrap,                              \
         ccc_omap_entry *: ccc_om_unwrap,                                       \
         ccc_omap_entry const *: ccc_om_unwrap,                                 \
         ccc_ommap_entry *: ccc_omm_unwrap,                                     \
@@ -281,10 +302,12 @@
     _Generic((container_entry_ptr),                                            \
         ccc_entry *: ccc_entry_occupied,                                       \
         ccc_entry const *: ccc_entry_occupied,                                 \
+        ccc_handle *: ccc_handle_occupied,                                     \
+        ccc_handle const *: ccc_handle_occupied,                               \
         ccc_fhmap_entry *: ccc_fhm_occupied,                                   \
         ccc_fhmap_entry const *: ccc_fhm_occupied,                             \
-        ccc_hhmap_entry *: ccc_hhm_occupied,                                   \
-        ccc_hhmap_entry const *: ccc_hhm_occupied,                             \
+        ccc_hhmap_handle *: ccc_hhm_occupied,                                  \
+        ccc_hhmap_handle const *: ccc_hhm_occupied,                            \
         ccc_omap_entry *: ccc_om_occupied,                                     \
         ccc_omap_entry const *: ccc_om_occupied,                               \
         ccc_ommap_entry *: ccc_omm_occupied,                                   \
@@ -300,10 +323,12 @@
     _Generic((container_entry_ptr),                                            \
         ccc_entry *: ccc_entry_insert_error,                                   \
         ccc_entry const *: ccc_entry_insert_error,                             \
+        ccc_handle *: ccc_handle_insert_error,                                 \
+        ccc_handle const *: ccc_handle_insert_error,                           \
         ccc_fhmap_entry *: ccc_fhm_insert_error,                               \
         ccc_fhmap_entry const *: ccc_fhm_insert_error,                         \
-        ccc_hhmap_entry *: ccc_hhm_insert_error,                               \
-        ccc_hhmap_entry const *: ccc_hhm_insert_error,                         \
+        ccc_hhmap_handle *: ccc_hhm_insert_error,                              \
+        ccc_hhmap_handle const *: ccc_hhm_insert_error,                        \
         ccc_omap_entry *: ccc_om_insert_error,                                 \
         ccc_omap_entry const *: ccc_om_insert_error,                           \
         ccc_ommap_entry *: ccc_omm_insert_error,                               \

--- a/ccc/impl/impl_traits.h
+++ b/ccc/impl/impl_traits.h
@@ -66,10 +66,43 @@
         (container_ptr), insert_or_assign_args)
 
 #define ccc_impl_insert_or_assign_r(container_ptr, insert_or_assign_args...)   \
-    &(ccc_entry)                                                               \
-    {                                                                          \
-        ccc_impl_insert_or_assign(container_ptr, insert_or_assign_args).impl_  \
-    }
+    _Generic((container_ptr),                                                  \
+        ccc_flat_hash_map                                                      \
+            *: &(ccc_entry){ccc_fhm_insert_or_assign(                          \
+                                (ccc_flat_hash_map *)container_ptr,            \
+                                (ccc_fhmap_elem *)insert_or_assign_args)       \
+                                .impl_},                                       \
+        ccc_handle_hash_map                                                    \
+            *: &(ccc_handle){ccc_hhm_insert_or_assign(                         \
+                                 (ccc_handle_hash_map *)container_ptr,         \
+                                 (ccc_hhmap_elem *)insert_or_assign_args)      \
+                                 .impl_},                                      \
+        ccc_ordered_map                                                        \
+            *: &(ccc_entry){ccc_om_insert_or_assign(                           \
+                                (ccc_ordered_map *)container_ptr,              \
+                                (ccc_omap_elem *)insert_or_assign_args)        \
+                                .impl_},                                       \
+        ccc_ordered_multimap                                                   \
+            *: &(ccc_entry){ccc_omm_insert_or_assign(                          \
+                                (ccc_ordered_multimap *)container_ptr,         \
+                                (ccc_ommap_elem *)insert_or_assign_args)       \
+                                .impl_},                                       \
+        ccc_flat_ordered_map                                                   \
+            *: &(ccc_entry){ccc_fom_insert_or_assign(                          \
+                                (ccc_flat_ordered_map *)container_ptr,         \
+                                (ccc_fomap_elem *)insert_or_assign_args)       \
+                                .impl_},                                       \
+        ccc_flat_realtime_ordered_map                                          \
+            *: &(                                                              \
+                ccc_entry){ccc_frm_insert_or_assign(                           \
+                               (ccc_flat_realtime_ordered_map *)container_ptr, \
+                               (ccc_fromap_elem *)insert_or_assign_args)       \
+                               .impl_},                                        \
+        ccc_realtime_ordered_map                                               \
+            *: &(ccc_entry){ccc_rom_insert_or_assign(                          \
+                                (ccc_realtime_ordered_map *)container_ptr,     \
+                                (ccc_romap_elem *)insert_or_assign_args)       \
+                                .impl_})
 
 #define ccc_impl_remove(container_ptr, key_val_container_handle_ptr...)        \
     _Generic((container_ptr),                                                  \
@@ -83,10 +116,46 @@
             *: ccc_rom_remove)((container_ptr), key_val_container_handle_ptr)
 
 #define ccc_impl_remove_r(container_ptr, key_val_container_handle_ptr...)      \
-    &(ccc_entry)                                                               \
-    {                                                                          \
-        ccc_impl_remove(container_ptr, key_val_container_handle_ptr).impl_     \
-    }
+    _Generic((container_ptr),                                                  \
+        ccc_handle_hash_map                                                    \
+            *: &(ccc_handle){ccc_hhm_remove(                                   \
+                                 (ccc_handle_hash_map *)container_ptr,         \
+                                 (ccc_hhmap_elem *)                            \
+                                     key_val_container_handle_ptr)             \
+                                 .impl_},                                      \
+        ccc_flat_hash_map                                                      \
+            *: &(ccc_entry){ccc_fhm_remove((ccc_flat_hash_map *)container_ptr, \
+                                           (ccc_fhmap_elem *)                  \
+                                               key_val_container_handle_ptr)   \
+                                .impl_},                                       \
+        ccc_ordered_map                                                        \
+            *: &(ccc_entry){ccc_om_remove(                                     \
+                                (ccc_ordered_map *)container_ptr,              \
+                                (ccc_omap_elem *)key_val_container_handle_ptr) \
+                                .impl_},                                       \
+        ccc_ordered_multimap                                                   \
+            *: &(                                                              \
+                ccc_entry){ccc_omm_remove(                                     \
+                               (ccc_ordered_multimap *)container_ptr,          \
+                               (ccc_ommap_elem *)key_val_container_handle_ptr) \
+                               .impl_},                                        \
+        ccc_flat_ordered_map                                                   \
+            *: &(                                                              \
+                ccc_entry){ccc_fom_remove(                                     \
+                               (ccc_flat_ordered_map *)container_ptr,          \
+                               (ccc_fomap_elem *)key_val_container_handle_ptr) \
+                               .impl_},                                        \
+        ccc_flat_realtime_ordered_map                                          \
+            *: &(ccc_entry){ccc_frm_remove((ccc_flat_realtime_ordered_map *)   \
+                                               container_ptr,                  \
+                                           (ccc_fromap_elem *)                 \
+                                               key_val_container_handle_ptr)   \
+                                .impl_},                                       \
+        ccc_realtime_ordered_map                                               \
+            *: &(ccc_entry){                                                   \
+                ccc_rom_remove((ccc_realtime_ordered_map *)container_ptr,      \
+                               (ccc_romap_elem *)key_val_container_handle_ptr) \
+                    .impl_})
 
 #define ccc_impl_remove_entry(container_entry_ptr)                             \
     _Generic((container_entry_ptr),                                            \

--- a/ccc/impl/impl_traits.h
+++ b/ccc/impl/impl_traits.h
@@ -9,6 +9,7 @@
 #include "../flat_ordered_map.h"
 #include "../flat_priority_queue.h"
 #include "../flat_realtime_ordered_map.h"
+#include "../handle_hash_map.h"
 #include "../ordered_map.h"
 #include "../ordered_multimap.h"
 #include "../priority_queue.h"
@@ -22,6 +23,7 @@
 #define ccc_impl_insert(container_ptr, insert_args...)                         \
     _Generic((container_ptr),                                                  \
         ccc_flat_hash_map *: ccc_fhm_insert,                                   \
+        ccc_handle_hash_map *: ccc_hhm_insert,                                 \
         ccc_ordered_map *: ccc_om_insert,                                      \
         ccc_ordered_multimap *: ccc_omm_insert,                                \
         ccc_flat_ordered_map *: ccc_fom_insert,                                \
@@ -38,6 +40,7 @@
 #define ccc_impl_try_insert(container_ptr, try_insert_args...)                 \
     _Generic((container_ptr),                                                  \
         ccc_flat_hash_map *: ccc_fhm_try_insert,                               \
+        ccc_handle_hash_map *: ccc_hhm_try_insert,                             \
         ccc_ordered_map *: ccc_om_try_insert,                                  \
         ccc_ordered_multimap *: ccc_omm_try_insert,                            \
         ccc_flat_ordered_map *: ccc_fom_try_insert,                            \
@@ -54,6 +57,7 @@
 #define ccc_impl_insert_or_assign(container_ptr, insert_or_assign_args...)     \
     _Generic((container_ptr),                                                  \
         ccc_flat_hash_map *: ccc_fhm_insert_or_assign,                         \
+        ccc_handle_hash_map *: ccc_hhm_insert_or_assign,                       \
         ccc_ordered_map *: ccc_om_insert_or_assign,                            \
         ccc_ordered_multimap *: ccc_omm_insert_or_assign,                      \
         ccc_flat_ordered_map *: ccc_fom_insert_or_assign,                      \
@@ -70,6 +74,7 @@
 #define ccc_impl_remove(container_ptr, key_val_container_handle_ptr...)        \
     _Generic((container_ptr),                                                  \
         ccc_flat_hash_map *: ccc_fhm_remove,                                   \
+        ccc_handle_hash_map *: ccc_hhm_remove,                                 \
         ccc_ordered_map *: ccc_om_remove,                                      \
         ccc_ordered_multimap *: ccc_omm_remove,                                \
         ccc_flat_ordered_map *: ccc_fom_remove,                                \
@@ -86,12 +91,14 @@
 #define ccc_impl_remove_entry(container_entry_ptr)                             \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_remove_entry,                               \
+        ccc_hhmap_entry *: ccc_hhm_remove_entry,                               \
         ccc_omap_entry *: ccc_om_remove_entry,                                 \
         ccc_ommap_entry *: ccc_omm_remove_entry,                               \
         ccc_fomap_entry *: ccc_fom_remove_entry,                               \
         ccc_fromap_entry *: ccc_frm_remove_entry,                              \
         ccc_romap_entry *: ccc_rom_remove_entry,                               \
         ccc_fhmap_entry const *: ccc_fhm_remove_entry,                         \
+        ccc_hhmap_entry const *: ccc_hhm_remove_entry,                         \
         ccc_fromap_entry const *: ccc_frm_remove_entry,                        \
         ccc_omap_entry const *: ccc_om_remove_entry,                           \
         ccc_fomap_entry const *: ccc_fom_remove_entry,                         \
@@ -107,6 +114,8 @@
     _Generic((container_ptr),                                                  \
         ccc_flat_hash_map *: ccc_fhm_entry,                                    \
         ccc_flat_hash_map const *: ccc_fhm_entry,                              \
+        ccc_handle_hash_map *: ccc_hhm_entry,                                  \
+        ccc_handle_hash_map const *: ccc_hhm_entry,                            \
         ccc_ordered_map *: ccc_om_entry,                                       \
         ccc_ordered_multimap *: ccc_omm_entry,                                 \
         ccc_flat_ordered_map *: ccc_fom_entry,                                 \
@@ -126,6 +135,16 @@
         ccc_flat_hash_map const *: &(                                          \
                  ccc_fhmap_entry){ccc_fhm_entry(                               \
                                       (ccc_flat_hash_map *)(container_ptr),    \
+                                      key_ptr)                                 \
+                                      .impl_},                                 \
+        ccc_handle_hash_map *: &(                                              \
+                 ccc_hhmap_entry){ccc_hhm_entry(                               \
+                                      (ccc_handle_hash_map *)(container_ptr),  \
+                                      key_ptr)                                 \
+                                      .impl_},                                 \
+        ccc_handle_hash_map const *: &(                                        \
+                 ccc_hhmap_entry){ccc_hhm_entry(                               \
+                                      (ccc_handle_hash_map *)(container_ptr),  \
                                       key_ptr)                                 \
                                       .impl_},                                 \
         ccc_ordered_map *: &(                                                  \
@@ -168,12 +187,14 @@
 #define ccc_impl_and_modify(container_entry_ptr, mod_fn)                       \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_and_modify,                                 \
+        ccc_hhmap_entry *: ccc_hhm_and_modify,                                 \
         ccc_omap_entry *: ccc_om_and_modify,                                   \
         ccc_ommap_entry *: ccc_omm_and_modify,                                 \
         ccc_fomap_entry *: ccc_fom_and_modify,                                 \
         ccc_romap_entry *: ccc_rom_and_modify,                                 \
         ccc_fromap_entry *: ccc_frm_and_modify,                                \
         ccc_fhmap_entry const *: ccc_fhm_and_modify,                           \
+        ccc_hhmap_entry const *: ccc_hhm_and_modify,                           \
         ccc_fromap_entry const *: ccc_frm_and_modify,                          \
         ccc_omap_entry const *: ccc_om_and_modify,                             \
         ccc_ommap_entry const *: ccc_omm_and_modify,                           \
@@ -184,12 +205,14 @@
 #define ccc_impl_and_modify_aux(container_entry_ptr, mod_fn, aux_data_ptr...)  \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_and_modify_aux,                             \
+        ccc_hhmap_entry *: ccc_hhm_and_modify_aux,                             \
         ccc_omap_entry *: ccc_om_and_modify_aux,                               \
         ccc_ommap_entry *: ccc_omm_and_modify_aux,                             \
         ccc_fomap_entry *: ccc_fom_and_modify_aux,                             \
         ccc_fromap_entry *: ccc_frm_and_modify_aux,                            \
         ccc_romap_entry *: ccc_rom_and_modify_aux,                             \
         ccc_fhmap_entry const *: ccc_fhm_and_modify_aux,                       \
+        ccc_hhmap_entry const *: ccc_hhm_and_modify_aux,                       \
         ccc_omap_entry const *: ccc_om_and_modify_aux,                         \
         ccc_ommap_entry const *: ccc_omm_and_modify_aux,                       \
         ccc_fromap_entry const *: ccc_frm_and_modify_aux,                      \
@@ -201,12 +224,14 @@
                               key_val_container_handle_ptr...)                 \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_insert_entry,                               \
+        ccc_hhmap_entry *: ccc_hhm_insert_entry,                               \
         ccc_omap_entry *: ccc_om_insert_entry,                                 \
         ccc_ommap_entry *: ccc_omm_insert_entry,                               \
         ccc_fomap_entry *: ccc_fom_insert_entry,                               \
         ccc_romap_entry *: ccc_rom_insert_entry,                               \
         ccc_fromap_entry *: ccc_frm_insert_entry,                              \
         ccc_fhmap_entry const *: ccc_fhm_insert_entry,                         \
+        ccc_hhmap_entry const *: ccc_hhm_insert_entry,                         \
         ccc_omap_entry const *: ccc_om_insert_entry,                           \
         ccc_ommap_entry const *: ccc_omm_insert_entry,                         \
         ccc_fomap_entry const *: ccc_fom_insert_entry,                         \
@@ -218,12 +243,14 @@
                            key_val_container_handle_ptr...)                    \
     _Generic((container_entry_ptr),                                            \
         ccc_fhmap_entry *: ccc_fhm_or_insert,                                  \
+        ccc_hhmap_entry *: ccc_hhm_or_insert,                                  \
         ccc_omap_entry *: ccc_om_or_insert,                                    \
         ccc_ommap_entry *: ccc_omm_or_insert,                                  \
         ccc_fomap_entry *: ccc_fom_or_insert,                                  \
         ccc_romap_entry *: ccc_rom_or_insert,                                  \
         ccc_fromap_entry *: ccc_frm_or_insert,                                 \
         ccc_fhmap_entry const *: ccc_fhm_or_insert,                            \
+        ccc_hhmap_entry const *: ccc_hhm_or_insert,                            \
         ccc_omap_entry const *: ccc_om_or_insert,                              \
         ccc_ommap_entry const *: ccc_omm_or_insert,                            \
         ccc_fromap_entry const *: ccc_frm_or_insert,                           \
@@ -237,6 +264,8 @@
         ccc_entry const *: ccc_entry_unwrap,                                   \
         ccc_fhmap_entry *: ccc_fhm_unwrap,                                     \
         ccc_fhmap_entry const *: ccc_fhm_unwrap,                               \
+        ccc_hhmap_entry *: ccc_hhm_unwrap,                                     \
+        ccc_hhmap_entry const *: ccc_hhm_unwrap,                               \
         ccc_omap_entry *: ccc_om_unwrap,                                       \
         ccc_omap_entry const *: ccc_om_unwrap,                                 \
         ccc_ommap_entry *: ccc_omm_unwrap,                                     \
@@ -254,6 +283,8 @@
         ccc_entry const *: ccc_entry_occupied,                                 \
         ccc_fhmap_entry *: ccc_fhm_occupied,                                   \
         ccc_fhmap_entry const *: ccc_fhm_occupied,                             \
+        ccc_hhmap_entry *: ccc_hhm_occupied,                                   \
+        ccc_hhmap_entry const *: ccc_hhm_occupied,                             \
         ccc_omap_entry *: ccc_om_occupied,                                     \
         ccc_omap_entry const *: ccc_om_occupied,                               \
         ccc_ommap_entry *: ccc_omm_occupied,                                   \
@@ -271,6 +302,8 @@
         ccc_entry const *: ccc_entry_insert_error,                             \
         ccc_fhmap_entry *: ccc_fhm_insert_error,                               \
         ccc_fhmap_entry const *: ccc_fhm_insert_error,                         \
+        ccc_hhmap_entry *: ccc_hhm_insert_error,                               \
+        ccc_hhmap_entry const *: ccc_hhm_insert_error,                         \
         ccc_omap_entry *: ccc_om_insert_error,                                 \
         ccc_omap_entry const *: ccc_om_insert_error,                           \
         ccc_ommap_entry *: ccc_omm_insert_error,                               \
@@ -288,6 +321,8 @@
     _Generic((container_ptr),                                                  \
         ccc_flat_hash_map *: ccc_fhm_get_key_val,                              \
         ccc_flat_hash_map const *: ccc_fhm_get_key_val,                        \
+        ccc_handle_hash_map *: ccc_hhm_get_key_val,                            \
+        ccc_handle_hash_map const *: ccc_hhm_get_key_val,                      \
         ccc_ordered_map *: ccc_om_get_key_val,                                 \
         ccc_ordered_multimap *: ccc_omm_get_key_val,                           \
         ccc_flat_ordered_map *: ccc_fom_get_key_val,                           \
@@ -301,6 +336,8 @@
     _Generic((container_ptr),                                                  \
         ccc_flat_hash_map *: ccc_fhm_contains,                                 \
         ccc_flat_hash_map const *: ccc_fhm_contains,                           \
+        ccc_handle_hash_map *: ccc_hhm_contains,                               \
+        ccc_handle_hash_map const *: ccc_hhm_contains,                         \
         ccc_ordered_map *: ccc_om_contains,                                    \
         ccc_flat_ordered_map *: ccc_fom_contains,                              \
         ccc_flat_realtime_ordered_map *: ccc_frm_contains,                     \
@@ -595,6 +632,7 @@
     _Generic((container_ptr),                                                  \
         ccc_buffer *: ccc_buf_size,                                            \
         ccc_flat_hash_map *: ccc_fhm_size,                                     \
+        ccc_handle_hash_map *: ccc_hhm_size,                                   \
         ccc_ordered_map *: ccc_om_size,                                        \
         ccc_flat_ordered_map *: ccc_fom_size,                                  \
         ccc_flat_priority_queue *: ccc_fpq_size,                               \
@@ -607,6 +645,7 @@
         ccc_flat_realtime_ordered_map *: ccc_frm_size,                         \
         ccc_buffer const *: ccc_buf_size,                                      \
         ccc_flat_hash_map const *: ccc_fhm_size,                               \
+        ccc_handle_hash_map const *: ccc_hhm_size,                             \
         ccc_ordered_map const *: ccc_om_size,                                  \
         ccc_flat_ordered_map const *: ccc_fom_size,                            \
         ccc_flat_priority_queue const *: ccc_fpq_size,                         \
@@ -622,6 +661,7 @@
     _Generic((container_ptr),                                                  \
         ccc_buffer *: ccc_buf_is_empty,                                        \
         ccc_flat_hash_map *: ccc_fhm_is_empty,                                 \
+        ccc_handle_hash_map *: ccc_hhm_is_empty,                               \
         ccc_ordered_map *: ccc_om_is_empty,                                    \
         ccc_flat_ordered_map *: ccc_fom_is_empty,                              \
         ccc_flat_priority_queue *: ccc_fpq_is_empty,                           \
@@ -634,6 +674,7 @@
         ccc_flat_realtime_ordered_map *: ccc_frm_is_empty,                     \
         ccc_buffer const *: ccc_buf_is_empty,                                  \
         ccc_flat_hash_map const *: ccc_fhm_is_empty,                           \
+        ccc_handle_hash_map const *: ccc_hhm_is_empty,                         \
         ccc_ordered_map const *: ccc_om_is_empty,                              \
         ccc_flat_ordered_map const *: ccc_fom_is_empty,                        \
         ccc_flat_priority_queue const *: ccc_fpq_is_empty,                     \
@@ -648,6 +689,7 @@
 #define ccc_impl_validate(container_ptr)                                       \
     _Generic((container_ptr),                                                  \
         ccc_flat_hash_map *: ccc_fhm_validate,                                 \
+        ccc_handle_hash_map *: ccc_hhm_validate,                               \
         ccc_ordered_map *: ccc_om_validate,                                    \
         ccc_flat_ordered_map *: ccc_fom_validate,                              \
         ccc_flat_priority_queue *: ccc_fpq_validate,                           \
@@ -659,6 +701,7 @@
         ccc_realtime_ordered_map *: ccc_rom_validate,                          \
         ccc_flat_realtime_ordered_map *: ccc_frm_validate,                     \
         ccc_flat_hash_map const *: ccc_fhm_validate,                           \
+        ccc_handle_hash_map const *: ccc_hhm_validate,                         \
         ccc_ordered_map const *: ccc_om_validate,                              \
         ccc_flat_ordered_map const *: ccc_fom_validate,                        \
         ccc_flat_priority_queue const *: ccc_fpq_validate,                     \
@@ -669,31 +712,5 @@
         ccc_doubly_linked_list const *: ccc_dll_validate,                      \
         ccc_flat_realtime_ordered_map const *: ccc_frm_validate,               \
         ccc_realtime_ordered_map const *: ccc_rom_validate)((container_ptr))
-
-#define ccc_impl_print(container_ptr, printer_fn)                              \
-    _Generic((container_ptr),                                                  \
-        ccc_flat_hash_map *: ccc_fhm_print,                                    \
-        ccc_ordered_map *: ccc_om_print,                                       \
-        ccc_flat_ordered_map *: ccc_fom_print,                                 \
-        ccc_flat_priority_queue *: ccc_fpq_print,                              \
-        ccc_flat_double_ended_queue *: ccc_fdeq_print,                         \
-        ccc_ordered_multimap *: ccc_omm_print,                                 \
-        ccc_priority_queue *: ccc_pq_print,                                    \
-        ccc_singly_linked_list *: ccc_sll_print,                               \
-        ccc_doubly_linked_list *: ccc_dll_print,                               \
-        ccc_realtime_ordered_map *: ccc_rom_print,                             \
-        ccc_flat_realtime_ordered_map *: ccc_frm_print,                        \
-        ccc_flat_hash_map const *: ccc_fhm_print,                              \
-        ccc_ordered_map const *: ccc_om_print,                                 \
-        ccc_flat_ordered_map const *: ccc_fom_print,                           \
-        ccc_flat_priority_queue const *: ccc_fpq_print,                        \
-        ccc_flat_double_ended_queue const *: ccc_fdeq_print,                   \
-        ccc_ordered_multimap const *: ccc_omm_print,                           \
-        ccc_priority_queue const *: ccc_pq_print,                              \
-        ccc_singly_linked_list const *: ccc_sll_print,                         \
-        ccc_doubly_linked_list const *: ccc_dll_print,                         \
-        ccc_flat_realtime_ordered_map const *: ccc_frm_print,                  \
-        ccc_realtime_ordered_map const *: ccc_rom_print)((container_ptr),      \
-                                                         (printer_fn))
 
 #endif /* CCC_IMPL_TRAITS_H */

--- a/ccc/impl/impl_types.h
+++ b/ccc/impl/impl_types.h
@@ -9,13 +9,13 @@
 /** @private */
 enum ccc_entry_status_ : uint8_t
 {
-    CCC_ENTRY_VACANT = 0,
-    CCC_ENTRY_OCCUPIED = 0x1,
-    CCC_ENTRY_INSERT_ERROR = 0x2,
-    CCC_ENTRY_SEARCH_ERROR = 0x4,
-    CCC_ENTRY_DELETE_ERROR = 0x8,
-    CCC_ENTRY_INPUT_ERROR = 0x10,
-    CCC_ENTRY_NO_UNWRAP = 0x20,
+    CCC_VACANT = 0,
+    CCC_OCCUPIED = 0x1,
+    CCC_INSERT_ERROR = 0x2,
+    CCC_SEARCH_ERROR = 0x4,
+    CCC_DELETE_ERROR = 0x8,
+    CCC_INPUT_ERROR = 0x10,
+    CCC_NO_UNWRAP = 0x20,
 };
 
 /** @private */

--- a/ccc/impl/impl_types.h
+++ b/ccc/impl/impl_types.h
@@ -2,6 +2,7 @@
 #define CCC_IMPL_TYPES_H
 
 /** @cond */
+#include <stddef.h>
 #include <stdint.h>
 /** @endcond */
 
@@ -28,6 +29,19 @@ struct ccc_ent_
 union ccc_entry_
 {
     struct ccc_ent_ impl_;
+};
+
+/** @private */
+struct ccc_handl_
+{
+    size_t i_;
+    enum ccc_entry_status_ stats_;
+};
+
+/** @private */
+union ccc_handle_
+{
+    struct ccc_handl_ impl_;
 };
 
 /** @private */

--- a/ccc/traits.h
+++ b/ccc/traits.h
@@ -108,6 +108,15 @@ See container documentation for specific behavior. */
 #define ccc_entry(container_ptr, key_ptr...)                                   \
     ccc_impl_entry(container_ptr, key_ptr)
 
+/** @brief Obtain a container specific handle for the handle Interface.
+@param [in] container_ptr a pointer to the container.
+@param [in] key_ptr a pointer to the search key.
+@return a container specific handle depending on container specific context.
+
+See container documentation for specific behavior. */
+#define ccc_handle(container_ptr, key_ptr...)                                  \
+    ccc_impl_handle(container_ptr, key_ptr)
+
 /** @brief Obtain a container specific entry for the Entry Interface.
 @param [in] container_ptr a pointer to the container.
 @param [in] key_ptr a pointer to the search key.
@@ -117,6 +126,16 @@ context.
 See container documentation for specific behavior. */
 #define ccc_entry_r(container_ptr, key_ptr...)                                 \
     ccc_impl_entry_r(container_ptr, key_ptr)
+
+/** @brief Obtain a container specific handle for the handle Interface.
+@param [in] container_ptr a pointer to the container.
+@param [in] key_ptr a pointer to the search key.
+@return a container specific handle reference depending on container specific
+context.
+
+See container documentation for specific behavior. */
+#define ccc_handle_r(container_ptr, key_ptr...)                                \
+    ccc_impl_handle_r(container_ptr, key_ptr)
 
 /** @brief Modify an entry if Occupied.
 @param [in] entry_ptr a pointer to the container.
@@ -144,6 +163,15 @@ See container documentation for specific behavior. */
 See container documentation for specific behavior. */
 #define ccc_insert_entry(entry_ptr, insert_entry_args...)                      \
     ccc_impl_insert_entry(entry_ptr, insert_entry_args)
+
+/** @brief Insert new element or overwrite old element.
+@param [in] handle_ptr a pointer to the container.
+@param insert_handle_args args depend on container.
+@return an reference to the inserted element.
+
+See container documentation for specific behavior. */
+#define ccc_insert_handle(handle_ptr, insert_handle_args...)                   \
+    ccc_impl_insert_handle(handle_ptr, insert_handle_args)
 
 /** @brief Insert new element if the entry is Vacant.
 @param [in] entry_ptr a pointer to the container.
@@ -483,10 +511,15 @@ See container documentation for specific behavior. */
 #    define remove_r(args...) ccc_remove_r(args)
 #    define remove_entry(args...) ccc_remove_entry(args)
 #    define remove_entry_r(args...) ccc_remove_entry_r(args)
+#    define remove_handle(args...) ccc_remove_handle(args)
+#    define remove_handle_r(args...) ccc_remove_handle_r(args)
 #    define entry(args...) ccc_entry(args)
 #    define entry_r(args...) ccc_entry_r(args)
+#    define handle(args...) ccc_handle(args)
+#    define handle_r(args...) ccc_handle_r(args)
 #    define or_insert(args...) ccc_or_insert(args)
 #    define insert_entry(args...) ccc_insert_entry(args)
+#    define insert_handle(args...) ccc_insert_handle(args)
 #    define and_modify(args...) ccc_and_modify(args)
 #    define and_modify_aux(args...) ccc_and_modify_aux(args)
 #    define occupied(args...) ccc_occupied(args)

--- a/ccc/traits.h
+++ b/ccc/traits.h
@@ -196,6 +196,20 @@ See container documentation for specific behavior. */
 See container documentation for specific behavior. */
 #define ccc_remove_entry_r(entry_ptr) ccc_impl_remove_entry_r(entry_ptr)
 
+/** @brief Remove the element if the handle is Occupied.
+@param [in] handle_ptr a pointer to the container.
+@return an handle depending on container specific context.
+
+See container documentation for specific behavior. */
+#define ccc_remove_handle(handle_ptr) ccc_impl_remove_handle(handle_ptr)
+
+/** @brief Remove the element if the handle is Occupied.
+@param [in] handle_ptr a pointer to the container.
+@return an handle depending on container specific context.
+
+See container documentation for specific behavior. */
+#define ccc_remove_handle_r(handle_ptr) ccc_impl_remove_handle_r(handle_ptr)
+
 /** @brief Unwrap user type in entry.
 @param [in] entry_ptr a pointer to the container.
 @return a valid reference if Occupied or NULL if vacant.
@@ -505,6 +519,7 @@ See container documentation for specific behavior. */
 #    define insert(args...) ccc_insert(args)
 #    define try_insert(args...) ccc_try_insert(args)
 #    define insert_or_assign(args...) ccc_insert_or_assign(args)
+#    define insert_or_assign_r(args...) ccc_insert_or_assign_r(args)
 #    define try_insert_r(args...) ccc_try_insert_r(args)
 #    define insert_r(args...) ccc_insert_r(args)
 #    define remove(args...) ccc_remove(args)

--- a/ccc/types.h
+++ b/ccc/types.h
@@ -98,7 +98,7 @@ additional information while still maintaining the truthy and falsey bool
 behavior one would normally expect. */
 typedef enum : int8_t
 {
-    /** Intended value of CCC_FALSE or CCC_TRUE could not be returned. */
+    /** Intended value if CCC_FALSE or CCC_TRUE could not be returned. */
     CCC_BOOL_ERR = -1,
     /** Equivalent to boolean false, guaranteed to be falsey aka 0. */
     CCC_FALSE,

--- a/ccc/types.h
+++ b/ccc/types.h
@@ -21,6 +21,18 @@ the allocation function interface. */
 Types used across many containers. */
 /**@{*/
 
+/** @brief A stable index to user data in a container that uses a flat array as
+the underlying storage method.
+
+User data at a handle position in an array remains valid until that element is
+removed from the container. This means that resizing of the underlying array
+may occur, but the handle index remains valid regardless.
+
+This is similar to pointer stability except that pointers would not remain valid
+when the underlying array is resized; a handle remains valid because it is an
+index not a pointer. */
+typedef size_t ccc_handle;
+
 /** @brief The result of a range query on iterable containers.
 
 A range provides a view all elements that fit the equals range criteria

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -207,9 +207,9 @@ ccc_bs_shiftl(ccc_bitset *const bs, size_t const left_shifts)
     else
     {
         blockwidth_t const remaining_shift = BLOCK_BITS - partial_shift;
-        for (size_t shifted = last_block - shifted_blocks + 1,
+        for (size_t shifted = last_block - shifted_blocks,
                     overwritten = last_block;
-             shifted--; --overwritten)
+             shifted > 0; --shifted, --overwritten)
         {
             bs->mem_[overwritten]
                 = (bs->mem_[shifted] << partial_shift)

--- a/src/flat_ordered_map.c
+++ b/src/flat_ordered_map.c
@@ -122,7 +122,7 @@ ccc_fom_entry(ccc_flat_ordered_map *const fom, void const *const key)
 {
     if (!fom || !key)
     {
-        return (ccc_fomap_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_fomap_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     return (ccc_fomap_entry){entry(fom, key)};
 }
@@ -134,7 +134,7 @@ ccc_fom_insert_entry(ccc_fomap_entry const *const e, ccc_fomap_elem *const elem)
     {
         return NULL;
     }
-    if (e->impl_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.stats_ == CCC_OCCUPIED)
     {
         *elem = *at(e->impl_.fom_, e->impl_.i_);
         void *const ret = base_at(e->impl_.fom_, e->impl_.i_);
@@ -152,7 +152,7 @@ ccc_fom_and_modify(ccc_fomap_entry *const e, ccc_update_fn *const fn)
     {
         return NULL;
     }
-    if (fn && e->impl_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (fn && e->impl_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){
             .user_type = base_at(e->impl_.fom_, e->impl_.i_),
@@ -170,7 +170,7 @@ ccc_fom_and_modify_aux(ccc_fomap_entry *const e, ccc_update_fn *const fn,
     {
         return NULL;
     }
-    if (fn && e->impl_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (fn && e->impl_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){
             .user_type = base_at(e->impl_.fom_, e->impl_.i_),
@@ -187,7 +187,7 @@ ccc_fom_or_insert(ccc_fomap_entry const *const e, ccc_fomap_elem *const elem)
     {
         return NULL;
     }
-    if (e->impl_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e->impl_.stats_ & CCC_OCCUPIED)
     {
         return base_at(e->impl_.fom_, e->impl_.i_);
     }
@@ -200,7 +200,7 @@ ccc_fom_insert(ccc_flat_ordered_map *const fom,
 {
     if (!fom || !out_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     void *const found = find(fom, key_from_node(fom, out_handle));
     if (found)
@@ -211,14 +211,14 @@ ccc_fom_insert(ccc_flat_ordered_map *const fom,
         void *const ret = base_at(fom, fom->root_);
         void *const tmp = ccc_buf_at(&fom->buf_, 0);
         swap(tmp, user_struct, ret, ccc_buf_elem_size(&fom->buf_));
-        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted = maybe_alloc_insert(fom, out_handle);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -227,20 +227,20 @@ ccc_fom_try_insert(ccc_flat_ordered_map *const fom,
 {
     if (!fom || !key_val_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     void *const found = find(fom, key_from_node(fom, key_val_handle));
     if (found)
     {
         assert(fom->root_);
-        return (ccc_entry){{.e_ = found, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = found, .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted = maybe_alloc_insert(fom, key_val_handle);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -249,7 +249,7 @@ ccc_fom_insert_or_assign(ccc_flat_ordered_map *const fom,
 {
     if (!fom || !key_val_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     void *const found = find(fom, key_from_node(fom, key_val_handle));
     if (found)
@@ -258,14 +258,14 @@ ccc_fom_insert_or_assign(ccc_flat_ordered_map *const fom,
         assert(fom->root_);
         memcpy(found, struct_base(fom, key_val_handle),
                ccc_buf_elem_size(&fom->buf_));
-        return (ccc_entry){{.e_ = found, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = found, .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted = maybe_alloc_insert(fom, key_val_handle);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -274,14 +274,14 @@ ccc_fom_remove(ccc_flat_ordered_map *const fom,
 {
     if (!fom || !out_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     void *const n = erase(fom, key_from_node(fom, out_handle));
     if (!n)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
     }
-    return (ccc_entry){{.e_ = n, .stats_ = CCC_ENTRY_OCCUPIED}};
+    return (ccc_entry){{.e_ = n, .stats_ = CCC_OCCUPIED}};
 }
 
 ccc_entry
@@ -289,16 +289,16 @@ ccc_fom_remove_entry(ccc_fomap_entry *const e)
 {
     if (!e)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
-    if (e->impl_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.stats_ == CCC_OCCUPIED)
     {
         void *const erased
             = erase(e->impl_.fom_, key_at(e->impl_.fom_, e->impl_.i_));
         assert(erased);
-        return (ccc_entry){{.e_ = erased, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = erased, .stats_ = CCC_OCCUPIED}};
     }
-    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 void *
@@ -308,27 +308,26 @@ ccc_fom_unwrap(ccc_fomap_entry const *const e)
     {
         return NULL;
     }
-    return e->impl_.stats_ == CCC_ENTRY_OCCUPIED
-               ? base_at(e->impl_.fom_, e->impl_.i_)
-               : NULL;
+    return e->impl_.stats_ == CCC_OCCUPIED ? base_at(e->impl_.fom_, e->impl_.i_)
+                                           : NULL;
 }
 
 bool
 ccc_fom_insert_error(ccc_fomap_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_INSERT_ERROR : false;
+    return e ? e->impl_.stats_ & CCC_INSERT_ERROR : false;
 }
 
 bool
 ccc_fom_occupied(ccc_fomap_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_OCCUPIED : false;
+    return e ? e->impl_.stats_ & CCC_OCCUPIED : false;
 }
 
 ccc_entry_status
 ccc_fom_entry_status(ccc_fomap_entry const *const e)
 {
-    return e ? e->impl_.stats_ : CCC_ENTRY_INPUT_ERROR;
+    return e ? e->impl_.stats_ : CCC_INPUT_ERROR;
 }
 
 bool
@@ -621,13 +620,13 @@ entry(struct ccc_fomap_ *const fom, void const *const key)
         return (struct ccc_ftree_entry_){
             .fom_ = fom,
             .i_ = ccc_buf_i(&fom->buf_, found),
-            .stats_ = CCC_ENTRY_OCCUPIED,
+            .stats_ = CCC_OCCUPIED,
         };
     }
     return (struct ccc_ftree_entry_){
         .fom_ = fom,
         .i_ = 0,
-        .stats_ = CCC_ENTRY_VACANT,
+        .stats_ = CCC_VACANT,
     };
 }
 

--- a/src/flat_realtime_ordered_map.c
+++ b/src/flat_realtime_ordered_map.c
@@ -180,7 +180,7 @@ ccc_frm_insert(ccc_flat_realtime_ordered_map *const frm,
 {
     if (!frm || !out_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     struct frm_query_ const q = find(frm, key_from_node(frm, out_handle));
     if (CCC_EQL == q.last_cmp_)
@@ -191,13 +191,13 @@ ccc_frm_insert(ccc_flat_realtime_ordered_map *const frm,
         void *const tmp = ccc_buf_at(&frm->buf_, 0);
         swap(tmp, user_struct, slot, ccc_buf_elem_size(&frm->buf_));
         elem_in_slot(frm, tmp)->parity_ = 1;
-        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_OCCUPIED}};
     }
     if (!maybe_alloc_insert(frm, q.parent_, q.last_cmp_, out_handle))
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -206,21 +206,21 @@ ccc_frm_try_insert(ccc_flat_realtime_ordered_map *const frm,
 {
     if (!frm || !key_val_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     struct frm_query_ const q = find(frm, key_from_node(frm, key_val_handle));
     if (CCC_EQL == q.last_cmp_)
     {
         return (ccc_entry){
-            {.e_ = base_at(frm, q.found_), .stats_ = CCC_ENTRY_OCCUPIED}};
+            {.e_ = base_at(frm, q.found_), .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted
         = maybe_alloc_insert(frm, q.parent_, q.last_cmp_, key_val_handle);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -229,7 +229,7 @@ ccc_frm_insert_or_assign(ccc_flat_realtime_ordered_map *const frm,
 {
     if (!frm || !key_val_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     struct frm_query_ const q = find(frm, key_from_node(frm, key_val_handle));
     if (CCC_EQL == q.last_cmp_)
@@ -238,21 +238,21 @@ ccc_frm_insert_or_assign(ccc_flat_realtime_ordered_map *const frm,
         *key_val_handle = *elem_in_slot(frm, found);
         (void)ccc_buf_write(&frm->buf_, q.found_,
                             struct_base(frm, key_val_handle));
-        return (ccc_entry){{.e_ = found, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = found, .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted
         = maybe_alloc_insert(frm, q.parent_, q.last_cmp_, key_val_handle);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_VACANT}};
 }
 
 ccc_fromap_entry *
 ccc_frm_and_modify(ccc_fromap_entry *const e, ccc_update_fn *const fn)
 {
-    if (e && fn && e->impl_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e && fn && e->impl_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){.user_type = base_at(e->impl_.frm_, e->impl_.i_),
                            NULL});
@@ -264,7 +264,7 @@ ccc_fromap_entry *
 ccc_frm_and_modify_aux(ccc_fromap_entry *const e, ccc_update_fn *const fn,
                        void *const aux)
 {
-    if (e && fn && e->impl_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e && fn && e->impl_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){.user_type = base_at(e->impl_.frm_, e->impl_.i_),
                            aux});
@@ -279,7 +279,7 @@ ccc_frm_or_insert(ccc_fromap_entry const *const e, ccc_fromap_elem *const elem)
     {
         return NULL;
     }
-    if (e->impl_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.stats_ == CCC_OCCUPIED)
     {
         return base_at(e->impl_.frm_, e->impl_.i_);
     }
@@ -295,7 +295,7 @@ ccc_frm_insert_entry(ccc_fromap_entry const *const e,
     {
         return NULL;
     }
-    if (e->impl_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.stats_ == CCC_OCCUPIED)
     {
         void *const ret = base_at(e->impl_.frm_, e->impl_.i_);
         *elem = *elem_in_slot(e->impl_.frm_, ret);
@@ -313,7 +313,7 @@ ccc_frm_entry(ccc_flat_realtime_ordered_map const *const frm,
 {
     if (!frm || !key)
     {
-        return (ccc_fromap_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_fromap_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     return (ccc_fromap_entry){entry(frm, key)};
 }
@@ -323,15 +323,15 @@ ccc_frm_remove_entry(ccc_fromap_entry const *const e)
 {
     if (!e)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
-    if (e->impl_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.stats_ == CCC_OCCUPIED)
     {
         void *const erased = remove_fixup(e->impl_.frm_, e->impl_.i_);
         assert(erased);
-        return (ccc_entry){{.e_ = erased, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = erased, .stats_ = CCC_OCCUPIED}};
     }
-    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -340,18 +340,18 @@ ccc_frm_remove(ccc_flat_realtime_ordered_map *const frm,
 {
     if (!frm || !out_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     struct frm_query_ const q = find(frm, key_from_node(frm, out_handle));
     if (q.last_cmp_ != CCC_EQL)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
     }
     void const *const removed = remove_fixup(frm, q.found_);
     assert(removed);
     void *const user_struct = struct_base(frm, out_handle);
     (void)memcpy(user_struct, removed, ccc_buf_elem_size(&frm->buf_));
-    return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_ENTRY_OCCUPIED}};
+    return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_OCCUPIED}};
 }
 
 ccc_range
@@ -380,7 +380,7 @@ ccc_frm_equal_rrange(ccc_flat_realtime_ordered_map const *const frm,
 void *
 ccc_frm_unwrap(ccc_fromap_entry const *const e)
 {
-    if (e && e->impl_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e && e->impl_.stats_ & CCC_OCCUPIED)
     {
         return ccc_buf_at(&e->impl_.frm_->buf_, e->impl_.i_);
     }
@@ -390,19 +390,19 @@ ccc_frm_unwrap(ccc_fromap_entry const *const e)
 bool
 ccc_frm_insert_error(ccc_fromap_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_INSERT_ERROR : false;
+    return e ? e->impl_.stats_ & CCC_INSERT_ERROR : false;
 }
 
 bool
 ccc_frm_occupied(ccc_fromap_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_OCCUPIED : false;
+    return e ? e->impl_.stats_ & CCC_OCCUPIED : false;
 }
 
 ccc_entry_status
 ccc_frm_entry_status(ccc_fromap_entry const *const e)
 {
-    return e ? e->impl_.stats_ : CCC_ENTRY_INPUT_ERROR;
+    return e ? e->impl_.stats_ : CCC_INPUT_ERROR;
 }
 
 bool
@@ -683,14 +683,14 @@ entry(struct ccc_fromap_ const *const frm, void const *const key)
             .frm_ = (struct ccc_fromap_ *)frm,
             .last_cmp_ = q.last_cmp_,
             .i_ = q.found_,
-            .stats_ = CCC_ENTRY_OCCUPIED,
+            .stats_ = CCC_OCCUPIED,
         };
     }
     return (struct ccc_frtree_entry_){
         .frm_ = (struct ccc_fromap_ *)frm,
         .last_cmp_ = q.last_cmp_,
         .i_ = q.parent_,
-        .stats_ = CCC_ENTRY_NO_UNWRAP | CCC_ENTRY_VACANT,
+        .stats_ = CCC_NO_UNWRAP | CCC_VACANT,
     };
 }
 

--- a/src/handle_hash_map.c
+++ b/src/handle_hash_map.c
@@ -1,0 +1,1288 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "buffer.h"
+#include "handle_hash_map.h"
+#include "impl/impl_handle_hash_map.h"
+#include "impl/impl_types.h"
+#include "types.h"
+
+#if defined(__GNUC__) || defined(__clang__)
+#    define unlikely(expr) __builtin_expect(!!(expr), 0)
+#    define likely(expr) __builtin_expect(!!(expr), 1)
+#else
+#    define unlikely(expr) expr
+#    define likely(expr) expr
+#endif
+
+/* We are fairly close to the maximum 64 bit address space size by the last
+   prime so we will stop there as max size if we ever get there. Not likely.
+   The last prime is closer to the second to last because doubling breaks down
+   at the end. */
+#define PRIMES_SIZE 58ULL
+static size_t const primes[PRIMES_SIZE] = {
+    11ULL,
+    37ULL,
+    79ULL,
+    163ULL,
+    331ULL,
+    691ULL,
+    1439ULL,
+    2999ULL,
+    6079ULL,
+    12263ULL,
+    25717ULL,
+    53611ULL,
+    111697ULL,
+    232499ULL,
+    483611ULL,
+    1005761ULL,
+    2091191ULL,
+    4347799ULL,
+    9039167ULL,
+    18792019ULL,
+    39067739ULL,
+    81219493ULL,
+    168849973ULL,
+    351027263ULL,
+    729760741ULL,
+    1517120861ULL,
+    3153985903ULL,
+    6556911073ULL,
+    13631348041ULL,
+    28338593999ULL,
+    58913902231ULL,
+    122477772247ULL,
+    254622492793ULL,
+    529341875947ULL,
+    1100463743389ULL,
+    2287785087839ULL,
+    4756140888377ULL,
+    9887675318611ULL,
+    20555766849589ULL,
+    42733962953639ULL,
+    88840839803449ULL,
+    184693725350723ULL,
+    383964990193007ULL,
+    798235638020831ULL,
+    1659474561692683ULL,
+    3449928429320413ULL,
+    7172153428667531ULL,
+    14910391869919981ULL,
+    30997633824443711ULL,
+    64441854452711651ULL,
+    133969987155270011ULL,
+    278513981492471381ULL,
+    579010564484755961ULL,
+    1203721378684243091ULL,
+    2502450294306576181ULL,
+    5202414434410211531ULL,
+    10815445968671840317ULL,
+    17617221824571301183ULL,
+};
+
+/* Some claim that Robin Hood tables can support a much higher load factor. I
+   would not be so sure. The primary clustering effect in these types of
+   tables can quickly rise. Mitigating with a lower load factor and prime
+   table sizes is a decent approach. Measure. */
+static double const load_factor = 0.8;
+static size_t const last_swap_slot = 1;
+static size_t const num_swap_slots = 2;
+
+/*=========================   Prototypes   ==================================*/
+
+static void erase(struct ccc_hhmap_ *, size_t e);
+static void swap_user_data(struct ccc_hhmap_ *, void *, void *);
+static void swap_meta_data(struct ccc_hhmap_ *h, struct ccc_hhmap_elem_ *a,
+                           struct ccc_hhmap_elem_ *b);
+static void *struct_base(struct ccc_hhmap_ const *,
+                         struct ccc_hhmap_elem_ const *);
+static struct ccc_handle_ entry(struct ccc_hhmap_ *, void const *key,
+                                uint64_t hash);
+static struct ccc_hhash_entry_ container_entry(struct ccc_hhmap_ *h,
+                                               void const *key);
+static struct ccc_hhash_entry_ *and_modify(struct ccc_hhash_entry_ *e,
+                                           ccc_update_fn *fn);
+static bool valid_distance_from_home(struct ccc_hhmap_ const *,
+                                     void const *slot);
+static size_t to_i(size_t capacity, uint64_t hash);
+static size_t increment(size_t capacity, size_t i);
+static size_t decrement(size_t capacity, size_t i);
+static size_t distance(size_t capacity, size_t i, size_t j);
+static void *key_in_slot(struct ccc_hhmap_ const *h, void const *slot);
+static struct ccc_hhmap_elem_ *elem_in_slot(struct ccc_hhmap_ const *h,
+                                            void const *slot);
+static struct ccc_hhmap_elem_ *elem_at(struct ccc_hhmap_ const *h, size_t i);
+static ccc_result maybe_resize(struct ccc_hhmap_ *h);
+static struct ccc_handle_ find(struct ccc_hhmap_ const *h, void const *key,
+                               uint64_t hash);
+static void insert(struct ccc_hhmap_ *h, void const *e, uint64_t hash,
+                   size_t i);
+static uint64_t *hash_at(struct ccc_hhmap_ const *h, size_t i);
+static uint64_t filter(struct ccc_hhmap_ const *h, void const *key);
+static size_t next_prime(size_t n);
+static void copy_to_slot(struct ccc_hhmap_ *h, void *slot_dst,
+                         void const *user_src);
+
+/*=========================   Interface    ==================================*/
+
+bool
+ccc_hhm_is_empty(ccc_handle_hash_map const *const h)
+{
+    if (unlikely(!h))
+    {
+        return true;
+    }
+    return !ccc_hhm_size(h);
+}
+
+bool
+ccc_hhm_contains(ccc_handle_hash_map *const h, void const *const key)
+{
+    if (unlikely(!h || !key))
+    {
+        return 0;
+    }
+    return entry(h, key, filter(h, key)).i_;
+}
+
+size_t
+ccc_hhm_size(ccc_handle_hash_map const *const h)
+{
+    if (unlikely(!h))
+    {
+        return 0;
+    }
+    size_t const size = ccc_buf_size(&h->buf_);
+    return size ? size - num_swap_slots : 0;
+}
+
+ccc_hhmap_entry
+ccc_hhm_entry(ccc_handle_hash_map *const h, void const *const key)
+{
+    if (unlikely(!h || !key))
+    {
+        return (ccc_hhmap_entry){{.entry_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}}};
+    }
+    return (ccc_hhmap_entry){container_entry(h, key)};
+}
+
+ccc_hhmap_handle
+ccc_hhm_insert_entry(ccc_hhmap_entry const *const e, ccc_hhmap_elem *const elem)
+{
+    if (unlikely(!e || !elem))
+    {
+        return 0;
+    }
+    void *const user_struct = struct_base(e->impl_.h_, elem);
+    if (e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    {
+        copy_to_slot(e->impl_.h_,
+                     ccc_buf_at(&e->impl_.h_->buf_, e->impl_.entry_.i_),
+                     struct_base(e->impl_.h_, elem));
+        return e->impl_.entry_.i_;
+    }
+    if (e->impl_.entry_.stats_ & CCC_ENTRY_INSERT_ERROR)
+    {
+        return 0;
+    }
+    insert(e->impl_.h_, user_struct, e->impl_.hash_, e->impl_.entry_.i_);
+    return e->impl_.entry_.i_;
+}
+
+ccc_hhmap_handle
+ccc_hhm_get_key_val(ccc_handle_hash_map *const h, void const *const key)
+{
+    if (unlikely(!h || !key || !ccc_buf_capacity(&h->buf_)))
+    {
+        return 0;
+    }
+    struct ccc_handle_ e = find(h, key, filter(h, key));
+    if (e.stats_ & CCC_ENTRY_OCCUPIED)
+    {
+        return e.i_;
+    }
+    return 0;
+}
+
+ccc_entry
+ccc_hhm_remove_entry(ccc_hhmap_entry const *const e)
+{
+    if (unlikely(!e))
+    {
+        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+    }
+    if (e->impl_.entry_.stats_ != CCC_ENTRY_OCCUPIED)
+    {
+        return (ccc_entry){{.stats_ = CCC_ENTRY_VACANT}};
+    }
+    erase(e->impl_.h_, e->impl_.entry_.i_);
+    return (ccc_entry){{.stats_ = CCC_ENTRY_OCCUPIED}};
+}
+
+ccc_hhmap_entry *
+ccc_hhm_and_modify(ccc_hhmap_entry *const e, ccc_update_fn *const fn)
+{
+    return (ccc_hhmap_entry *)and_modify(&e->impl_, fn);
+}
+
+ccc_hhmap_entry *
+ccc_hhm_and_modify_aux(ccc_hhmap_entry *const e, ccc_update_fn *const fn,
+                       void *const aux)
+{
+    if (unlikely(!e))
+    {
+        return NULL;
+    }
+    if (e->impl_.entry_.stats_ == CCC_ENTRY_OCCUPIED && fn)
+    {
+        fn((ccc_user_type){ccc_buf_at(&e->impl_.h_->buf_, e->impl_.entry_.i_),
+                           aux});
+    }
+    return e;
+}
+
+ccc_entry
+ccc_hhm_insert(ccc_handle_hash_map *const h, ccc_hhmap_elem *const out_handle)
+{
+    if (unlikely(!h || !out_handle))
+    {
+        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+    }
+    void *const user_return = struct_base(h, out_handle);
+    void *const key = key_in_slot(h, user_return);
+    struct ccc_hhash_entry_ ent = container_entry(h, key);
+    if (ent.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    {
+        swap_user_data(h, ccc_buf_at(&h->buf_, ent.entry_.i_), user_return);
+        return (ccc_entry){{.e_ = user_return, .stats_ = CCC_ENTRY_OCCUPIED}};
+    }
+    if (ent.entry_.stats_ & CCC_ENTRY_INSERT_ERROR)
+    {
+        return (ccc_entry){{.stats_ = CCC_ENTRY_INSERT_ERROR}};
+    }
+    insert(h, user_return, ent.hash_, ent.entry_.i_);
+    return (ccc_entry){{.e_ = ccc_buf_at(&h->buf_, ent.entry_.i_),
+                        .stats_ = CCC_ENTRY_VACANT}};
+}
+
+ccc_entry
+ccc_hhm_try_insert(ccc_handle_hash_map *const h,
+                   ccc_hhmap_elem *const key_val_handle)
+{
+    if (unlikely(!h || !key_val_handle))
+    {
+        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+    }
+    void *const user_base = struct_base(h, key_val_handle);
+    struct ccc_hhash_entry_ ent = container_entry(h, key_in_slot(h, user_base));
+    if (ent.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    {
+        return (ccc_entry){{.e_ = ccc_buf_at(&h->buf_, ent.entry_.i_),
+                            .stats_ = CCC_ENTRY_OCCUPIED}};
+    }
+    if (ent.entry_.stats_ & CCC_ENTRY_INSERT_ERROR)
+    {
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+    }
+    insert(h, user_base, ent.hash_, ent.entry_.i_);
+    return (ccc_entry){{.e_ = ccc_buf_at(&h->buf_, ent.entry_.i_),
+                        .stats_ = CCC_ENTRY_VACANT}};
+}
+
+ccc_entry
+ccc_hhm_insert_or_assign(ccc_handle_hash_map *const h,
+                         ccc_hhmap_elem *const key_val_handle)
+{
+    if (unlikely(!h || !key_val_handle))
+    {
+        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+    }
+    void *const user_base = struct_base(h, key_val_handle);
+    struct ccc_hhash_entry_ ent = container_entry(h, key_in_slot(h, user_base));
+    void *const ret = ccc_buf_at(&h->buf_, ent.entry_.i_);
+    if (ent.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    {
+        copy_to_slot(h, ret, user_base);
+        return (ccc_entry){{.e_ = ret, .stats_ = CCC_ENTRY_OCCUPIED}};
+    }
+    if (ent.entry_.stats_ & CCC_ENTRY_INSERT_ERROR)
+    {
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+    }
+    insert(h, user_base, ent.hash_, ent.entry_.i_);
+    return (ccc_entry){{.e_ = ret, .stats_ = CCC_ENTRY_VACANT}};
+}
+
+ccc_entry
+ccc_hhm_remove(ccc_handle_hash_map *const h, ccc_hhmap_elem *const out_handle)
+{
+    if (unlikely(!h || !out_handle))
+    {
+        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+    }
+    void *const ret = struct_base(h, out_handle);
+    void *const key = key_in_slot(h, ret);
+    struct ccc_handle_ const ent = find(h, key, filter(h, key));
+    if (ent.stats_ & CCC_ENTRY_OCCUPIED)
+    {
+        (void)memcpy(ret, ccc_buf_at(&h->buf_, ent.i_),
+                     ccc_buf_elem_size(&h->buf_));
+        erase(h, ent.i_);
+        return (ccc_entry){{.e_ = ret, .stats_ = CCC_ENTRY_OCCUPIED}};
+    }
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+}
+
+ccc_hhmap_handle
+ccc_hhm_or_insert(ccc_hhmap_entry const *const e, ccc_hhmap_elem *const elem)
+{
+    if (unlikely(!e || !elem))
+    {
+        return 0;
+    }
+    if (e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    {
+        return e->impl_.entry_.i_;
+    }
+    if (e->impl_.entry_.stats_ & CCC_ENTRY_INSERT_ERROR)
+    {
+        return 0;
+    }
+    void *user_struct = struct_base(e->impl_.h_, elem);
+    insert(e->impl_.h_, user_struct, e->impl_.hash_, e->impl_.entry_.i_);
+    return e->impl_.entry_.i_;
+}
+
+ccc_hhmap_handle
+ccc_hhm_unwrap(ccc_hhmap_entry const *const e)
+{
+    if (unlikely(!e) || !(e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED))
+    {
+        return 0;
+    }
+    return e->impl_.entry_.i_;
+}
+
+bool
+ccc_hhm_occupied(ccc_hhmap_entry const *const e)
+{
+    if (unlikely(!e))
+    {
+        return false;
+    }
+    return e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED;
+}
+
+bool
+ccc_hhm_insert_error(ccc_hhmap_entry const *const e)
+{
+    if (unlikely(!e))
+    {
+        return false;
+    }
+    return e->impl_.entry_.stats_ & CCC_ENTRY_INSERT_ERROR;
+}
+
+ccc_entry_status
+ccc_hhm_entry_status(ccc_hhmap_entry const *const e)
+{
+    if (unlikely(!e))
+    {
+        return CCC_ENTRY_INPUT_ERROR;
+    }
+    return e->impl_.entry_.stats_;
+}
+
+void *
+ccc_hhm_begin(ccc_handle_hash_map const *const h)
+{
+    if (unlikely(!h || ccc_buf_is_empty(&h->buf_)))
+    {
+        return NULL;
+    }
+    void const *iter = ccc_buf_begin(&h->buf_);
+    for (; iter != ccc_buf_capacity_end(&h->buf_)
+           && elem_in_slot(h, iter)->meta_.hash_ == CCC_HHM_EMPTY;
+         iter = ccc_buf_next(&h->buf_, iter))
+    {}
+    if (iter == ccc_buf_capacity_end(&h->buf_))
+    {
+        return NULL;
+    }
+    return ccc_buf_at(&h->buf_, elem_in_slot(h, iter)->meta_.slot_i_);
+}
+
+void *
+ccc_hhm_next(ccc_handle_hash_map const *const h,
+             ccc_hhmap_elem const *const iter)
+{
+    if (unlikely(!h))
+    {
+        return NULL;
+    }
+    void const *i = struct_base(h, ccc_buf_at(&h->buf_, iter->meta_i_));
+    for (i = ccc_buf_next(&h->buf_, i);
+         i != ccc_buf_capacity_end(&h->buf_)
+         && elem_in_slot(h, i)->meta_.hash_ == CCC_HHM_EMPTY;
+         i = ccc_buf_next(&h->buf_, i))
+    {}
+    if (iter == ccc_buf_capacity_end(&h->buf_))
+    {
+        return NULL;
+    }
+    return ccc_buf_at(&h->buf_, elem_in_slot(h, iter)->meta_.slot_i_);
+}
+
+void *
+ccc_hhm_end(ccc_handle_hash_map const *const)
+{
+    return NULL;
+}
+
+size_t
+ccc_hhm_next_prime(size_t const n)
+{
+    return next_prime(n);
+}
+
+ccc_result
+ccc_hhm_copy(ccc_handle_hash_map *const dst,
+             ccc_handle_hash_map const *const src, ccc_alloc_fn *const fn)
+{
+    if (!dst || !src || (dst->buf_.capacity_ < src->buf_.capacity_ && !fn))
+    {
+        return CCC_INPUT_ERR;
+    }
+    /* Copy everything so we don't worry about staying in sync with future
+       changes to buf container. But we have to give back original destination
+       memory in case it has already been allocated. Alloc will remain the
+       same as in dst initialization because that controls permission. */
+    void *const dst_mem = dst->buf_.mem_;
+    size_t const dst_cap = dst->buf_.capacity_;
+    ccc_alloc_fn *const dst_alloc = dst->buf_.alloc_;
+    *dst = *src;
+    dst->buf_.mem_ = dst_mem;
+    dst->buf_.capacity_ = dst_cap;
+    dst->buf_.alloc_ = dst_alloc;
+    if (dst->buf_.capacity_ < src->buf_.capacity_)
+    {
+        ccc_result resize_res
+            = ccc_buf_alloc(&dst->buf_, src->buf_.capacity_, fn);
+        if (resize_res != CCC_OK)
+        {
+            return resize_res;
+        }
+        dst->buf_.capacity_ = src->buf_.capacity_;
+    }
+    (void)memcpy(dst->buf_.mem_, src->buf_.mem_,
+                 src->buf_.capacity_ * src->buf_.elem_sz_);
+    return CCC_OK;
+}
+
+ccc_result
+ccc_hhm_clear(ccc_handle_hash_map *const h, ccc_destructor_fn *const fn)
+{
+    if (unlikely(!h))
+    {
+        return CCC_INPUT_ERR;
+    }
+    if (!fn)
+    {
+        h->buf_.sz_ = 0;
+        return CCC_OK;
+    }
+    for (void *slot = ccc_buf_begin(&h->buf_);
+         slot != ccc_buf_capacity_end(&h->buf_);
+         slot = ccc_buf_next(&h->buf_, slot))
+    {
+        struct ccc_hhmap_elem_ *const e = elem_in_slot(h, slot);
+        if (e->meta_.hash_ != CCC_HHM_EMPTY)
+        {
+            fn((ccc_user_type){.user_type = ccc_buf_at(&h->buf_, e->meta_i_),
+                               .aux = h->buf_.aux_});
+        }
+    }
+    return CCC_OK;
+}
+
+ccc_result
+ccc_hhm_clear_and_free(ccc_handle_hash_map *const h,
+                       ccc_destructor_fn *const fn)
+{
+    if (unlikely(!h))
+    {
+        return CCC_INPUT_ERR;
+    }
+    if (!fn)
+    {
+        h->buf_.sz_ = 0;
+        return ccc_buf_alloc(&h->buf_, 0, h->buf_.alloc_);
+    }
+    for (void *slot = ccc_buf_begin(&h->buf_);
+         slot != ccc_buf_capacity_end(&h->buf_);
+         slot = ccc_buf_next(&h->buf_, slot))
+    {
+        struct ccc_hhmap_elem_ *const e = elem_in_slot(h, slot);
+        if (e->meta_.hash_ != CCC_HHM_EMPTY)
+        {
+            fn((ccc_user_type){.user_type = ccc_buf_at(&h->buf_, e->meta_i_),
+                               .aux = h->buf_.aux_});
+        }
+    }
+    return ccc_buf_alloc(&h->buf_, 0, h->buf_.alloc_);
+}
+
+size_t
+ccc_hhm_capacity(ccc_handle_hash_map const *const h)
+{
+    if (unlikely(!h))
+    {
+        return 0;
+    }
+    return ccc_buf_capacity(&h->buf_);
+}
+
+void *
+ccc_hhm_data(ccc_handle_hash_map const *const h)
+{
+    return h ? ccc_buf_begin(&h->buf_) : NULL;
+}
+
+bool
+ccc_hhm_validate(ccc_handle_hash_map const *const h)
+{
+    if (!h || !h->eq_fn_ || !h->hash_fn_)
+    {
+        return false;
+    }
+    size_t empties = 0;
+    size_t occupied = 0;
+    size_t index = 0;
+    for (void const *i = ccc_buf_begin(&h->buf_);
+         i != ccc_buf_capacity_end(&h->buf_);
+         i = ccc_buf_next(&h->buf_, i), ++index)
+    {
+        struct ccc_hhmap_elem_ const *const e = elem_in_slot(h, i);
+        if (elem_in_slot(h, ccc_buf_at(&h->buf_, e->meta_.slot_i_))->meta_i_
+            != index)
+        {
+            return false;
+        }
+        if (e->meta_.hash_ == CCC_HHM_EMPTY)
+        {
+            ++empties;
+        }
+        else
+        {
+            ++occupied;
+        }
+        if (e->meta_.hash_ != CCC_HHM_EMPTY && !valid_distance_from_home(h, i))
+        {
+            return false;
+        }
+    }
+    return occupied == ccc_hhm_size(h)
+           && empties == (ccc_buf_capacity(&h->buf_) - occupied);
+}
+
+static bool
+valid_distance_from_home(struct ccc_hhmap_ const *const h,
+                         void const *const slot)
+{
+    size_t const cap = ccc_buf_capacity(&h->buf_);
+    uint64_t const hash = elem_in_slot(h, slot)->meta_.hash_;
+    size_t const home = to_i(cap, hash);
+    size_t const end = decrement(cap, home);
+    for (size_t i = ccc_buf_i(&h->buf_, slot),
+                distance_to_home = distance(cap, i, to_i(cap, hash));
+         i != end; --distance_to_home, i = decrement(cap, i))
+    {
+        uint64_t const cur_hash = *hash_at(h, i);
+        /* The only reason an element is not home is because it has been
+           moved away to help another element be closer to its home. This
+           would break the purpose of doing that. Upon erase everyone needs
+           to shuffle closer to home. */
+        if (cur_hash == CCC_HHM_EMPTY)
+        {
+            return false;
+        }
+        /* This shouldn't happen either. The whole point of Robin Hood is
+           taking from the close and giving to the far. If this happens
+           we have made our algorithm greedy not altruistic. */
+        if (distance_to_home > distance(cap, i, to_i(cap, cur_hash)))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/*=======================   Private Interface   =============================*/
+
+struct ccc_hhash_entry_
+ccc_impl_fhm_entry(struct ccc_hhmap_ *const h, void const *const key)
+{
+    return container_entry(h, key);
+}
+
+struct ccc_hhash_entry_ *
+ccc_impl_fhm_and_modify(struct ccc_hhash_entry_ *const e,
+                        ccc_update_fn *const fn)
+{
+    return and_modify(e, fn);
+}
+
+struct ccc_handle_
+ccc_impl_fhm_find(struct ccc_hhmap_ const *const h, void const *const key,
+                  uint64_t const hash)
+{
+    return find(h, key, hash);
+}
+
+void
+ccc_impl_fhm_insert(struct ccc_hhmap_ *const h, void const *const e,
+                    uint64_t const hash, size_t cur_i)
+{
+    insert(h, e, hash, cur_i);
+}
+
+ccc_result
+ccc_impl_fhm_maybe_resize(struct ccc_hhmap_ *const h)
+{
+    return maybe_resize(h);
+}
+
+struct ccc_hhmap_elem_ *
+ccc_impl_fhm_in_slot(struct ccc_hhmap_ const *const h, void const *const slot)
+{
+    return elem_in_slot(h, slot);
+}
+
+void *
+ccc_impl_fhm_key_in_slot(struct ccc_hhmap_ const *const h,
+                         void const *const slot)
+{
+    return key_in_slot(h, slot);
+}
+
+size_t
+ccc_impl_fhm_distance(size_t const capacity, size_t const i, size_t const j)
+{
+    return distance(capacity, i, j);
+}
+
+size_t
+ccc_impl_fhm_increment(size_t const capacity, size_t const i)
+{
+    return increment(capacity, i);
+}
+
+void *
+ccc_impl_fhm_base(struct ccc_hhmap_ const *const h)
+{
+    return ccc_buf_begin(&h->buf_);
+}
+
+uint64_t *
+ccc_impl_fhm_hash_at(struct ccc_hhmap_ const *const h, size_t const i)
+{
+    return hash_at(h, i);
+}
+
+uint64_t
+ccc_impl_fhm_filter(struct ccc_hhmap_ const *const h, void const *const key)
+{
+    return filter(h, key);
+}
+
+/*=======================     Static Helpers    =============================*/
+
+static inline struct ccc_handle_
+entry(struct ccc_hhmap_ *const h, void const *const key, uint64_t const hash)
+{
+    char upcoming_insertion_error = 0;
+    if (maybe_resize(h) != CCC_OK)
+    {
+        upcoming_insertion_error = CCC_ENTRY_INSERT_ERROR;
+    }
+    struct ccc_handle_ res = find(h, key, hash);
+    res.stats_ |= upcoming_insertion_error;
+    return res;
+}
+
+static inline struct ccc_handle_
+find(struct ccc_hhmap_ const *const h, void const *const key,
+     uint64_t const hash)
+{
+    size_t const cap = ccc_buf_capacity(&h->buf_);
+    /* A few sanity checks. The load factor should be managed a full table is
+       never allowed even under no allocation permission because that could
+       lead to an infinite loop and illustrates a degenerate table anyway. */
+    if (unlikely(!cap))
+    {
+        return (struct ccc_handle_){.i_ = 0, .stats_ = CCC_ENTRY_VACANT};
+    }
+    if (unlikely(ccc_buf_size(&h->buf_) >= ccc_buf_capacity(&h->buf_)))
+    {
+        return (struct ccc_handle_){.i_ = 0, .stats_ = CCC_ENTRY_INPUT_ERROR};
+    }
+    size_t i = to_i(cap, hash);
+    size_t dist = 0;
+    do
+    {
+        struct ccc_hhmap_elem_ const *const e = elem_at(h, i);
+        if (e->meta_.hash_ == CCC_HHM_EMPTY
+            || dist > distance(cap, i, to_i(cap, e->meta_.hash_)))
+        {
+            return (struct ccc_handle_){.i_ = e->meta_.slot_i_,
+                                        .stats_ = CCC_ENTRY_VACANT
+                                                  | CCC_ENTRY_NO_UNWRAP};
+        }
+        if (hash == e->meta_.hash_
+            && h->eq_fn_((ccc_key_cmp){.key_lhs = key,
+                                       .user_type_rhs
+                                       = ccc_buf_at(&h->buf_, e->meta_.slot_i_),
+                                       .aux = h->buf_.aux_}))
+        {
+            return (struct ccc_handle_){.i_ = e->meta_.slot_i_,
+                                        .stats_ = CCC_ENTRY_OCCUPIED};
+        }
+        ++dist;
+        i = increment(cap, i);
+    } while (true);
+}
+
+/* Assumes that element to be inserted does not already exist in the table.
+   Assumes that the table has room for another insertion. Unexpected results
+   may occur if these assumptions are not accommodated. */
+static inline void
+insert(struct ccc_hhmap_ *const h, void const *const e, uint64_t const hash,
+       size_t i)
+{
+    size_t const cap = ccc_buf_capacity(&h->buf_);
+    struct ccc_hhmap_elem_ *floater = elem_at(h, 1);
+    /* This function cannot modify e and e may be copied over to new
+       insertion from old table. So should this function invariantly assign
+       starting hash to this slot copy for insertion? I think yes so far. */
+    floater->meta_.hash_ = hash;
+    floater->meta_.slot_i_ = 0;
+    size_t e_meta = 0;
+    size_t dist = distance(cap, i, to_i(cap, hash));
+    do
+    {
+        struct ccc_hhmap_elem_ *const elem = elem_at(h, i);
+        void *const slot = ccc_buf_at(&h->buf_, elem->meta_.slot_i_);
+        if (elem->meta_.hash_ == CCC_HHM_EMPTY)
+        {
+            copy_to_slot(h, slot, e);
+            elem_in_slot(h, slot)->meta_i_ = e_meta;
+            elem_at(h, e_meta)->meta_.slot_i_ = elem->meta_.slot_i_;
+            elem->meta_ = floater->meta_;
+            elem_at(h, floater->meta_.slot_i_)->meta_i_ = i;
+            (void)ccc_buf_size_plus(&h->buf_, 1);
+            *hash_at(h, 0) = CCC_HHM_EMPTY;
+            *hash_at(h, 1) = CCC_HHM_EMPTY;
+            return;
+        }
+        size_t const slot_dist = distance(cap, i, to_i(cap, elem->meta_.hash_));
+        if (dist > slot_dist)
+        {
+            e_meta = e_meta ? e_meta : i;
+            swap_meta_data(h, floater, elem);
+            elem_at(h, floater->meta_.slot_i_)->meta_i_ = i;
+            dist = slot_dist;
+        }
+        i = increment(cap, i);
+        ++dist;
+    } while (true);
+}
+
+/* Backshift deletion is important in for this table because it may not be able
+   to allocate. This prevents the need for tombstones which would hurt table
+   quality quickly if we can't resize. */
+static void
+erase(struct ccc_hhmap_ *const h, size_t e)
+{
+    *hash_at(h, e) = CCC_HHM_EMPTY;
+    size_t const cap = ccc_buf_capacity(&h->buf_);
+    size_t i = e;
+    size_t next = increment(cap, i);
+    do
+    {
+        struct ccc_hhmap_elem_ *const next_elem = elem_at(h, next);
+        if (next_elem->meta_.hash_ == CCC_HHM_EMPTY
+            || !distance(cap, next, to_i(cap, next_elem->meta_.hash_)))
+        {
+            *hash_at(h, 0) = CCC_HHM_EMPTY;
+            (void)ccc_buf_size_minus(&h->buf_, 1);
+            return;
+        }
+        struct ccc_hhmap_elem_ *const i_elem = elem_at(h, i);
+        swap_meta_data(h, i_elem, next_elem);
+        elem_at(h, i_elem->meta_.slot_i_)->meta_i_ = i;
+        i = next;
+        next = increment(cap, next);
+    } while (true);
+}
+
+static inline struct ccc_hhash_entry_
+container_entry(struct ccc_hhmap_ *const h, void const *const key)
+{
+    uint64_t const hash = filter(h, key);
+    return (struct ccc_hhash_entry_){
+        .h_ = h,
+        .hash_ = hash,
+        .entry_ = entry(h, key, hash),
+    };
+}
+
+static inline struct ccc_hhash_entry_ *
+and_modify(struct ccc_hhash_entry_ *const e, ccc_update_fn *const fn)
+{
+    if (e->entry_.stats_ == CCC_ENTRY_OCCUPIED)
+    {
+        fn((ccc_user_type){ccc_buf_at(&e->h_->buf_, e->entry_.i_), NULL});
+    }
+    return e;
+}
+
+static inline ccc_result
+maybe_resize(struct ccc_hhmap_ *const h)
+{
+    if (ccc_buf_capacity(&h->buf_) && ccc_buf_size(&h->buf_) < num_swap_slots)
+    {
+
+        for (size_t i = 0; i < ccc_buf_capacity(&h->buf_); ++i)
+        {
+            struct ccc_hhmap_elem_ *const e = elem_at(h, i);
+            e->meta_.hash_ = CCC_HHM_EMPTY;
+            e->meta_.slot_i_ = i;
+            e->meta_i_ = i;
+        }
+        (void)ccc_buf_size_set(&h->buf_, num_swap_slots);
+    }
+    if (ccc_buf_capacity(&h->buf_)
+        && (double)(ccc_buf_size(&h->buf_)) / (double)ccc_buf_capacity(&h->buf_)
+               <= load_factor)
+    {
+        return CCC_OK;
+    }
+    if (!h->buf_.alloc_)
+    {
+        return CCC_NO_ALLOC;
+    }
+    struct ccc_hhmap_ new_hash = *h;
+    new_hash.buf_.sz_ = 0;
+    new_hash.buf_.capacity_ = new_hash.buf_.capacity_
+                                  ? next_prime(ccc_buf_size(&h->buf_) * 2)
+                                  : primes[0];
+    if (new_hash.buf_.capacity_ <= h->buf_.capacity_)
+    {
+        return CCC_MEM_ERR;
+    }
+    new_hash.buf_.mem_ = new_hash.buf_.alloc_(
+        NULL, ccc_buf_elem_size(&h->buf_) * new_hash.buf_.capacity_,
+        h->buf_.aux_);
+    if (!new_hash.buf_.mem_)
+    {
+        return CCC_MEM_ERR;
+    }
+    for (size_t i = 0; i < ccc_buf_capacity(&new_hash.buf_); ++i)
+    {
+        struct ccc_hhmap_elem_ *const e = elem_at(h, i);
+        e->meta_.hash_ = CCC_HHM_EMPTY;
+        e->meta_.slot_i_ = i;
+        e->meta_i_ = i;
+    }
+    for (void *slot = ccc_buf_begin(&h->buf_);
+         slot != ccc_buf_capacity_end(&h->buf_);
+         slot = ccc_buf_next(&h->buf_, slot))
+    {
+        struct ccc_hhmap_elem_ const *const e = elem_in_slot(h, slot);
+        if (e->meta_.hash_ != CCC_HHM_EMPTY)
+        {
+            struct ccc_handle_ const new_ent
+                = find(&new_hash, key_in_slot(h, slot), e->meta_.hash_);
+            insert(&new_hash, slot, e->meta_.hash_, new_ent.i_);
+        }
+    }
+    if (ccc_buf_alloc(&h->buf_, 0, h->buf_.alloc_) != CCC_OK)
+    {
+        *h = new_hash;
+        return CCC_MEM_ERR;
+    }
+    *h = new_hash;
+    return CCC_OK;
+}
+
+static inline void
+copy_to_slot(struct ccc_hhmap_ *const h, void *const slot_dst,
+             void const *const user_src)
+{
+    struct ccc_hhmap_elem_ *const elem = elem_in_slot(h, slot_dst);
+    size_t surrounding_bytes = (char *)elem - (char *)slot_dst;
+    if (surrounding_bytes)
+    {
+        (void)memcpy(slot_dst, user_src, surrounding_bytes);
+    }
+    char *const remain_start
+        = (char *)elem_in_slot(h, user_src) + sizeof(struct ccc_hhmap_elem_);
+    surrounding_bytes = (char *)((char *)user_src + ccc_buf_elem_size(&h->buf_))
+                        - remain_start;
+    if (surrounding_bytes)
+    {
+        (void)memcpy((char *)elem + sizeof(struct ccc_hhmap_elem_),
+                     remain_start, surrounding_bytes);
+    }
+}
+
+static inline size_t
+next_prime(size_t const n)
+{
+    for (size_t i = 0; i < PRIMES_SIZE; ++i)
+    {
+        if (primes[i] > n)
+        {
+            return primes[i];
+        }
+    }
+    return 0;
+}
+
+static inline uint64_t *
+hash_at(struct ccc_hhmap_ const *const h, size_t const i)
+{
+    return &((struct ccc_hhmap_elem_ *)((char *)ccc_buf_at(&h->buf_, i)
+                                        + h->hash_elem_offset_))
+                ->meta_.hash_;
+}
+
+static inline uint64_t
+filter(struct ccc_hhmap_ const *const h, void const *const key)
+{
+    uint64_t const hash
+        = h->hash_fn_((ccc_user_key){.user_key = key, .aux = h->buf_.aux_});
+    return hash == CCC_HHM_EMPTY ? hash + 1 : hash;
+}
+
+static inline struct ccc_hhmap_elem_ *
+elem_in_slot(struct ccc_hhmap_ const *const h, void const *const slot)
+{
+    return (struct ccc_hhmap_elem_ *)((char *)slot + h->hash_elem_offset_);
+}
+
+static inline struct ccc_hhmap_elem_ *
+elem_at(struct ccc_hhmap_ const *const h, size_t const i)
+{
+    return (struct ccc_hhmap_elem_ *)((char *)ccc_buf_at(&h->buf_, i)
+                                      + h->hash_elem_offset_);
+}
+
+static inline void *
+key_in_slot(struct ccc_hhmap_ const *const h, void const *const slot)
+{
+    return (char *)slot + h->key_offset_;
+}
+
+static inline size_t
+distance(size_t const capacity, size_t const i, size_t const j)
+{
+    return i < j ? (capacity - j) + i - num_swap_slots : i - j;
+}
+
+static inline size_t
+increment(size_t const capacity, size_t const i)
+{
+    return (i + 1) >= capacity ? last_swap_slot + 1 : i + 1;
+}
+
+static inline size_t
+decrement(size_t const capacity, size_t const i)
+{
+    return i <= num_swap_slots ? capacity - 1 : i - 1;
+}
+
+static inline void *
+struct_base(struct ccc_hhmap_ const *const h,
+            struct ccc_hhmap_elem_ const *const e)
+{
+    return ((char *)&e->meta_.hash_) - h->hash_elem_offset_;
+}
+
+static inline void
+swap_user_data(struct ccc_hhmap_ *const h, void *const a, void *const b)
+{
+    if (a == b)
+    {
+        return;
+    }
+    void *const tmp = ccc_buf_at(&h->buf_, 0);
+    (void)memcpy(tmp, a, ccc_buf_elem_size(&h->buf_));
+    copy_to_slot(h, a, b);
+    copy_to_slot(h, b, tmp);
+    *hash_at(h, 0) = CCC_HHM_EMPTY;
+}
+
+static inline void
+swap_meta_data(struct ccc_hhmap_ *const h, struct ccc_hhmap_elem_ *const a,
+               struct ccc_hhmap_elem_ *const b)
+{
+    if (a == b)
+    {
+        return;
+    }
+    struct ccc_hhmap_elem_ *const tmp
+        = elem_in_slot(h, ccc_buf_at(&h->buf_, 0));
+    tmp->meta_ = a->meta_;
+    a->meta_ = b->meta_;
+    b->meta_ = tmp->meta_;
+    tmp->meta_.hash_ = CCC_HHM_EMPTY;
+}
+
+/** This function converts a hash to its home index in the table. Because this
+operation is in the hot path of all table functions and Robin Hood relies on
+home slot distance calculations, this function tries to use Daniel Lemire's
+fastrange library modulo calculation alternative:
+    https://github.com/lemire/fastrange
+Such a technique is helpful because the prime table capacities used to mitigate
+primary clustering of Robin Hood hash tables make efficient modulo calculations
+more difficult than power of two table capacities. The appropriate license for
+this technique is included immediately following this function and only applies
+to this function in this source file. */
+static inline size_t
+to_i(size_t const capacity, uint64_t hash)
+{
+#ifdef __SIZEOF_INT128__
+    hash = (uint64_t)(((__uint128_t)hash * (__uint128_t)capacity) >> 64);
+#else
+    hash %= capacity;
+#endif
+    return hash <= last_swap_slot ? last_swap_slot + 1 : hash;
+}
+
+/** The following Apache License applies only to the above function. This
+function uses one line from Daniel Lemire's fastrange library to compute the
+modulo of a number range with multiplication and shifts rather than  modulo
+division. Specifically, the 128 bit widening is from the fastrange library which
+can be found here: https://github.com/lemire/fastrange
+
+Below is the required license for the code in the above function. Lemire's
+copyright applies to the integer widening line of code as he copyrights the
+source file from which it came with his name and the year. The notice in
+https://github.com/lemire/fastrange/fastrange.h appears as follows:
+
+```
+Fair maps to intervals without division.
+Reference :
+http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+
+(c) Daniel Lemire
+Apache License 2.0
+```
+
+The license for the cited repository is included below for completeness.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */

--- a/src/handle_hash_map.c
+++ b/src/handle_hash_map.c
@@ -625,10 +625,15 @@ ccc_hhm_validate(ccc_handle_hash_map const *const h)
         else
         {
             ++occupied;
-        }
-        if (e->hash_ != CCC_HHM_EMPTY && !valid_distance_from_home(h, i))
-        {
-            return false;
+            uint64_t const hash = filter(h, key_at(h, e->slot_i_));
+            if (hash != e->hash_)
+            {
+                return false;
+            }
+            if (!valid_distance_from_home(h, i))
+            {
+                return false;
+            }
         }
     }
     return occupied == ccc_hhm_size(h)

--- a/src/handle_hash_map.c
+++ b/src/handle_hash_map.c
@@ -897,7 +897,9 @@ and_modify(struct ccc_hhash_handle_ *const e, ccc_update_fn *const fn)
 {
     if (e->handle_.stats_ == CCC_OCCUPIED)
     {
-        fn((ccc_user_type){ccc_buf_at(&e->h_->buf_, e->handle_.i_), NULL});
+        fn((ccc_user_type){
+            ccc_buf_at(&e->h_->buf_, elem_at(e->h_, e->handle_.i_)->slot_i_),
+            NULL});
     }
     return e;
 }
@@ -1088,6 +1090,7 @@ swap_user_data(struct ccc_hhmap_ *const h, void *const a, void *const b)
     (void)memcpy(tmp, a, ccc_buf_elem_size(&h->buf_));
     copy_to_slot(h, a, b);
     copy_to_slot(h, b, tmp);
+    *elem_at(h, 0) = (struct ccc_hhmap_elem_){};
 }
 
 static inline void
@@ -1103,6 +1106,7 @@ swap_meta_data(struct ccc_hhmap_ *const h, struct ccc_hhmap_elem_ *const a,
     *tmp = *a;
     *a = *b;
     *b = *tmp;
+    *elem_at(h, 0) = (struct ccc_hhmap_elem_){};
 }
 
 /** This function converts a hash to its home index in the table. Because this

--- a/src/ordered_map.c
+++ b/src/ordered_map.c
@@ -109,7 +109,7 @@ ccc_om_entry(ccc_ordered_map *const om, void const *const key)
 {
     if (!om || !key)
     {
-        return (ccc_omap_entry){{.entry_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}}};
+        return (ccc_omap_entry){{.entry_ = {.stats_ = CCC_INPUT_ERROR}}};
     }
     return (ccc_omap_entry){container_entry(&om->impl_, key)};
 }
@@ -121,7 +121,7 @@ ccc_om_insert_entry(ccc_omap_entry const *const e, ccc_omap_elem *const elem)
     {
         return NULL;
     }
-    if (e->impl_.entry_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ == CCC_OCCUPIED)
     {
         elem->impl_ = *elem_in_slot(e->impl_.t_, e->impl_.entry_.e_);
         (void)memcpy(e->impl_.entry_.e_, struct_base(e->impl_.t_, &elem->impl_),
@@ -138,7 +138,7 @@ ccc_om_or_insert(ccc_omap_entry const *const e, ccc_omap_elem *const elem)
     {
         return NULL;
     }
-    if (e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ & CCC_OCCUPIED)
     {
         return e->impl_.entry_.e_;
     }
@@ -152,7 +152,7 @@ ccc_om_and_modify(ccc_omap_entry *const e, ccc_update_fn *const fn)
     {
         return NULL;
     }
-    if (fn && e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (fn && e->impl_.entry_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){.user_type = e->impl_.entry_.e_, .aux = NULL});
     }
@@ -163,7 +163,7 @@ ccc_omap_entry *
 ccc_om_and_modify_aux(ccc_omap_entry *const e, ccc_update_fn *const fn,
                       void *const aux)
 {
-    if (e && fn && e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e && fn && e->impl_.entry_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){.user_type = e->impl_.entry_.e_, .aux = aux});
     }
@@ -176,7 +176,7 @@ ccc_om_insert(ccc_ordered_map *const om, ccc_omap_elem *const key_val_handle,
 {
     if (!om || !key_val_handle || !tmp)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     void *const found
         = find(&om->impl_, key_from_node(&om->impl_, &key_val_handle->impl_));
@@ -193,14 +193,14 @@ ccc_om_insert(ccc_ordered_map *const om, ccc_omap_elem *const key_val_handle,
             = key_val_handle->impl_.parent_ = NULL;
         tmp->impl_.branch_[L] = tmp->impl_.branch_[R] = tmp->impl_.parent_
             = NULL;
-        return (ccc_entry){{.e_ = old_val, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = old_val, .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted = alloc_insert(&om->impl_, &key_val_handle->impl_);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -209,7 +209,7 @@ ccc_om_try_insert(ccc_ordered_map *const om,
 {
     if (!om || !key_val_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     void *const found
         = find(&om->impl_, key_from_node(&om->impl_, &key_val_handle->impl_));
@@ -217,14 +217,14 @@ ccc_om_try_insert(ccc_ordered_map *const om,
     {
         assert(om->impl_.root_ != &om->impl_.end_);
         return (ccc_entry){{.e_ = struct_base(&om->impl_, om->impl_.root_),
-                            .stats_ = CCC_ENTRY_OCCUPIED}};
+                            .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted = alloc_insert(&om->impl_, &key_val_handle->impl_);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -233,7 +233,7 @@ ccc_om_insert_or_assign(ccc_ordered_map *const om,
 {
     if (!om || !key_val_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     void *const found
         = find(&om->impl_, key_from_node(&om->impl_, &key_val_handle->impl_));
@@ -243,14 +243,14 @@ ccc_om_insert_or_assign(ccc_ordered_map *const om,
         assert(om->impl_.root_ != &om->impl_.end_);
         memcpy(found, struct_base(&om->impl_, &key_val_handle->impl_),
                om->impl_.elem_sz_);
-        return (ccc_entry){{.e_ = found, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = found, .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted = alloc_insert(&om->impl_, &key_val_handle->impl_);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -258,22 +258,22 @@ ccc_om_remove(ccc_ordered_map *const om, ccc_omap_elem *const out_handle)
 {
     if (!om || !out_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     void *const n
         = erase(&om->impl_, key_from_node(&om->impl_, &out_handle->impl_));
     if (!n)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
     }
     if (om->impl_.alloc_)
     {
         void *const user_struct = struct_base(&om->impl_, &out_handle->impl_);
         memcpy(user_struct, n, om->impl_.elem_sz_);
         om->impl_.alloc_(n, 0, om->impl_.aux_);
-        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_OCCUPIED}};
     }
-    return (ccc_entry){{.e_ = n, .stats_ = CCC_ENTRY_OCCUPIED}};
+    return (ccc_entry){{.e_ = n, .stats_ = CCC_OCCUPIED}};
 }
 
 ccc_entry
@@ -281,9 +281,9 @@ ccc_om_remove_entry(ccc_omap_entry *const e)
 {
     if (!e)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
-    if (e->impl_.entry_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ == CCC_OCCUPIED)
     {
         void *const erased
             = erase(e->impl_.t_, key_in_slot(e->impl_.t_, e->impl_.entry_.e_));
@@ -291,11 +291,11 @@ ccc_om_remove_entry(ccc_omap_entry *const e)
         if (e->impl_.t_->alloc_)
         {
             e->impl_.t_->alloc_(erased, 0, e->impl_.t_->aux_);
-            return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_OCCUPIED}};
+            return (ccc_entry){{.e_ = NULL, .stats_ = CCC_OCCUPIED}};
         }
-        return (ccc_entry){{.e_ = erased, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = erased, .stats_ = CCC_OCCUPIED}};
     }
-    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 void *
@@ -315,26 +315,25 @@ ccc_om_unwrap(ccc_omap_entry const *const e)
     {
         return NULL;
     }
-    return e->impl_.entry_.stats_ == CCC_ENTRY_OCCUPIED ? e->impl_.entry_.e_
-                                                        : NULL;
+    return e->impl_.entry_.stats_ == CCC_OCCUPIED ? e->impl_.entry_.e_ : NULL;
 }
 
 bool
 ccc_om_insert_error(ccc_omap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ & CCC_ENTRY_INSERT_ERROR : false;
+    return e ? e->impl_.entry_.stats_ & CCC_INSERT_ERROR : false;
 }
 
 bool
 ccc_om_occupied(ccc_omap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED : false;
+    return e ? e->impl_.entry_.stats_ & CCC_OCCUPIED : false;
 }
 
 ccc_entry_status
 ccc_om_entry_status(ccc_omap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ : CCC_ENTRY_INPUT_ERROR;
+    return e ? e->impl_.entry_.stats_ : CCC_INPUT_ERROR;
 }
 
 void *
@@ -486,10 +485,10 @@ container_entry(struct ccc_tree_ *const t, void const *const key)
     if (found)
     {
         return (struct ccc_tree_entry_){
-            .t_ = t, .entry_ = {.e_ = found, .stats_ = CCC_ENTRY_OCCUPIED}};
+            .t_ = t, .entry_ = {.e_ = found, .stats_ = CCC_OCCUPIED}};
     }
     return (struct ccc_tree_entry_){
-        .t_ = t, .entry_ = {.e_ = found, .stats_ = CCC_ENTRY_VACANT}};
+        .t_ = t, .entry_ = {.e_ = found, .stats_ = CCC_VACANT}};
 }
 
 static inline void *

--- a/src/ordered_multimap.c
+++ b/src/ordered_multimap.c
@@ -141,8 +141,7 @@ ccc_omm_entry(ccc_ordered_multimap *const mm, void const *const key)
     if (!mm || !key)
     {
         return (ccc_ommap_entry){
-            {.t_ = NULL,
-             .entry_ = {.e_ = NULL, .stats_ = CCC_ENTRY_SEARCH_ERROR}}};
+            {.t_ = NULL, .entry_ = {.e_ = NULL, .stats_ = CCC_SEARCH_ERROR}}};
     }
     return (ccc_ommap_entry){container_entry(&mm->impl_, key)};
 }
@@ -166,7 +165,7 @@ ccc_omm_or_insert(ccc_ommap_entry const *const e,
     {
         return NULL;
     }
-    if (e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ & CCC_OCCUPIED)
     {
         return e->impl_.entry_.e_;
     }
@@ -180,7 +179,7 @@ ccc_omm_and_modify(ccc_ommap_entry *const e, ccc_update_fn *const fn)
     {
         return NULL;
     }
-    if (e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){.user_type = e->impl_.entry_.e_, .aux = NULL});
     }
@@ -195,7 +194,7 @@ ccc_omm_and_modify_aux(ccc_ommap_entry *const e, ccc_update_fn *const fn,
     {
         return NULL;
     }
-    if (e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){.user_type = e->impl_.entry_.e_, .aux = aux});
     }
@@ -208,7 +207,7 @@ ccc_omm_insert(ccc_ordered_multimap *const mm,
 {
     if (!mm || !key_val_handle)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INPUT_ERROR}};
     }
     struct ccc_node_ *n = &key_val_handle->impl_;
     if (mm->impl_.alloc_)
@@ -217,7 +216,7 @@ ccc_omm_insert(ccc_ordered_multimap *const mm,
             = mm->impl_.alloc_(NULL, mm->impl_.elem_sz_, mm->impl_.aux_);
         if (!mem)
         {
-            return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+            return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
         }
         (void)memcpy(mem, struct_base(&mm->impl_, &key_val_handle->impl_),
                      mm->impl_.elem_sz_);
@@ -232,13 +231,13 @@ ccc_omm_try_insert(ccc_ordered_multimap *const mm,
 {
     if (!mm || !key_val_handle)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INPUT_ERROR}};
     }
     void const *const key = key_from_node(&mm->impl_, &key_val_handle->impl_);
     void *const found = find(&mm->impl_, key);
     if (found)
     {
-        return (ccc_entry){{.e_ = found, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = found, .stats_ = CCC_OCCUPIED}};
     }
     return (ccc_entry){multimap_insert(&mm->impl_, &key_val_handle->impl_)};
 }
@@ -249,7 +248,7 @@ ccc_omm_insert_or_assign(ccc_ordered_multimap *const mm,
 {
     if (!mm || !key_val_handle)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INPUT_ERROR}};
     }
     void *const found
         = find(&mm->impl_, key_from_node(&mm->impl_, &key_val_handle->impl_));
@@ -259,7 +258,7 @@ ccc_omm_insert_or_assign(ccc_ordered_multimap *const mm,
         assert(mm->impl_.root_ != &mm->impl_.end_);
         memcpy(found, struct_base(&mm->impl_, &key_val_handle->impl_),
                mm->impl_.elem_sz_);
-        return (ccc_entry){{.e_ = found, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = found, .stats_ = CCC_OCCUPIED}};
     }
     return (ccc_entry){multimap_insert(&mm->impl_, &key_val_handle->impl_)};
 }
@@ -270,22 +269,22 @@ ccc_omm_remove(ccc_ordered_multimap *const mm, ccc_ommap_elem *const out_handle)
 
     if (!mm || !out_handle)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INPUT_ERROR}};
     }
     void *const n = multimap_erase(
         &mm->impl_, key_from_node(&mm->impl_, &out_handle->impl_));
     if (!n)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
     }
     if (mm->impl_.alloc_)
     {
         void *const user_struct = struct_base(&mm->impl_, &out_handle->impl_);
         memcpy(user_struct, n, mm->impl_.elem_sz_);
         mm->impl_.alloc_(n, 0, mm->impl_.aux_);
-        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_OCCUPIED}};
     }
-    return (ccc_entry){{.e_ = n, .stats_ = CCC_ENTRY_OCCUPIED}};
+    return (ccc_entry){{.e_ = n, .stats_ = CCC_OCCUPIED}};
 }
 
 ccc_entry
@@ -293,9 +292,9 @@ ccc_omm_remove_entry(ccc_ommap_entry *const e)
 {
     if (!e)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INPUT_ERROR}};
     }
-    if (e->impl_.entry_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ == CCC_OCCUPIED)
     {
         void *const erased = multimap_erase(
             e->impl_.t_, key_in_slot(e->impl_.t_, e->impl_.entry_.e_));
@@ -303,11 +302,11 @@ ccc_omm_remove_entry(ccc_ommap_entry *const e)
         if (e->impl_.t_->alloc_)
         {
             e->impl_.t_->alloc_(erased, 0, e->impl_.t_->aux_);
-            return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_OCCUPIED}};
+            return (ccc_entry){{.e_ = NULL, .stats_ = CCC_OCCUPIED}};
         }
-        return (ccc_entry){{.e_ = erased, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = erased, .stats_ = CCC_OCCUPIED}};
     }
-    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 void *
@@ -534,25 +533,25 @@ ccc_omm_unwrap(ccc_ommap_entry const *const e)
 bool
 ccc_omm_insert_error(ccc_ommap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ & CCC_ENTRY_INSERT_ERROR : false;
+    return e ? e->impl_.entry_.stats_ & CCC_INSERT_ERROR : false;
 }
 
 bool
 ccc_omm_input_error(ccc_ommap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ & CCC_ENTRY_INPUT_ERROR : false;
+    return e ? e->impl_.entry_.stats_ & CCC_INPUT_ERROR : false;
 }
 
 bool
 ccc_omm_occupied(ccc_ommap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED : false;
+    return e ? e->impl_.entry_.stats_ & CCC_OCCUPIED : false;
 }
 
 ccc_entry_status
 ccc_omm_entry_status(ccc_ommap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ : CCC_ENTRY_INPUT_ERROR;
+    return e ? e->impl_.entry_.stats_ : CCC_INPUT_ERROR;
 }
 
 bool
@@ -634,10 +633,10 @@ container_entry(struct ccc_tree_ *const t, void const *const key)
     if (found)
     {
         return (struct ccc_tree_entry_){
-            .t_ = t, .entry_ = {.e_ = found, .stats_ = CCC_ENTRY_OCCUPIED}};
+            .t_ = t, .entry_ = {.e_ = found, .stats_ = CCC_OCCUPIED}};
     }
     return (struct ccc_tree_entry_){
-        .t_ = t, .entry_ = {.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+        .t_ = t, .entry_ = {.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 static inline void *
@@ -840,7 +839,7 @@ multimap_insert(struct ccc_tree_ *const t, struct ccc_node_ *const out_handle)
         t->root_ = out_handle;
         t->size_ = 1;
         return (struct ccc_ent_){.e_ = struct_base(t, out_handle),
-                                 .stats_ = CCC_ENTRY_VACANT};
+                                 .stats_ = CCC_VACANT};
     }
     t->size_++;
     void const *const key = key_from_node(t, out_handle);
@@ -851,10 +850,10 @@ multimap_insert(struct ccc_tree_ *const t, struct ccc_node_ *const out_handle)
     {
         add_duplicate(t, t->root_, out_handle, &t->end_);
         return (struct ccc_ent_){.e_ = struct_base(t, out_handle),
-                                 .stats_ = CCC_ENTRY_OCCUPIED};
+                                 .stats_ = CCC_OCCUPIED};
     }
     return (struct ccc_ent_){.e_ = connect_new_root(t, out_handle, root_cmp),
-                             .stats_ = CCC_ENTRY_VACANT};
+                             .stats_ = CCC_VACANT};
 }
 
 static void *

--- a/src/realtime_ordered_map.c
+++ b/src/realtime_ordered_map.c
@@ -180,7 +180,7 @@ ccc_rom_insert(ccc_realtime_ordered_map *const rom,
 {
     if (!rom || !key_val_handle || !tmp)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     struct romap_query_ const q = find(rom, key_from_node(rom, key_val_handle));
     if (CCC_EQL == q.last_cmp_)
@@ -193,13 +193,13 @@ ccc_rom_insert(ccc_realtime_ordered_map *const rom,
         key_val_handle->branch_[L] = key_val_handle->branch_[R]
             = key_val_handle->parent_ = NULL;
         tmp->branch_[L] = tmp->branch_[R] = tmp->parent_ = NULL;
-        return (ccc_entry){{.e_ = old_val, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = old_val, .stats_ = CCC_OCCUPIED}};
     }
     if (!maybe_alloc_insert(rom, q.parent_, q.last_cmp_, key_val_handle))
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -208,21 +208,21 @@ ccc_rom_try_insert(ccc_realtime_ordered_map *const rom,
 {
     if (!rom || !key_val_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     struct romap_query_ const q = find(rom, key_from_node(rom, key_val_handle));
     if (CCC_EQL == q.last_cmp_)
     {
         return (ccc_entry){
-            {.e_ = struct_base(rom, q.found_), .stats_ = CCC_ENTRY_OCCUPIED}};
+            {.e_ = struct_base(rom, q.found_), .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted
         = maybe_alloc_insert(rom, q.parent_, q.last_cmp_, key_val_handle);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -231,7 +231,7 @@ ccc_rom_insert_or_assign(ccc_realtime_ordered_map *const rom,
 {
     if (!rom || !key_val_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     struct romap_query_ const q = find(rom, key_from_node(rom, key_val_handle));
     if (CCC_EQL == q.last_cmp_)
@@ -239,15 +239,15 @@ ccc_rom_insert_or_assign(ccc_realtime_ordered_map *const rom,
         void *const found = struct_base(rom, q.found_);
         *key_val_handle = *elem_in_slot(rom, found);
         memcpy(found, struct_base(rom, key_val_handle), rom->elem_sz_);
-        return (ccc_entry){{.e_ = found, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = found, .stats_ = CCC_OCCUPIED}};
     }
     void *const inserted
         = maybe_alloc_insert(rom, q.parent_, q.last_cmp_, key_val_handle);
     if (!inserted)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_INSERT_ERROR}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_INSERT_ERROR}};
     }
-    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = inserted, .stats_ = CCC_VACANT}};
 }
 
 ccc_romap_entry
@@ -255,7 +255,7 @@ ccc_rom_entry(ccc_realtime_ordered_map const *const rom, void const *const key)
 {
     if (!rom || !key)
     {
-        return (ccc_romap_entry){{.entry_ = {.stats_ = CCC_ENTRY_INPUT_ERROR}}};
+        return (ccc_romap_entry){{.entry_ = {.stats_ = CCC_INPUT_ERROR}}};
     }
     return (ccc_romap_entry){entry(rom, key)};
 }
@@ -267,7 +267,7 @@ ccc_rom_or_insert(ccc_romap_entry const *const e, ccc_romap_elem *const elem)
     {
         return NULL;
     }
-    if (e->impl_.entry_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ == CCC_OCCUPIED)
     {
         return e->impl_.entry_.e_;
     }
@@ -283,7 +283,7 @@ ccc_rom_insert_entry(ccc_romap_entry const *const e, ccc_romap_elem *const elem)
     {
         return NULL;
     }
-    if (e->impl_.entry_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ == CCC_OCCUPIED)
     {
         *elem = *elem_in_slot(e->impl_.rom_, e->impl_.entry_.e_);
         memcpy(e->impl_.entry_.e_, struct_base(e->impl_.rom_, elem),
@@ -300,9 +300,9 @@ ccc_rom_remove_entry(ccc_romap_entry const *const e)
 {
     if (!e)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
-    if (e->impl_.entry_.stats_ == CCC_ENTRY_OCCUPIED)
+    if (e->impl_.entry_.stats_ == CCC_OCCUPIED)
     {
         void *const erased = remove_fixup(
             e->impl_.rom_, elem_in_slot(e->impl_.rom_, e->impl_.entry_.e_));
@@ -310,11 +310,11 @@ ccc_rom_remove_entry(ccc_romap_entry const *const e)
         if (e->impl_.rom_->alloc_)
         {
             e->impl_.rom_->alloc_(erased, 0, e->impl_.rom_->aux_);
-            return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_OCCUPIED}};
+            return (ccc_entry){{.e_ = NULL, .stats_ = CCC_OCCUPIED}};
         }
-        return (ccc_entry){{.e_ = erased, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = erased, .stats_ = CCC_OCCUPIED}};
     }
-    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+    return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
 }
 
 ccc_entry
@@ -323,12 +323,12 @@ ccc_rom_remove(ccc_realtime_ordered_map *const rom,
 {
     if (!rom || !out_handle)
     {
-        return (ccc_entry){{.stats_ = CCC_ENTRY_INPUT_ERROR}};
+        return (ccc_entry){{.stats_ = CCC_INPUT_ERROR}};
     }
     struct romap_query_ const q = find(rom, key_from_node(rom, out_handle));
     if (q.last_cmp_ != CCC_EQL)
     {
-        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_ENTRY_VACANT}};
+        return (ccc_entry){{.e_ = NULL, .stats_ = CCC_VACANT}};
     }
     void *const removed = remove_fixup(rom, q.found_);
     if (rom->alloc_)
@@ -336,9 +336,9 @@ ccc_rom_remove(ccc_realtime_ordered_map *const rom,
         void *const user_struct = struct_base(rom, out_handle);
         memcpy(user_struct, removed, rom->elem_sz_);
         rom->alloc_(removed, 0, rom->aux_);
-        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_ENTRY_OCCUPIED}};
+        return (ccc_entry){{.e_ = user_struct, .stats_ = CCC_OCCUPIED}};
     }
-    return (ccc_entry){{.e_ = removed, .stats_ = CCC_ENTRY_OCCUPIED}};
+    return (ccc_entry){{.e_ = removed, .stats_ = CCC_OCCUPIED}};
 }
 
 ccc_romap_entry *
@@ -348,7 +348,7 @@ ccc_rom_and_modify(ccc_romap_entry *e, ccc_update_fn *fn)
     {
         return NULL;
     }
-    if (fn && e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (fn && e->impl_.entry_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){.user_type = e->impl_.entry_.e_, NULL});
     }
@@ -362,7 +362,7 @@ ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_update_fn *fn, void *aux)
     {
         return NULL;
     }
-    if (fn && e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (fn && e->impl_.entry_.stats_ & CCC_OCCUPIED)
     {
         fn((ccc_user_type){.user_type = e->impl_.entry_.e_, aux});
     }
@@ -372,7 +372,7 @@ ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_update_fn *fn, void *aux)
 void *
 ccc_rom_unwrap(ccc_romap_entry const *const e)
 {
-    if (e && e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED)
+    if (e && e->impl_.entry_.stats_ & CCC_OCCUPIED)
     {
         return e->impl_.entry_.e_;
     }
@@ -382,19 +382,19 @@ ccc_rom_unwrap(ccc_romap_entry const *const e)
 bool
 ccc_rom_occupied(ccc_romap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED : false;
+    return e ? e->impl_.entry_.stats_ & CCC_OCCUPIED : false;
 }
 
 bool
 ccc_rom_insert_error(ccc_romap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ & CCC_ENTRY_INSERT_ERROR : false;
+    return e ? e->impl_.entry_.stats_ & CCC_INSERT_ERROR : false;
 }
 
 ccc_entry_status
 ccc_rom_entry_status(ccc_romap_entry const *const e)
 {
-    return e ? e->impl_.entry_.stats_ : CCC_ENTRY_INPUT_ERROR;
+    return e ? e->impl_.entry_.stats_ : CCC_INPUT_ERROR;
 }
 
 void *
@@ -592,7 +592,7 @@ entry(struct ccc_romap_ const *const rom, void const *const key)
             .last_cmp_ = q.last_cmp_,
             .entry_ = {
                 .e_ = struct_base(rom, q.found_),
-                .stats_ = CCC_ENTRY_OCCUPIED,
+                .stats_ = CCC_OCCUPIED,
             },
         };
     }
@@ -601,7 +601,7 @@ entry(struct ccc_romap_ const *const rom, void const *const key)
         .last_cmp_ = q.last_cmp_,
         .entry_ = {
             .e_ = struct_base(rom, q.parent_),
-            .stats_ = CCC_ENTRY_VACANT | CCC_ENTRY_NO_UNWRAP,
+            .stats_ = CCC_VACANT | CCC_NO_UNWRAP,
         },
     };
 }

--- a/src/types.c
+++ b/src/types.c
@@ -47,6 +47,34 @@ ccc_entry_unwrap(ccc_entry const *const e)
     return e->impl_.stats_ & CCC_ENTRY_NO_UNWRAP ? NULL : e->impl_.e_;
 }
 
+bool
+ccc_handle_occupied(ccc_handle const *const e)
+{
+    return e ? e->impl_.stats_ & CCC_ENTRY_OCCUPIED : false;
+}
+
+bool
+ccc_handle_insert_error(ccc_handle const *const e)
+{
+    return e ? e->impl_.stats_ & CCC_ENTRY_INSERT_ERROR : false;
+}
+
+bool
+ccc_handle_input_error(ccc_handle const *const e)
+{
+    return e ? e->impl_.stats_ & CCC_ENTRY_INPUT_ERROR : false;
+}
+
+ccc_handle_i
+ccc_handle_unwrap(ccc_handle const *const e)
+{
+    if (!e)
+    {
+        return 0;
+    }
+    return e->impl_.stats_ & CCC_ENTRY_NO_UNWRAP ? 0 : e->impl_.i_;
+}
+
 void *
 ccc_begin_range(ccc_range const *const r)
 {
@@ -91,34 +119,50 @@ ccc_get_entry_status(ccc_entry const *e)
     return e->impl_.stats_;
 }
 
+ccc_handle_status
+ccc_get_handle_status(ccc_handle const *e)
+{
+    if (!e)
+    {
+        return CCC_ENTRY_INPUT_ERROR;
+    }
+    return e->impl_.stats_;
+}
+
+char const *
+ccc_handle_status_msg(ccc_handle_status const status)
+{
+    return ccc_entry_status_msg(status);
+}
+
 char const *
 ccc_entry_status_msg(ccc_entry_status const status)
 {
     switch (status)
     {
     case CCC_ENTRY_VACANT:
-        return "entry is Vacant with no errors";
+        return "Vacant with no errors";
         break;
     case CCC_ENTRY_OCCUPIED:
-        return "entry is Occupied and non-NULL";
+        return "Occupied and non-NULL";
         break;
     case CCC_ENTRY_INSERT_ERROR:
-        return "entry should have been inserted but encountered an error";
+        return "should have been inserted but encountered an error";
         break;
     case CCC_ENTRY_SEARCH_ERROR:
-        return "entry encountered an error while searching for a key";
+        return "encountered an error while searching for a key";
         break;
     case CCC_ENTRY_DELETE_ERROR:
-        return "entry encountered an error while trying to delete";
+        return "encountered an error while trying to delete";
         break;
     case CCC_ENTRY_INPUT_ERROR:
-        return "entry could not be produced due to bad input to function";
+        return "could not be produced due to bad input to function";
         break;
     case CCC_ENTRY_NO_UNWRAP:
-        return "entry shall not be unwrapped by user to protect container";
+        return "shall not be unwrapped by user to protect container";
         break;
     default:
-        return "error: entry encountered an unknown combination of flags";
+        return "error: encountered an unknown combination of flags";
         break;
     }
 }

--- a/src/types.c
+++ b/src/types.c
@@ -22,19 +22,19 @@ static char const *const result_msgs[CCC_RESULTS_SIZE] = {
 bool
 ccc_entry_occupied(ccc_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_OCCUPIED : false;
+    return e ? e->impl_.stats_ & CCC_OCCUPIED : false;
 }
 
 bool
 ccc_entry_insert_error(ccc_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_INSERT_ERROR : false;
+    return e ? e->impl_.stats_ & CCC_INSERT_ERROR : false;
 }
 
 bool
 ccc_entry_input_error(ccc_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_INPUT_ERROR : false;
+    return e ? e->impl_.stats_ & CCC_INPUT_ERROR : false;
 }
 
 void *
@@ -44,25 +44,25 @@ ccc_entry_unwrap(ccc_entry const *const e)
     {
         return NULL;
     }
-    return e->impl_.stats_ & CCC_ENTRY_NO_UNWRAP ? NULL : e->impl_.e_;
+    return e->impl_.stats_ & CCC_NO_UNWRAP ? NULL : e->impl_.e_;
 }
 
 bool
 ccc_handle_occupied(ccc_handle const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_OCCUPIED : false;
+    return e ? e->impl_.stats_ & CCC_OCCUPIED : false;
 }
 
 bool
 ccc_handle_insert_error(ccc_handle const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_INSERT_ERROR : false;
+    return e ? e->impl_.stats_ & CCC_INSERT_ERROR : false;
 }
 
 bool
 ccc_handle_input_error(ccc_handle const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_ENTRY_INPUT_ERROR : false;
+    return e ? e->impl_.stats_ & CCC_INPUT_ERROR : false;
 }
 
 ccc_handle_i
@@ -72,7 +72,7 @@ ccc_handle_unwrap(ccc_handle const *const e)
     {
         return 0;
     }
-    return e->impl_.stats_ & CCC_ENTRY_NO_UNWRAP ? 0 : e->impl_.i_;
+    return e->impl_.stats_ & CCC_NO_UNWRAP ? 0 : e->impl_.i_;
 }
 
 void *
@@ -114,7 +114,7 @@ ccc_get_entry_status(ccc_entry const *e)
 {
     if (!e)
     {
-        return CCC_ENTRY_INPUT_ERROR;
+        return CCC_INPUT_ERROR;
     }
     return e->impl_.stats_;
 }
@@ -124,7 +124,7 @@ ccc_get_handle_status(ccc_handle const *e)
 {
     if (!e)
     {
-        return CCC_ENTRY_INPUT_ERROR;
+        return CCC_INPUT_ERROR;
     }
     return e->impl_.stats_;
 }
@@ -140,25 +140,25 @@ ccc_entry_status_msg(ccc_entry_status const status)
 {
     switch (status)
     {
-    case CCC_ENTRY_VACANT:
+    case CCC_VACANT:
         return "Vacant with no errors";
         break;
-    case CCC_ENTRY_OCCUPIED:
+    case CCC_OCCUPIED:
         return "Occupied and non-NULL";
         break;
-    case CCC_ENTRY_INSERT_ERROR:
+    case CCC_INSERT_ERROR:
         return "should have been inserted but encountered an error";
         break;
-    case CCC_ENTRY_SEARCH_ERROR:
+    case CCC_SEARCH_ERROR:
         return "encountered an error while searching for a key";
         break;
-    case CCC_ENTRY_DELETE_ERROR:
+    case CCC_DELETE_ERROR:
         return "encountered an error while trying to delete";
         break;
-    case CCC_ENTRY_INPUT_ERROR:
+    case CCC_INPUT_ERROR:
         return "could not be produced due to bad input to function";
         break;
-    case CCC_ENTRY_NO_UNWRAP:
+    case CCC_NO_UNWRAP:
         return "shall not be unwrapped by user to protect container";
         break;
     default:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -291,6 +291,36 @@ add_fhmap_test(test_fhmap_erase)
 add_fhmap_test(test_fhmap_lru)
 add_fhmap_test(test_fhmap_entry)
 
+#############  Handle Hash Map ##########################
+
+add_library(hhmap_util hhmap/hhmap_util.h hhmap/hhmap_util.c)
+target_link_libraries(hhmap_util
+    ccc
+)
+
+macro(add_hhmap_test TEST_NAME)
+  add_executable(${TEST_NAME} hhmap/${TEST_NAME}.c)
+  target_include_directories(${TEST_NAME} PRIVATE "../util")
+  target_link_libraries(${TEST_NAME}
+    PRIVATE
+      checkers
+      hhmap_util
+      ccc
+      alloc
+  )
+  set_target_properties(${TEST_NAME} 
+    PROPERTIES 
+      RUNTIME_OUTPUT_DIRECTORY 
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests
+  )
+endmacro()
+
+add_hhmap_test(test_hhmap_construct)
+#add_hhmap_test(test_hhmap_insert)
+#add_hhmap_test(test_hhmap_erase)
+#add_hhmap_test(test_hhmap_lru)
+#add_hhmap_test(test_hhmap_entry)
+
 #############  Doubly Linked List ##########################
 
 add_library(dll_util dll/dll_util.h dll/dll_util.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -317,7 +317,7 @@ endmacro()
 
 add_hhmap_test(test_hhmap_construct)
 add_hhmap_test(test_hhmap_insert)
-#add_hhmap_test(test_hhmap_erase)
+add_hhmap_test(test_hhmap_erase)
 #add_hhmap_test(test_hhmap_lru)
 #add_hhmap_test(test_hhmap_entry)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -319,7 +319,7 @@ add_hhmap_test(test_hhmap_construct)
 add_hhmap_test(test_hhmap_insert)
 add_hhmap_test(test_hhmap_erase)
 #add_hhmap_test(test_hhmap_lru)
-#add_hhmap_test(test_hhmap_entry)
+add_hhmap_test(test_hhmap_handle)
 
 #############  Doubly Linked List ##########################
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -316,7 +316,7 @@ macro(add_hhmap_test TEST_NAME)
 endmacro()
 
 add_hhmap_test(test_hhmap_construct)
-#add_hhmap_test(test_hhmap_insert)
+add_hhmap_test(test_hhmap_insert)
 #add_hhmap_test(test_hhmap_erase)
 #add_hhmap_test(test_hhmap_lru)
 #add_hhmap_test(test_hhmap_entry)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -318,7 +318,7 @@ endmacro()
 add_hhmap_test(test_hhmap_construct)
 add_hhmap_test(test_hhmap_insert)
 add_hhmap_test(test_hhmap_erase)
-#add_hhmap_test(test_hhmap_lru)
+add_hhmap_test(test_hhmap_lru)
 add_hhmap_test(test_hhmap_handle)
 
 #############  Doubly Linked List ##########################

--- a/tests/hhmap/hhmap_util.c
+++ b/tests/hhmap/hhmap_util.c
@@ -1,0 +1,54 @@
+#include "hhmap_util.h"
+#include "types.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+uint64_t
+hhmap_int_zero(ccc_user_key const)
+{
+    return 0;
+}
+
+uint64_t
+hhmap_int_last_digit(ccc_user_key const n)
+{
+    return *((int *)n.user_key) % 10;
+}
+
+bool
+hhmap_id_eq(ccc_key_cmp const cmp)
+{
+    struct val const *const va = cmp.user_type_rhs;
+    return va->key == *((int *)cmp.key_lhs);
+}
+
+uint64_t
+hhmap_int_to_u64(ccc_user_key const k)
+{
+    int const id_int = *((int *)k.user_key);
+    uint64_t x = id_int;
+    x = (x ^ (x >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)) * UINT64_C(0x94d049bb133111eb);
+    x = x ^ (x >> 31);
+    return x;
+}
+
+void
+hhmap_modplus(ccc_user_type const mod)
+{
+    ((struct val *)mod.user_type)->val++;
+}
+
+struct val
+hhmap_create(int const id, int const val)
+{
+    return (struct val){.key = id, .val = val};
+}
+
+void
+hhmap_swap_val(ccc_user_type const u)
+{
+    struct val *v = u.user_type;
+    v->val = *((int *)u.aux);
+}

--- a/tests/hhmap/hhmap_util.h
+++ b/tests/hhmap/hhmap_util.h
@@ -1,0 +1,25 @@
+#ifndef CCC_HHMAP_UTIL_H
+#define CCC_HHMAP_UTIL_H
+
+#include "handle_hash_map.h"
+#include "types.h"
+
+#include <stdint.h>
+
+struct val
+{
+    int key;
+    ccc_hhmap_elem e;
+    int val;
+};
+
+uint64_t hhmap_int_zero(ccc_user_key);
+uint64_t hhmap_int_last_digit(ccc_user_key);
+uint64_t hhmap_int_to_u64(ccc_user_key);
+bool hhmap_id_eq(ccc_key_cmp);
+
+void hhmap_modplus(ccc_user_type);
+struct val hhmap_create(int id, int val);
+void hhmap_swap_val(ccc_user_type u);
+
+#endif /* CCC_HHMAP_UTIL_H */

--- a/tests/hhmap/test_hhmap_construct.c
+++ b/tests/hhmap/test_hhmap_construct.c
@@ -1,0 +1,333 @@
+#include <stddef.h>
+
+#define HANDLE_HASH_MAP_USING_NAMESPACE_CCC
+#define TRAITS_USING_NAMESPACE_CCC
+#include "alloc.h"
+#include "checkers.h"
+#include "handle_hash_map.h"
+#include "hhmap_util.h"
+#include "traits.h"
+#include "types.h"
+
+static void
+mod(ccc_user_type const u)
+{
+    struct val *v = u.user_type;
+    v->val += 5;
+}
+
+static void
+modw(ccc_user_type const u)
+{
+    struct val *v = u.user_type;
+    v->val = *((int *)u.aux);
+}
+
+static int
+def(int *to_affect)
+{
+    *to_affect += 1;
+    return 0;
+}
+
+static int
+gen(int *to_affect)
+{
+    *to_affect = 0;
+    return 42;
+}
+
+static struct val s_vals[10];
+static handle_hash_map static_fh
+    = hhm_init(s_vals, sizeof(s_vals) / sizeof(s_vals[0]), e, key, NULL,
+               hhmap_int_to_u64, hhmap_id_eq, NULL);
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_static_init)
+{
+    CHECK(hhm_capacity(&static_fh), sizeof(s_vals) / sizeof(s_vals[0]));
+    CHECK(hhm_size(&static_fh), 0);
+    CHECK(hhm_validate(&static_fh), true);
+    CHECK(hhm_is_empty(&static_fh), true);
+    struct val def = {.key = 137, .val = 0};
+
+    /* Returning a vacant hhm_entry is possible when modification is attempted.
+     */
+    hhmap_entry *ent = hhm_and_modify(hhm_entry_r(&static_fh, &def.key), mod);
+    CHECK(hhm_occupied(ent), false);
+    CHECK((hhm_unwrap(ent) == 0), true);
+
+    /* Inserting default value before an in place modification is possible. */
+    ccc_handle h = hhm_or_insert(hhm_entry_r(&static_fh, &def.key), &def.e);
+    CHECK(h, true);
+    struct val *v = hhm_at(&static_fh, h);
+    CHECK(v != NULL, true);
+    v->val++;
+    h = hhm_get_key_val(&static_fh, &def.key);
+    struct val const *const inserted = hhm_at(&static_fh, h);
+    CHECK((inserted != NULL), true);
+    CHECK(inserted->key, 137);
+    CHECK(inserted->val, 1);
+
+    /* Modifying an existing value or inserting default is possible when no
+       auxiliary input is needed. */
+    struct val *v2 = hhm_or_insert(
+        hhm_and_modify(hhm_entry_r(&static_fh, &def.key), mod), &def.e);
+    CHECK((v2 != NULL), true);
+    CHECK(inserted->key, 137);
+    CHECK(v2->val, 6);
+
+    /* Modifying an existing value that requires external input is also
+       possible with slightly different signature. */
+    struct val *v3 = hhm_or_insert(
+        hhm_and_modify_aux(hhm_entry_r(&static_fh, &def.key), modw, &def.key),
+        &def.e);
+    CHECK((v3 != NULL), true);
+    CHECK(inserted->key, 137);
+    CHECK(v3->val, 137);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_copy_no_alloc)
+{
+    handle_hash_map src = hhm_init((struct val[11]){}, 11, e, key, NULL,
+                                   hhmap_int_zero, hhmap_id_eq, NULL);
+    handle_hash_map dst = hhm_init((struct val[13]){}, 13, e, key, NULL,
+                                   hhmap_int_zero, hhmap_id_eq, NULL);
+    (void)hhm_insert(&src, &(struct val){.key = 0}.e);
+    (void)hhm_insert(&src, &(struct val){.key = 1, .val = 1}.e);
+    (void)hhm_insert(&src, &(struct val){.key = 2, .val = 2}.e);
+    CHECK(hhm_size(&src), 3);
+    CHECK(hhm_is_empty(&dst), true);
+    ccc_result res = hhm_copy(&dst, &src, NULL);
+    CHECK(res, CCC_OK);
+    CHECK(hhm_size(&dst), hhm_size(&src));
+    for (int i = 0; i < 3; ++i)
+    {
+        ccc_entry src_e = hhm_remove(&src, &(struct val){.key = i}.e);
+        ccc_entry dst_e = hhm_remove(&dst, &(struct val){.key = i}.e);
+        CHECK(occupied(&src_e), occupied(&dst_e));
+    }
+    CHECK(hhm_is_empty(&src), hhm_is_empty(&dst));
+    CHECK(hhm_is_empty(&dst), true);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_copy_no_alloc_fail)
+{
+    handle_hash_map src = hhm_init((struct val[11]){}, 11, e, key, NULL,
+                                   hhmap_int_zero, hhmap_id_eq, NULL);
+    handle_hash_map dst = hhm_init((struct val[7]){}, 7, e, key, NULL,
+                                   hhmap_int_zero, hhmap_id_eq, NULL);
+    (void)hhm_insert(&src, &(struct val){.key = 0}.e);
+    (void)hhm_insert(&src, &(struct val){.key = 1, .val = 1}.e);
+    (void)hhm_insert(&src, &(struct val){.key = 2, .val = 2}.e);
+    CHECK(hhm_size(&src), 3);
+    CHECK(hhm_is_empty(&dst), true);
+    ccc_result res = hhm_copy(&dst, &src, NULL);
+    CHECK(res != CCC_OK, true);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_copy_alloc)
+{
+    handle_hash_map src = hhm_init((struct val *)NULL, 0, e, key, std_alloc,
+                                   hhmap_int_zero, hhmap_id_eq, NULL);
+    handle_hash_map dst = hhm_init((struct val *)NULL, 0, e, key, std_alloc,
+                                   hhmap_int_zero, hhmap_id_eq, NULL);
+    (void)hhm_insert(&src, &(struct val){.key = 0}.e);
+    (void)hhm_insert(&src, &(struct val){.key = 1, .val = 1}.e);
+    (void)hhm_insert(&src, &(struct val){.key = 2, .val = 2}.e);
+    CHECK(hhm_size(&src), 3);
+    CHECK(hhm_is_empty(&dst), true);
+    ccc_result res = hhm_copy(&dst, &src, std_alloc);
+    CHECK(res, CCC_OK);
+    CHECK(hhm_size(&dst), hhm_size(&src));
+    for (int i = 0; i < 3; ++i)
+    {
+        ccc_entry src_e = hhm_remove(&src, &(struct val){.key = i}.e);
+        ccc_entry dst_e = hhm_remove(&dst, &(struct val){.key = i}.e);
+        CHECK(occupied(&src_e), occupied(&dst_e));
+    }
+    CHECK(hhm_is_empty(&src), hhm_is_empty(&dst));
+    CHECK(hhm_is_empty(&dst), true);
+    CHECK_END_FN({
+        (void)hhm_clear_and_free(&src, NULL);
+        (void)hhm_clear_and_free(&dst, NULL);
+    });
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_copy_alloc_fail)
+{
+    handle_hash_map src = hhm_init((struct val *)NULL, 0, e, key, std_alloc,
+                                   hhmap_int_zero, hhmap_id_eq, NULL);
+    handle_hash_map dst = hhm_init((struct val *)NULL, 0, e, key, std_alloc,
+                                   hhmap_int_zero, hhmap_id_eq, NULL);
+    (void)hhm_insert(&src, &(struct val){.key = 0}.e);
+    (void)hhm_insert(&src, &(struct val){.key = 1, .val = 1}.e);
+    (void)hhm_insert(&src, &(struct val){.key = 2, .val = 2}.e);
+    CHECK(hhm_size(&src), 3);
+    CHECK(hhm_is_empty(&dst), true);
+    ccc_result res = hhm_copy(&dst, &src, NULL);
+    CHECK(res != CCC_OK, true);
+    CHECK_END_FN({ (void)hhm_clear_and_free(&src, NULL); });
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_empty)
+{
+    struct val vals[5] = {};
+    handle_hash_map fh = hhm_init(vals, sizeof(vals) / sizeof(vals[0]), key, e,
+                                  NULL, hhmap_int_zero, hhmap_id_eq, NULL);
+    CHECK(hhm_is_empty(&fh), true);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_functional)
+{
+    handle_hash_map fh = hhm_init((struct val[5]){}, 5, e, key, NULL,
+                                  hhmap_int_zero, hhmap_id_eq, NULL);
+    CHECK(hhm_is_empty(&fh), true);
+    struct val def = {.key = 137, .val = 0};
+    hhmap_entry ent = hhm_entry(&fh, &def.key);
+    CHECK(hhm_unwrap(&ent) == NULL, true);
+    struct val *v = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    CHECK(v != NULL, true);
+    v->val += 1;
+    struct val const *const inserted = hhm_get_key_val(&fh, &def.key);
+    CHECK((inserted != NULL), true);
+    CHECK(inserted->val, 1);
+    v = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    CHECK(v != NULL, true);
+    v->val += 1;
+    CHECK(inserted->val, 2);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_macros)
+{
+    handle_hash_map fh = hhm_init((struct val[5]){}, 5, e, key, NULL,
+                                  hhmap_int_zero, hhmap_id_eq, NULL);
+    CHECK(hhm_is_empty(&fh), true);
+    CHECK(get_key_val(&fh, &(int){137}) == NULL, true);
+    int const key = 137;
+    int mut = 99;
+    /* The function with a side effect should execute. */
+    struct val *inserted = hhm_or_insert_w(
+        hhm_entry_r(&fh, &key), (struct val){.key = key, .val = def(&mut)});
+    CHECK(inserted != NULL, true);
+    CHECK(mut, 100);
+    CHECK(inserted->val, 0);
+    /* The function with a side effect should NOT execute. */
+    struct val *v = hhm_or_insert_w(hhm_entry_r(&fh, &key),
+                                    (struct val){.key = key, .val = def(&mut)});
+    CHECK(v != NULL, true);
+    v->val++;
+    CHECK(mut, 100);
+    CHECK(inserted->val, 1);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_functional)
+{
+    handle_hash_map fh = hhm_init((struct val[5]){}, 5, e, key, NULL,
+                                  hhmap_int_zero, hhmap_id_eq, NULL);
+    CHECK(hhm_is_empty(&fh), true);
+    struct val def = {.key = 137, .val = 0};
+
+    /* Returning a vacant hhm_entry is possible when modification is attempted.
+     */
+    hhmap_entry *ent = hhm_and_modify(hhm_entry_r(&fh, &def.key), mod);
+    CHECK(hhm_occupied(ent), false);
+    CHECK((hhm_unwrap(ent) == NULL), true);
+
+    /* Inserting default value before an in place modification is possible. */
+    struct val *v = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    CHECK(v != NULL, true);
+    v->val++;
+    struct val const *const inserted = hhm_get_key_val(&fh, &def.key);
+    CHECK((inserted != NULL), true);
+    CHECK(inserted->key, 137);
+    CHECK(inserted->val, 1);
+
+    /* Modifying an existing value or inserting default is possible when no
+       auxiliary input is needed. */
+    struct val *v2 = hhm_or_insert(
+        hhm_and_modify(hhm_entry_r(&fh, &def.key), mod), &def.e);
+    CHECK((v2 != NULL), true);
+    CHECK(inserted->key, 137);
+    CHECK(v2->val, 6);
+
+    /* Modifying an existing value that requires external input is also
+       possible with slightly different signature. */
+    struct val *v3 = hhm_or_insert(
+        hhm_and_modify_aux(hhm_entry_r(&fh, &def.key), modw, &def.key), &def.e);
+    CHECK((v3 != NULL), true);
+    CHECK(inserted->key, 137);
+    CHECK(v3->val, 137);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_macros)
+{
+    handle_hash_map fh = hhm_init((struct val[5]){}, 5, e, key, NULL,
+                                  hhmap_int_zero, hhmap_id_eq, NULL);
+    CHECK(hhm_is_empty(&fh), true);
+
+    /* Returning a vacant hhm_entry is possible when modification is attempted.
+     */
+    hhmap_entry *ent = hhm_and_modify(hhm_entry_r(&fh, &(int){137}), mod);
+    CHECK(hhm_occupied(ent), false);
+    CHECK((hhm_unwrap(ent) == NULL), true);
+
+    int mut = 99;
+
+    /* Inserting default value before an in place modification is possible. */
+    struct val *v = hhm_or_insert_w(
+        hhm_and_modify_w(hhm_entry_r(&fh, &(int){137}), struct val,
+                         {
+                             T->val = gen(&mut);
+                         }),
+        (struct val){.key = 137, .val = def(&mut)});
+    CHECK((v != NULL), true);
+    CHECK(v->key, 137);
+    CHECK(v->val, 0);
+    CHECK(mut, 100);
+
+    /* Modifying an existing value or inserting default is possible when no
+       auxiliary input is needed. */
+    struct val *v2
+        = hhm_or_insert_w(hhm_and_modify(hhm_entry_r(&fh, &(int){137}), mod),
+                          (struct val){.key = 137, .val = def(&mut)});
+    CHECK((v2 != NULL), true);
+    CHECK(v2->key, 137);
+    CHECK(v2->val, 5);
+    CHECK(mut, 100);
+
+    /* Modifying an existing value that requires external input is also
+       possible with slightly different signature. Generate val also has
+       lazy evaluation. The function gen executes with its side effect,
+       but the function def does not execute and therefore does not modify
+       mut. */
+    struct val *v3 = hhm_or_insert_w(
+        hhm_and_modify_w(hhm_entry_r(&fh, &(int){137}), struct val,
+                         {
+                             T->val = gen(&mut);
+                         }),
+        (struct val){.key = 137, .val = def(&mut)});
+    CHECK((v3 != NULL), true);
+    CHECK(v3->key, 137);
+    CHECK(v3->val, 42);
+    CHECK(mut, 0);
+    CHECK_END_FN();
+}
+
+int
+main()
+{
+    return CHECK_RUN(hhmap_test_static_init(), hhmap_test_copy_no_alloc(),
+                     hhmap_test_copy_no_alloc_fail(), hhmap_test_copy_alloc(),
+                     hhmap_test_copy_alloc_fail(), hhmap_test_empty(),
+                     hhmap_test_hhm_entry_macros(),
+                     hhmap_test_hhm_entry_functional(),
+                     hhmap_test_hhm_entry_hhm_and_modify_functional(),
+                     hhmap_test_hhm_entry_hhm_and_modify_macros());
+}

--- a/tests/hhmap/test_hhmap_construct.c
+++ b/tests/hhmap/test_hhmap_construct.c
@@ -50,14 +50,14 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_static_init)
     CHECK(hhm_is_empty(&static_fh), true);
     struct val def = {.key = 137, .val = 0};
 
-    /* Returning a vacant hhm_entry is possible when modification is attempted.
+    /* Returning a vacant hhm_handle is possible when modification is attempted.
      */
-    hhmap_entry *ent = hhm_and_modify(hhm_entry_r(&static_fh, &def.key), mod);
+    hhmap_handle *ent = hhm_and_modify(hhm_handle_r(&static_fh, &def.key), mod);
     CHECK(hhm_occupied(ent), false);
     CHECK((hhm_unwrap(ent) == 0), true);
 
     /* Inserting default value before an in place modification is possible. */
-    ccc_handle h = hhm_or_insert(hhm_entry_r(&static_fh, &def.key), &def.e);
+    ccc_handle_i h = hhm_or_insert(hhm_handle_r(&static_fh, &def.key), &def.e);
     CHECK(h != 0, true);
     struct val *v = hhm_at(&static_fh, h);
     CHECK(v != NULL, true);
@@ -70,7 +70,7 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_static_init)
 
     /* Modifying an existing value or inserting default is possible when no
        auxiliary input is needed. */
-    h = hhm_or_insert(hhm_and_modify(hhm_entry_r(&static_fh, &def.key), mod),
+    h = hhm_or_insert(hhm_and_modify(hhm_handle_r(&static_fh, &def.key), mod),
                       &def.e);
     struct val *const v2 = hhm_at(&static_fh, h);
     CHECK((v2 != NULL), true);
@@ -80,7 +80,7 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_static_init)
     /* Modifying an existing value that requires external input is also
        possible with slightly different signature. */
     h = hhm_or_insert(
-        hhm_and_modify_aux(hhm_entry_r(&static_fh, &def.key), modw, &def.key),
+        hhm_and_modify_aux(hhm_handle_r(&static_fh, &def.key), modw, &def.key),
         &def.e);
     struct val *const v3 = hhm_at(&static_fh, h);
     CHECK((v3 != NULL), true);
@@ -111,8 +111,8 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_copy_no_alloc)
     CHECK(hhm_size(&dst), hhm_size(&src));
     for (int i = 0; i < 3; ++i)
     {
-        ccc_entry src_e = hhm_remove(&src, &(struct val){.key = i}.e);
-        ccc_entry dst_e = hhm_remove(&dst, &(struct val){.key = i}.e);
+        ccc_handle src_e = hhm_remove(&src, &(struct val){.key = i}.e);
+        ccc_handle dst_e = hhm_remove(&dst, &(struct val){.key = i}.e);
         CHECK(occupied(&src_e), occupied(&dst_e));
     }
     CHECK(hhm_is_empty(&src), hhm_is_empty(&dst));
@@ -158,8 +158,8 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_copy_alloc)
     CHECK(hhm_size(&dst), hhm_size(&src));
     for (int i = 0; i < 3; ++i)
     {
-        ccc_entry src_e = hhm_remove(&src, &(struct val){.key = i}.e);
-        ccc_entry dst_e = hhm_remove(&dst, &(struct val){.key = i}.e);
+        ccc_handle src_e = hhm_remove(&src, &(struct val){.key = i}.e);
+        ccc_handle dst_e = hhm_remove(&dst, &(struct val){.key = i}.e);
         CHECK(occupied(&src_e), occupied(&dst_e));
     }
     CHECK(hhm_is_empty(&src), hhm_is_empty(&dst));
@@ -195,15 +195,15 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_empty)
     CHECK_END_FN();
 }
 
-CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_functional)
+CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_handle_functional)
 {
     handle_hash_map fh = hhm_init((struct val[5]){}, 5, e, key, NULL,
                                   hhmap_int_zero, hhmap_id_eq, NULL);
     CHECK(hhm_is_empty(&fh), true);
     struct val def = {.key = 137, .val = 0};
-    hhmap_entry ent = hhm_entry(&fh, &def.key);
+    hhmap_handle ent = hhm_handle(&fh, &def.key);
     CHECK(hhm_unwrap(&ent), false);
-    ccc_handle h = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    ccc_handle_i h = hhm_or_insert(hhm_handle_r(&fh, &def.key), &def.e);
     struct val *v = hhm_at(&fh, h);
     CHECK(v != NULL, true);
     v->val += 1;
@@ -211,7 +211,7 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_functional)
     struct val const *const inserted = hhm_at(&fh, h);
     CHECK((inserted != NULL), true);
     CHECK(inserted->val, 1);
-    h = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    h = hhm_or_insert(hhm_handle_r(&fh, &def.key), &def.e);
     v = hhm_at(&fh, h);
     CHECK(v != NULL, true);
     v->val += 1;
@@ -219,7 +219,7 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_functional)
     CHECK_END_FN();
 }
 
-CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_macros)
+CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_handle_macros)
 {
     handle_hash_map fh = hhm_init((struct val[5]){}, 5, e, key, NULL,
                                   hhmap_int_zero, hhmap_id_eq, NULL);
@@ -228,14 +228,14 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_macros)
     int const key = 137;
     int mut = 99;
     /* The function with a side effect should execute. */
-    ccc_handle h = hhm_or_insert_w(hhm_entry_r(&fh, &key),
-                                   (struct val){.key = key, .val = def(&mut)});
+    ccc_handle_i h = hhm_or_insert_w(
+        hhm_handle_r(&fh, &key), (struct val){.key = key, .val = def(&mut)});
     struct val *inserted = hhm_at(&fh, h);
     CHECK(inserted != NULL, true);
     CHECK(mut, 100);
     CHECK(inserted->val, 0);
     /* The function with a side effect should NOT execute. */
-    h = hhm_or_insert_w(hhm_entry_r(&fh, &key),
+    h = hhm_or_insert_w(hhm_handle_r(&fh, &key),
                         (struct val){.key = key, .val = def(&mut)});
     struct val *v = hhm_at(&fh, h);
     CHECK(v != NULL, true);
@@ -245,21 +245,21 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_macros)
     CHECK_END_FN();
 }
 
-CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_functional)
+CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_handle_hhm_and_modify_functional)
 {
     handle_hash_map fh = hhm_init((struct val[5]){}, 5, e, key, NULL,
                                   hhmap_int_zero, hhmap_id_eq, NULL);
     CHECK(hhm_is_empty(&fh), true);
     struct val def = {.key = 137, .val = 0};
 
-    /* Returning a vacant hhm_entry is possible when modification is attempted.
+    /* Returning a vacant hhm_handle is possible when modification is attempted.
      */
-    hhmap_entry *ent = hhm_and_modify(hhm_entry_r(&fh, &def.key), mod);
+    hhmap_handle *ent = hhm_and_modify(hhm_handle_r(&fh, &def.key), mod);
     CHECK(hhm_occupied(ent), false);
     CHECK(hhm_unwrap(ent), false);
 
     /* Inserting default value before an in place modification is possible. */
-    ccc_handle h = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    ccc_handle_i h = hhm_or_insert(hhm_handle_r(&fh, &def.key), &def.e);
     struct val *v = hhm_at(&fh, h);
     CHECK(v != NULL, true);
     v->val++;
@@ -271,7 +271,7 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_functional)
 
     /* Modifying an existing value or inserting default is possible when no
        auxiliary input is needed. */
-    h = hhm_or_insert(hhm_and_modify(hhm_entry_r(&fh, &def.key), mod), &def.e);
+    h = hhm_or_insert(hhm_and_modify(hhm_handle_r(&fh, &def.key), mod), &def.e);
     struct val *v2 = hhm_at(&fh, h);
     CHECK((v2 != NULL), true);
     CHECK(inserted->key, 137);
@@ -280,7 +280,8 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_functional)
     /* Modifying an existing value that requires external input is also
        possible with slightly different signature. */
     h = hhm_or_insert(
-        hhm_and_modify_aux(hhm_entry_r(&fh, &def.key), modw, &def.key), &def.e);
+        hhm_and_modify_aux(hhm_handle_r(&fh, &def.key), modw, &def.key),
+        &def.e);
     struct val *v3 = hhm_at(&fh, h);
     CHECK((v3 != NULL), true);
     CHECK(inserted->key, 137);
@@ -288,23 +289,23 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_functional)
     CHECK_END_FN();
 }
 
-CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_macros)
+CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_handle_hhm_and_modify_macros)
 {
     handle_hash_map fh = hhm_init((struct val[5]){}, 5, e, key, NULL,
                                   hhmap_int_zero, hhmap_id_eq, NULL);
     CHECK(hhm_is_empty(&fh), true);
 
-    /* Returning a vacant hhm_entry is possible when modification is attempted.
+    /* Returning a vacant hhm_handle is possible when modification is attempted.
      */
-    hhmap_entry *ent = hhm_and_modify(hhm_entry_r(&fh, &(int){137}), mod);
+    hhmap_handle *ent = hhm_and_modify(hhm_handle_r(&fh, &(int){137}), mod);
     CHECK(hhm_occupied(ent), false);
     CHECK(hhm_unwrap(ent), false);
 
     int mut = 99;
 
     /* Inserting default value before an in place modification is possible. */
-    ccc_handle h
-        = hhm_or_insert_w(hhm_and_modify_w(hhm_entry_r(&fh, &(int){137}),
+    ccc_handle_i h
+        = hhm_or_insert_w(hhm_and_modify_w(hhm_handle_r(&fh, &(int){137}),
                                            struct val, { T->val = gen(&mut); }),
                           (struct val){.key = 137, .val = def(&mut)});
     struct val *v = hhm_at(&fh, h);
@@ -315,7 +316,7 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_macros)
 
     /* Modifying an existing value or inserting default is possible when no
        auxiliary input is needed. */
-    h = hhm_or_insert_w(hhm_and_modify(hhm_entry_r(&fh, &(int){137}), mod),
+    h = hhm_or_insert_w(hhm_and_modify(hhm_handle_r(&fh, &(int){137}), mod),
                         (struct val){.key = 137, .val = def(&mut)});
     struct val *v2 = hhm_at(&fh, h);
     CHECK((v2 != NULL), true);
@@ -328,7 +329,7 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_macros)
        lazy evaluation. The function gen executes with its side effect,
        but the function def does not execute and therefore does not modify
        mut. */
-    h = hhm_or_insert_w(hhm_and_modify_w(hhm_entry_r(&fh, &(int){137}),
+    h = hhm_or_insert_w(hhm_and_modify_w(hhm_handle_r(&fh, &(int){137}),
                                          struct val, { T->val = gen(&mut); }),
                         (struct val){.key = 137, .val = def(&mut)});
     struct val *v3 = hhm_at(&fh, h);
@@ -345,8 +346,8 @@ main()
     return CHECK_RUN(hhmap_test_static_init(), hhmap_test_copy_no_alloc(),
                      hhmap_test_copy_no_alloc_fail(), hhmap_test_copy_alloc(),
                      hhmap_test_copy_alloc_fail(), hhmap_test_empty(),
-                     hhmap_test_hhm_entry_macros(),
-                     hhmap_test_hhm_entry_functional(),
-                     hhmap_test_hhm_entry_hhm_and_modify_functional(),
-                     hhmap_test_hhm_entry_hhm_and_modify_macros());
+                     hhmap_test_hhm_handle_macros(),
+                     hhmap_test_hhm_handle_functional(),
+                     hhmap_test_hhm_handle_hhm_and_modify_functional(),
+                     hhmap_test_hhm_handle_hhm_and_modify_macros());
 }

--- a/tests/hhmap/test_hhmap_construct.c
+++ b/tests/hhmap/test_hhmap_construct.c
@@ -58,7 +58,7 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_static_init)
 
     /* Inserting default value before an in place modification is possible. */
     ccc_handle h = hhm_or_insert(hhm_entry_r(&static_fh, &def.key), &def.e);
-    CHECK(h, true);
+    CHECK(h != 0, true);
     struct val *v = hhm_at(&static_fh, h);
     CHECK(v != NULL, true);
     v->val++;
@@ -70,17 +70,19 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_static_init)
 
     /* Modifying an existing value or inserting default is possible when no
        auxiliary input is needed. */
-    struct val *v2 = hhm_or_insert(
-        hhm_and_modify(hhm_entry_r(&static_fh, &def.key), mod), &def.e);
+    h = hhm_or_insert(hhm_and_modify(hhm_entry_r(&static_fh, &def.key), mod),
+                      &def.e);
+    struct val *const v2 = hhm_at(&static_fh, h);
     CHECK((v2 != NULL), true);
     CHECK(inserted->key, 137);
     CHECK(v2->val, 6);
 
     /* Modifying an existing value that requires external input is also
        possible with slightly different signature. */
-    struct val *v3 = hhm_or_insert(
+    h = hhm_or_insert(
         hhm_and_modify_aux(hhm_entry_r(&static_fh, &def.key), modw, &def.key),
         &def.e);
+    struct val *const v3 = hhm_at(&static_fh, h);
     CHECK((v3 != NULL), true);
     CHECK(inserted->key, 137);
     CHECK(v3->val, 137);
@@ -94,8 +96,14 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_copy_no_alloc)
     handle_hash_map dst = hhm_init((struct val[13]){}, 13, e, key, NULL,
                                    hhmap_int_zero, hhmap_id_eq, NULL);
     (void)hhm_insert(&src, &(struct val){.key = 0}.e);
+    CHECK(hhm_contains(&src, &(int){0}), true);
     (void)hhm_insert(&src, &(struct val){.key = 1, .val = 1}.e);
+    CHECK(hhm_contains(&src, &(int){0}), true);
+    CHECK(hhm_contains(&src, &(int){1}), true);
     (void)hhm_insert(&src, &(struct val){.key = 2, .val = 2}.e);
+    CHECK(hhm_contains(&src, &(int){0}), true);
+    CHECK(hhm_contains(&src, &(int){1}), true);
+    CHECK(hhm_contains(&src, &(int){2}), true);
     CHECK(hhm_size(&src), 3);
     CHECK(hhm_is_empty(&dst), true);
     ccc_result res = hhm_copy(&dst, &src, NULL);
@@ -135,8 +143,14 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_copy_alloc)
     handle_hash_map dst = hhm_init((struct val *)NULL, 0, e, key, std_alloc,
                                    hhmap_int_zero, hhmap_id_eq, NULL);
     (void)hhm_insert(&src, &(struct val){.key = 0}.e);
+    CHECK(hhm_contains(&src, &(int){0}), true);
     (void)hhm_insert(&src, &(struct val){.key = 1, .val = 1}.e);
+    CHECK(hhm_contains(&src, &(int){0}), true);
+    CHECK(hhm_contains(&src, &(int){1}), true);
     (void)hhm_insert(&src, &(struct val){.key = 2, .val = 2}.e);
+    CHECK(hhm_contains(&src, &(int){0}), true);
+    CHECK(hhm_contains(&src, &(int){1}), true);
+    CHECK(hhm_contains(&src, &(int){2}), true);
     CHECK(hhm_size(&src), 3);
     CHECK(hhm_is_empty(&dst), true);
     ccc_result res = hhm_copy(&dst, &src, std_alloc);
@@ -188,14 +202,17 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_functional)
     CHECK(hhm_is_empty(&fh), true);
     struct val def = {.key = 137, .val = 0};
     hhmap_entry ent = hhm_entry(&fh, &def.key);
-    CHECK(hhm_unwrap(&ent) == NULL, true);
-    struct val *v = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    CHECK(hhm_unwrap(&ent), false);
+    ccc_handle h = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    struct val *v = hhm_at(&fh, h);
     CHECK(v != NULL, true);
     v->val += 1;
-    struct val const *const inserted = hhm_get_key_val(&fh, &def.key);
+    h = hhm_get_key_val(&fh, &def.key);
+    struct val const *const inserted = hhm_at(&fh, h);
     CHECK((inserted != NULL), true);
     CHECK(inserted->val, 1);
-    v = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    h = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    v = hhm_at(&fh, h);
     CHECK(v != NULL, true);
     v->val += 1;
     CHECK(inserted->val, 2);
@@ -207,18 +224,20 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_macros)
     handle_hash_map fh = hhm_init((struct val[5]){}, 5, e, key, NULL,
                                   hhmap_int_zero, hhmap_id_eq, NULL);
     CHECK(hhm_is_empty(&fh), true);
-    CHECK(get_key_val(&fh, &(int){137}) == NULL, true);
+    CHECK(hhm_get_key_val(&fh, &(int){137}), false);
     int const key = 137;
     int mut = 99;
     /* The function with a side effect should execute. */
-    struct val *inserted = hhm_or_insert_w(
-        hhm_entry_r(&fh, &key), (struct val){.key = key, .val = def(&mut)});
+    ccc_handle h = hhm_or_insert_w(hhm_entry_r(&fh, &key),
+                                   (struct val){.key = key, .val = def(&mut)});
+    struct val *inserted = hhm_at(&fh, h);
     CHECK(inserted != NULL, true);
     CHECK(mut, 100);
     CHECK(inserted->val, 0);
     /* The function with a side effect should NOT execute. */
-    struct val *v = hhm_or_insert_w(hhm_entry_r(&fh, &key),
-                                    (struct val){.key = key, .val = def(&mut)});
+    h = hhm_or_insert_w(hhm_entry_r(&fh, &key),
+                        (struct val){.key = key, .val = def(&mut)});
+    struct val *v = hhm_at(&fh, h);
     CHECK(v != NULL, true);
     v->val++;
     CHECK(mut, 100);
@@ -237,29 +256,32 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_functional)
      */
     hhmap_entry *ent = hhm_and_modify(hhm_entry_r(&fh, &def.key), mod);
     CHECK(hhm_occupied(ent), false);
-    CHECK((hhm_unwrap(ent) == NULL), true);
+    CHECK(hhm_unwrap(ent), false);
 
     /* Inserting default value before an in place modification is possible. */
-    struct val *v = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    ccc_handle h = hhm_or_insert(hhm_entry_r(&fh, &def.key), &def.e);
+    struct val *v = hhm_at(&fh, h);
     CHECK(v != NULL, true);
     v->val++;
-    struct val const *const inserted = hhm_get_key_val(&fh, &def.key);
+    h = hhm_get_key_val(&fh, &def.key);
+    struct val const *const inserted = hhm_at(&fh, h);
     CHECK((inserted != NULL), true);
     CHECK(inserted->key, 137);
     CHECK(inserted->val, 1);
 
     /* Modifying an existing value or inserting default is possible when no
        auxiliary input is needed. */
-    struct val *v2 = hhm_or_insert(
-        hhm_and_modify(hhm_entry_r(&fh, &def.key), mod), &def.e);
+    h = hhm_or_insert(hhm_and_modify(hhm_entry_r(&fh, &def.key), mod), &def.e);
+    struct val *v2 = hhm_at(&fh, h);
     CHECK((v2 != NULL), true);
     CHECK(inserted->key, 137);
     CHECK(v2->val, 6);
 
     /* Modifying an existing value that requires external input is also
        possible with slightly different signature. */
-    struct val *v3 = hhm_or_insert(
+    h = hhm_or_insert(
         hhm_and_modify_aux(hhm_entry_r(&fh, &def.key), modw, &def.key), &def.e);
+    struct val *v3 = hhm_at(&fh, h);
     CHECK((v3 != NULL), true);
     CHECK(inserted->key, 137);
     CHECK(v3->val, 137);
@@ -276,17 +298,16 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_macros)
      */
     hhmap_entry *ent = hhm_and_modify(hhm_entry_r(&fh, &(int){137}), mod);
     CHECK(hhm_occupied(ent), false);
-    CHECK((hhm_unwrap(ent) == NULL), true);
+    CHECK(hhm_unwrap(ent), false);
 
     int mut = 99;
 
     /* Inserting default value before an in place modification is possible. */
-    struct val *v = hhm_or_insert_w(
-        hhm_and_modify_w(hhm_entry_r(&fh, &(int){137}), struct val,
-                         {
-                             T->val = gen(&mut);
-                         }),
-        (struct val){.key = 137, .val = def(&mut)});
+    ccc_handle h
+        = hhm_or_insert_w(hhm_and_modify_w(hhm_entry_r(&fh, &(int){137}),
+                                           struct val, { T->val = gen(&mut); }),
+                          (struct val){.key = 137, .val = def(&mut)});
+    struct val *v = hhm_at(&fh, h);
     CHECK((v != NULL), true);
     CHECK(v->key, 137);
     CHECK(v->val, 0);
@@ -294,9 +315,9 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_macros)
 
     /* Modifying an existing value or inserting default is possible when no
        auxiliary input is needed. */
-    struct val *v2
-        = hhm_or_insert_w(hhm_and_modify(hhm_entry_r(&fh, &(int){137}), mod),
-                          (struct val){.key = 137, .val = def(&mut)});
+    h = hhm_or_insert_w(hhm_and_modify(hhm_entry_r(&fh, &(int){137}), mod),
+                        (struct val){.key = 137, .val = def(&mut)});
+    struct val *v2 = hhm_at(&fh, h);
     CHECK((v2 != NULL), true);
     CHECK(v2->key, 137);
     CHECK(v2->val, 5);
@@ -307,12 +328,10 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_hhm_entry_hhm_and_modify_macros)
        lazy evaluation. The function gen executes with its side effect,
        but the function def does not execute and therefore does not modify
        mut. */
-    struct val *v3 = hhm_or_insert_w(
-        hhm_and_modify_w(hhm_entry_r(&fh, &(int){137}), struct val,
-                         {
-                             T->val = gen(&mut);
-                         }),
-        (struct val){.key = 137, .val = def(&mut)});
+    h = hhm_or_insert_w(hhm_and_modify_w(hhm_entry_r(&fh, &(int){137}),
+                                         struct val, { T->val = gen(&mut); }),
+                        (struct val){.key = 137, .val = def(&mut)});
+    struct val *v3 = hhm_at(&fh, h);
     CHECK((v3 != NULL), true);
     CHECK(v3->key, 137);
     CHECK(v3->val, 42);

--- a/tests/hhmap/test_hhmap_erase.c
+++ b/tests/hhmap/test_hhmap_erase.c
@@ -1,0 +1,95 @@
+#define HANDLE_HASH_MAP_USING_NAMESPACE_CCC
+#define TRAITS_USING_NAMESPACE_CCC
+
+#include "alloc.h"
+#include "checkers.h"
+#include "handle_hash_map.h"
+#include "hhmap_util.h"
+#include "traits.h"
+#include "types.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_erase)
+{
+    ccc_handle_hash_map hh = hhm_init((struct val[10]){}, 10, e, key, NULL,
+                                      hhmap_int_zero, hhmap_id_eq, NULL);
+
+    struct val query = {.key = 137, .val = 99};
+    /* Nothing was there before so nothing is in the handle. */
+    ccc_handle ent = insert(&hh, &query.e);
+    CHECK(occupied(&ent), false);
+    CHECK(unwrap(&ent) != 0, true);
+    CHECK(size(&hh), 1);
+    ent = remove(&hh, &query.e);
+    CHECK(occupied(&ent), true);
+    struct val *v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v == NULL, true);
+    CHECK(query.key, 137);
+    CHECK(query.val, 99);
+    CHECK(size(&hh), 0);
+    query.key = 101;
+    ent = remove(&hh, &query.e);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), 0);
+    ccc_hhm_insert_handle_w(handle_r(&hh, &(int){137}),
+                            (struct val){.key = 137, .val = 99});
+    CHECK(size(&hh), 1);
+    CHECK(occupied(remove_handle_r(handle_r(&hh, &(int){137}))), true);
+    CHECK(size(&hh), 0);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_shuffle_insert_erase)
+{
+    ccc_handle_hash_map h = hhm_init((struct val *)NULL, 0, e, key, std_alloc,
+                                     hhmap_int_to_u64, hhmap_id_eq, NULL);
+
+    int const to_insert = 100;
+    int const larger_prime = (int)hhm_next_prime(to_insert);
+    for (int i = 0, shuffle = larger_prime % to_insert; i < to_insert;
+         ++i, shuffle = (shuffle + larger_prime) % to_insert)
+    {
+        ccc_handle const *const hndl
+            = hhm_insert_or_assign_w(&h, shuffle, (struct val){.val = i});
+        ccc_handle_i hndl_i = unwrap(hndl);
+        struct val *const v = hhm_at(&h, hndl_i);
+        CHECK(v != NULL, true);
+        CHECK(v->key, shuffle);
+        CHECK(v->val, i);
+        bool const valid = validate(&h);
+        CHECK(valid, true);
+    }
+    CHECK(size(&h), to_insert);
+    size_t cur_size = size(&h);
+    int i = 0;
+    while (!is_empty(&h) && cur_size)
+    {
+        CHECK(contains(&h, &i), true);
+        if (i % 2)
+        {
+            struct val const k = {.key = i};
+            ccc_handle const *const hndl = remove_r(&h, &k.e);
+            CHECK(occupied(hndl), true);
+            CHECK(k.key, i);
+        }
+        else
+        {
+            ccc_handle removed = remove_handle(handle_r(&h, &i));
+            CHECK(occupied(&removed), true);
+        }
+        --cur_size;
+        ++i;
+        CHECK(size(&h), cur_size);
+        CHECK(validate(&h), true);
+    }
+    CHECK(size(&h), 0);
+    CHECK_END_FN(hhm_clear_and_free(&h, NULL););
+}
+
+int
+main()
+{
+    return CHECK_RUN(hhmap_test_erase(), hhmap_test_shuffle_insert_erase());
+}

--- a/tests/hhmap/test_hhmap_handle.c
+++ b/tests/hhmap/test_hhmap_handle.c
@@ -1,0 +1,888 @@
+/** This file dedicated to testing the handle Interface. The interface has
+grown significantly requiring a dedicated file to test all code paths in all
+the handle functions. */
+#define HANDLE_HASH_MAP_USING_NAMESPACE_CCC
+#define TRAITS_USING_NAMESPACE_CCC
+
+#include "checkers.h"
+#include "handle_hash_map.h"
+#include "hhmap_util.h"
+#include "traits.h"
+#include "types.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+
+static inline struct val
+val(int const val)
+{
+    return (struct val){.val = val};
+}
+
+static inline struct val
+idval(int const key, int const val)
+{
+    return (struct val){.key = key, .val = val};
+}
+
+static inline void
+plus(ccc_user_type const t)
+{
+    ((struct val *)t.user_type)->val++;
+}
+
+static inline void
+plusaux(ccc_user_type const t)
+{
+    ((struct val *)t.user_type)->val += *(int *)t.aux;
+}
+
+/* Every test should have three uses of each tested function: one when the
+   container is empty, one when the container has a few elements and one when
+   the container has many elements. If the function has different behavior
+   given an element being present or absent, each possibility should be
+   tested at each of those three stages. */
+
+/* Fills the container with n elements with id and val starting at the provided
+   value and incrementing by 1 until n is reached. Assumes id_and_val are
+   not present by key in the table and all subsequent inserts are unique. */
+CHECK_BEGIN_STATIC_FN(fill_n, ccc_handle_hash_map *const hh, size_t const n,
+                      int id_and_val)
+{
+    for (size_t i = 0; i < n; ++i, ++id_and_val)
+    {
+        ccc_handle ent
+            = insert(hh, &(struct val){.key = id_and_val, .val = id_and_val}.e);
+        CHECK(insert_error(&ent), false);
+        CHECK(occupied(&ent), false);
+        CHECK(validate(hh), true);
+    }
+    CHECK_END_FN();
+}
+
+/* Internally there is some maintenance to perform when swapping values for
+   the user on insert. Leave this test here to always catch this. */
+CHECK_BEGIN_STATIC_FN(hhmap_test_validate)
+{
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+
+    ccc_handle ent = insert(&hh, &(struct val){.key = -1, .val = -1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), 1);
+    ent = insert(&hh, &(struct val){.key = -1, .val = -1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), 1);
+    struct val *v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, -1);
+    CHECK(v->key, -1);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    ccc_handle ent = insert(&hh, &(struct val){.key = -1, .val = -1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), 1);
+    ent = insert(&hh, &(struct val){.key = -1, .val = -1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), 1);
+    struct val *v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, -1);
+    CHECK(v->key, -1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    ent = insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i);
+    CHECK(v->key, i);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    ent = insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i);
+    CHECK(v->key, i);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_remove)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    ccc_handle ent = remove(&hh, &(struct val){.key = -1, .val = -1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), 0);
+    ent = insert(&hh, &(struct val){.key = -1, .val = -1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), 1);
+    struct val rem = {.key = -1, .val = -1};
+    ent = remove(&hh, &rem.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), 0);
+    CHECK(rem.val, -1);
+    CHECK(rem.key, -1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    ent = remove(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i);
+    ent = insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i + 1);
+    rem = (struct val){.key = i, .val = i};
+    ent = remove(&hh, &rem.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), i);
+    CHECK(rem.val, i);
+    CHECK(rem.key, i);
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    ent = remove(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i);
+    ent = insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i + 1);
+    rem = (struct val){.key = i, .val = i};
+    ent = remove(&hh, &rem.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), i);
+    CHECK(rem.val, i);
+    CHECK(rem.key, i);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_try_insert)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    ccc_handle ent = try_insert(&hh, &(struct val){.key = -1, .val = -1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), 1);
+    ent = try_insert(&hh, &(struct val){.key = -1, .val = -1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), 1);
+    struct val *v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, -1);
+    CHECK(v->key, -1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    ent = try_insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = try_insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i);
+    CHECK(v->key, i);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    ent = try_insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = try_insert(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i);
+    CHECK(v->key, i);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_try_insert_with)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    ccc_handle *ent = hhm_try_insert_w(&hh, -1, val(-1));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), 1);
+    ent = hhm_try_insert_w(&hh, -1, val(-1));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), 1);
+    struct val *v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, -1);
+    CHECK(v->key, -1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    ent = hhm_try_insert_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = hhm_try_insert_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i);
+    CHECK(v->key, i);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    ent = hhm_try_insert_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = hhm_try_insert_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i);
+    CHECK(v->key, i);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_or_assign)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    ccc_handle ent
+        = insert_or_assign(&hh, &(struct val){.key = -1, .val = -1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), 1);
+    ent = insert_or_assign(&hh, &(struct val){.key = -1, .val = -2}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), 1);
+    struct val *v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, -2);
+    CHECK(v->key, -1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    ent = insert_or_assign(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = insert_or_assign(&hh, &(struct val){.key = i, .val = i + 1}.e);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    ent = insert_or_assign(&hh, &(struct val){.key = i, .val = i}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = insert_or_assign(&hh, &(struct val){.key = i, .val = i + 1}.e);
+    CHECK(validate(&hh), true);
+    CHECK(occupied(&ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(&ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_or_assign_with)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    ccc_handle *ent = hhm_insert_or_assign_w(&hh, -1, val(-1));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), 1);
+    ent = hhm_insert_or_assign_w(&hh, -1, val(0));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), 1);
+    struct val *v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, 0);
+    CHECK(v->key, -1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    ent = hhm_insert_or_assign_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = hhm_insert_or_assign_w(&hh, i, val(i + 1));
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    ent = hhm_insert_or_assign_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 2);
+    ent = hhm_insert_or_assign_w(&hh, i, val(i + 1));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_handle_and_modify)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    ccc_hhmap_handle *ent = handle_r(&hh, &(int){-1});
+    CHECK(validate(&hh), true);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), 0);
+    ent = and_modify(ent, plus);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), 0);
+    (void)hhm_insert_or_assign_w(&hh, -1, val(-1));
+    CHECK(validate(&hh), true);
+    ent = handle_r(&hh, &(int){-1});
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), 1);
+    struct val *v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, -1);
+    CHECK(v->key, -1);
+    ent = and_modify(ent, plus);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, 0);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    ent = handle_r(&hh, &i);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 1);
+    (void)hhm_insert_or_assign_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    ent = handle_r(&hh, &i);
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), i + 2);
+    ent = and_modify(ent, plus);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    ent = handle_r(&hh, &i);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 1);
+    (void)hhm_insert_or_assign_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    ent = handle_r(&hh, &i);
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), i + 2);
+    ent = and_modify(ent, plus);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_handle_and_modify_aux)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    int aux = 1;
+    ccc_hhmap_handle *ent = handle_r(&hh, &(int){-1});
+    ent = and_modify_aux(ent, plusaux, &aux);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), 0);
+    (void)hhm_insert_or_assign_w(&hh, -1, val(-1));
+    CHECK(validate(&hh), true);
+    ent = handle_r(&hh, &(int){-1});
+    CHECK(occupied(ent), true);
+    CHECK(size(&hh), 1);
+    struct val *v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, -1);
+    CHECK(v->key, -1);
+    ent = and_modify_aux(ent, plusaux, &aux);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, 0);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    ent = handle_r(&hh, &i);
+    ent = and_modify_aux(ent, plusaux, &aux);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 1);
+    (void)hhm_insert_or_assign_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    ent = handle_r(&hh, &i);
+    ent = and_modify_aux(ent, plusaux, &aux);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    CHECK(size(&hh), i + 2);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    ent = handle_r(&hh, &i);
+    ent = and_modify_aux(ent, plusaux, &aux);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 1);
+    (void)hhm_insert_or_assign_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    ent = handle_r(&hh, &i);
+    ent = and_modify_aux(ent, plusaux, &aux);
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    CHECK(size(&hh), i + 2);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_handle_and_modify_with)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    ccc_hhmap_handle *ent = handle_r(&hh, &(int){-1});
+    ent = hhm_and_modify_w(ent, struct val, { T->val++; });
+    CHECK(size(&hh), 0);
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), 0);
+    (void)hhm_insert_or_assign_w(&hh, -1, val(-1));
+    CHECK(validate(&hh), true);
+    ent = handle_r(&hh, &(int){-1});
+    struct val *v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, -1);
+    CHECK(v->key, -1);
+    ent = hhm_and_modify_w(ent, struct val, { T->val++; });
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, 0);
+    CHECK(size(&hh), 1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    ent = handle_r(&hh, &i);
+    ent = hhm_and_modify_w(ent, struct val, { T->val++; });
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 1);
+    (void)hhm_insert_or_assign_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    ent = handle_r(&hh, &i);
+    ent = hhm_and_modify_w(ent, struct val, { T->val++; });
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    CHECK(size(&hh), i + 2);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    ent = handle_r(&hh, &i);
+    ent = hhm_and_modify_w(ent, struct val, { T->val++; });
+    CHECK(occupied(ent), false);
+    CHECK(size(&hh), i + 1);
+    (void)hhm_insert_or_assign_w(&hh, i, val(i));
+    CHECK(validate(&hh), true);
+    ent = handle_r(&hh, &i);
+    ent = hhm_and_modify_w(ent, struct val, { T->val++; });
+    v = hhm_at(&hh, unwrap(ent));
+    CHECK(v != NULL, true);
+    CHECK(v->val, i + 1);
+    CHECK(v->key, i);
+    CHECK(size(&hh), i + 2);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_or_insert)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    struct val *v
+        = hhm_at(&hh, or_insert(handle_r(&hh, &(int){-1}),
+                                &(struct val){.key = -1, .val = -1}.e));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, -1);
+    CHECK(size(&hh), 1);
+    v = hhm_at(&hh, or_insert(handle_r(&hh, &(int){-1}),
+                              &(struct val){.key = -1, .val = -2}.e));
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, -1);
+    CHECK(size(&hh), 1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    v = hhm_at(
+        &hh, or_insert(handle_r(&hh, &i), &(struct val){.key = i, .val = i}.e));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, or_insert(handle_r(&hh, &i),
+                              &(struct val){.key = i, .val = i + 1}.e));
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    v = hhm_at(
+        &hh, or_insert(handle_r(&hh, &i), &(struct val){.key = i, .val = i}.e));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, or_insert(handle_r(&hh, &i),
+                              &(struct val){.key = i, .val = i + 1}.e));
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_or_insert_with)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    struct val *v = hhm_at(
+        &hh, hhm_or_insert_w(handle_r(&hh, &(int){-1}), idval(-1, -1)));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, -1);
+    CHECK(size(&hh), 1);
+    v = hhm_at(&hh, hhm_or_insert_w(handle_r(&hh, &(int){-1}), idval(-1, -2)));
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, -1);
+    CHECK(size(&hh), 1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    v = hhm_at(&hh, hhm_or_insert_w(handle_r(&hh, &i), idval(i, i)));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, hhm_or_insert_w(handle_r(&hh, &i), idval(i, i + 1)));
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    v = hhm_at(&hh, hhm_or_insert_w(handle_r(&hh, &i), idval(i, i)));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, hhm_or_insert_w(handle_r(&hh, &i), idval(i, i + 1)));
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_handle)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    struct val *v
+        = hhm_at(&hh, insert_handle(handle_r(&hh, &(int){-1}),
+                                    &(struct val){.key = -1, .val = -1}.e));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, -1);
+    CHECK(size(&hh), 1);
+    v = hhm_at(&hh, insert_handle(handle_r(&hh, &(int){-1}),
+                                  &(struct val){.key = -1, .val = -2}.e));
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, -2);
+    CHECK(size(&hh), 1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    v = hhm_at(&hh, insert_handle(handle_r(&hh, &i),
+                                  &(struct val){.key = i, .val = i}.e));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, insert_handle(handle_r(&hh, &i),
+                                  &(struct val){.key = i, .val = i + 1}.e));
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i + 1);
+    CHECK(size(&hh), i + 2);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    v = hhm_at(&hh, insert_handle(handle_r(&hh, &i),
+                                  &(struct val){.key = i, .val = i}.e));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, insert_handle(handle_r(&hh, &i),
+                                  &(struct val){.key = i, .val = i + 1}.e));
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i + 1);
+    CHECK(size(&hh), i + 2);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_handle_with)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    struct val *v = hhm_at(
+        &hh, hhm_insert_handle_w(handle_r(&hh, &(int){-1}), idval(-1, -1)));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, -1);
+    CHECK(size(&hh), 1);
+    v = hhm_at(&hh,
+               hhm_insert_handle_w(handle_r(&hh, &(int){-1}), idval(-1, -2)));
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, -2);
+    CHECK(size(&hh), 1);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    v = hhm_at(&hh, hhm_insert_handle_w(handle_r(&hh, &i), idval(i, i)));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, hhm_insert_handle_w(handle_r(&hh, &i), idval(i, i + 1)));
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i + 1);
+    CHECK(size(&hh), i + 2);
+    ++i;
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    v = hhm_at(&hh, hhm_insert_handle_w(handle_r(&hh, &i), idval(i, i)));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 2);
+    v = hhm_at(&hh, hhm_insert_handle_w(handle_r(&hh, &i), idval(i, i + 1)));
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i + 1);
+    CHECK(size(&hh), i + 2);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_remove_handle)
+{
+    int size = 30;
+    ccc_handle_hash_map hh = hhm_init((struct val[50]){}, 50, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    struct val *v
+        = hhm_at(&hh, or_insert(handle_r(&hh, &(int){-1}),
+                                &(struct val){.key = -1, .val = -1}.e));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, -1);
+    CHECK(v->val, -1);
+    CHECK(size(&hh), 1);
+    ccc_handle *e = remove_handle_r(handle_r(&hh, &(int){-1}));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(e), true);
+    CHECK(size(&hh), 0);
+    int i = 0;
+
+    CHECK(fill_n(&hh, size / 2, i), PASS);
+
+    i += (size / 2);
+    v = hhm_at(
+        &hh, or_insert(handle_r(&hh, &i), &(struct val){.key = i, .val = i}.e));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 1);
+    e = remove_handle_r(handle_r(&hh, &i));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(e), true);
+    CHECK(size(&hh), i);
+
+    CHECK(fill_n(&hh, size - i, i), PASS);
+
+    i = size;
+    v = hhm_at(
+        &hh, or_insert(handle_r(&hh, &i), &(struct val){.key = i, .val = i}.e));
+    CHECK(validate(&hh), true);
+    CHECK(v != NULL, true);
+    CHECK(v->key, i);
+    CHECK(v->val, i);
+    CHECK(size(&hh), i + 1);
+    e = remove_handle_r(handle_r(&hh, &i));
+    CHECK(validate(&hh), true);
+    CHECK(occupied(e), true);
+    CHECK(size(&hh), i);
+    CHECK_END_FN();
+}
+
+int
+main(void)
+{
+    return CHECK_RUN(
+        hhmap_test_insert(), hhmap_test_remove(), hhmap_test_validate(),
+        hhmap_test_try_insert(), hhmap_test_try_insert_with(),
+        hhmap_test_insert_or_assign(), hhmap_test_insert_or_assign_with(),
+        hhmap_test_handle_and_modify(), hhmap_test_handle_and_modify_aux(),
+        hhmap_test_handle_and_modify_with(), hhmap_test_or_insert(),
+        hhmap_test_or_insert_with(), hhmap_test_insert_handle(),
+        hhmap_test_insert_handle_with(), hhmap_test_remove_handle());
+}

--- a/tests/hhmap/test_hhmap_insert.c
+++ b/tests/hhmap/test_hhmap_insert.c
@@ -395,10 +395,13 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_resize)
          ++i, shuffled_index = (shuffled_index + larger_prime) % to_insert)
     {
         struct val swap_slot = {shuffled_index, {}, shuffled_index};
+        bool const contain = contains(&hh, &shuffled_index);
+        CHECK(contain, true);
         ccc_handle h = insert_entry(entry_r(&hh, &swap_slot.key), &swap_slot.e);
         struct val const *const in_table = hhm_at(&hh, h);
         CHECK(in_table != NULL, true);
         CHECK(in_table->val, shuffled_index);
+        CHECK(size(&hh), to_insert);
     }
     CHECK(hhm_clear_and_free(&hh, NULL), CCC_OK);
     CHECK_END_FN();

--- a/tests/hhmap/test_hhmap_insert.c
+++ b/tests/hhmap/test_hhmap_insert.c
@@ -1,0 +1,611 @@
+#define HANDLE_HASH_MAP_USING_NAMESPACE_CCC
+#define TRAITS_USING_NAMESPACE_CCC
+
+#include "alloc.h"
+#include "checkers.h"
+#include "handle_hash_map.h"
+#include "hhmap_util.h"
+#include "traits.h"
+#include "types.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert)
+{
+    ccc_handle_hash_map hh = hhm_init((struct val[10]){}, 10, e, key, NULL,
+                                      hhmap_int_zero, hhmap_id_eq, NULL);
+
+    /* Nothing was there before so nothing is in the entry. */
+    ccc_entry ent = insert(&hh, &(struct val){.key = 137, .val = 99}.e);
+    CHECK(occupied(&ent), false);
+    CHECK(unwrap(&ent), NULL);
+    CHECK(size(&hh), 1);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_macros)
+{
+    ccc_handle_hash_map hh = hhm_init((struct val[10]){}, 10, e, key, NULL,
+                                      hhmap_int_zero, hhmap_id_eq, NULL);
+
+    ccc_handle h = ccc_hhm_or_insert_w(entry_r(&hh, &(int){2}),
+                                       (struct val){.key = 2, .val = 0});
+    struct val const *ins = hhm_at(&hh, h);
+    CHECK(ins != NULL, true);
+    CHECK(validate(&hh), true);
+    CHECK(size(&hh), 1);
+    h = hhm_insert_entry_w(entry_r(&hh, &(int){2}),
+                           (struct val){.key = 2, .val = 0});
+    ins = hhm_at(&hh, h);
+    CHECK(validate(&hh), true);
+    CHECK(ins != NULL, true);
+    h = hhm_insert_entry_w(entry_r(&hh, &(int){9}),
+                           (struct val){.key = 9, .val = 1});
+    ins = hhm_at(&hh, h);
+    CHECK(validate(&hh), true);
+    CHECK(ins != NULL, true);
+    ins = ccc_entry_unwrap(
+        hhm_insert_or_assign_w(&hh, 3, (struct val){.val = 99}));
+    ins = hhm_at(&hh, h);
+    CHECK(validate(&hh), true);
+    CHECK(ins == NULL, false);
+    CHECK(validate(&hh), true);
+    CHECK(ins->val, 99);
+    CHECK(size(&hh), 3);
+    ins = ccc_entry_unwrap(
+        hhm_insert_or_assign_w(&hh, 3, (struct val){.val = 98}));
+    CHECK(validate(&hh), true);
+    CHECK(ins == NULL, false);
+    CHECK(ins->val, 98);
+    CHECK(size(&hh), 3);
+    ins = ccc_entry_unwrap(hhm_try_insert_w(&hh, 3, (struct val){.val = 100}));
+    CHECK(ins == NULL, false);
+    CHECK(validate(&hh), true);
+    CHECK(ins->val, 98);
+    CHECK(size(&hh), 3);
+    ins = ccc_entry_unwrap(hhm_try_insert_w(&hh, 4, (struct val){.val = 100}));
+    CHECK(ins == NULL, false);
+    CHECK(validate(&hh), true);
+    CHECK(ins->val, 100);
+    CHECK(size(&hh), 4);
+    CHECK_END_FN(ccc_hhm_clear_and_free(&hh, NULL););
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_overwrite)
+{
+    ccc_handle_hash_map hh = hhm_init((struct val[10]){}, 10, e, key, NULL,
+                                      hhmap_int_zero, hhmap_id_eq, NULL);
+
+    struct val q = {.key = 137, .val = 99};
+    ccc_entry ent = insert(&hh, &q.e);
+    CHECK(occupied(&ent), false);
+    CHECK(unwrap(&ent), NULL);
+
+    ccc_handle h = unwrap(entry_r(&hh, &q.key));
+    struct val const *v = hhm_at(&hh, h);
+    CHECK(v != NULL, true);
+    CHECK(v->val, 99);
+
+    /* Now the second insertion will take place and the old occupying value
+       will be written into our struct we used to make the query. */
+    q = (struct val){.key = 137, .val = 100};
+
+    /* The contents of q are now in the table. */
+    ccc_entry old_ent = insert(&hh, &q.e);
+    CHECK(occupied(&old_ent), true);
+
+    /* The old contents are now in q and the entry is in the table. */
+    v = unwrap(&old_ent);
+    CHECK(v != NULL, true);
+    CHECK(v->val, 99);
+    CHECK(q.val, 99);
+    h = unwrap(entry_r(&hh, &q.key));
+    v = hhm_at(&hh, h);
+    CHECK(v != NULL, true);
+    CHECK(v->val, 100);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_then_bad_ideas)
+{
+    ccc_handle_hash_map hh = hhm_init((struct val[10]){}, 10, e, key, NULL,
+                                      hhmap_int_zero, hhmap_id_eq, NULL);
+    struct val q = {.key = 137, .val = 99};
+    ccc_entry ent = insert(&hh, &q.e);
+    CHECK(occupied(&ent), false);
+    CHECK(unwrap(&ent), NULL);
+    struct val const *v = unwrap(entry_r(&hh, &q.key));
+    CHECK(v != NULL, true);
+    CHECK(v->val, 99);
+
+    q = (struct val){.key = 137, .val = 100};
+
+    ent = insert(&hh, &q.e);
+    CHECK(occupied(&ent), true);
+    v = unwrap(&ent);
+    CHECK(v != NULL, true);
+    CHECK(v->val, 99);
+    CHECK(q.val, 99);
+    q.val -= 9;
+
+    v = get_key_val(&hh, &q.key);
+    CHECK(v != NULL, true);
+    CHECK(v->val, 100);
+    CHECK(q.val, 90);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_entry_api_functional)
+{
+    /* Over allocate size now because we don't want to worry about resizing. */
+    ccc_handle_hash_map hh = hhm_init((struct val[200]){}, 200, e, key, NULL,
+                                      hhmap_int_last_digit, hhmap_id_eq, NULL);
+    size_t const size = 200;
+
+    /* Test entry or insert with for all even values. Default should be
+       inserted. All entries are hashed to last digit so many spread out
+       collisions. */
+    struct val def = {0};
+    for (size_t i = 0; i < size / 2; i += 2)
+    {
+        def.key = (int)i;
+        def.val = (int)i;
+        struct val const *const d = or_insert(entry_r(&hh, &def.key), &def.e);
+        CHECK((d != NULL), true);
+        CHECK(d->key, i);
+        CHECK(d->val, i);
+    }
+    CHECK(size(&hh), (size / 2) / 2);
+    /* The default insertion should not occur every other element. */
+    for (size_t i = 0; i < size / 2; ++i)
+    {
+        def.key = (int)i;
+        def.val = (int)i;
+        struct val const *const d = or_insert(
+            and_modify(entry_r(&hh, &def.key), hhmap_modplus), &def.e);
+        /* All values in the array should be odd now */
+        CHECK((d != NULL), true);
+        CHECK(d->key, i);
+        if (i % 2)
+        {
+            CHECK(d->val, i);
+        }
+        else
+        {
+            CHECK(d->val, i + 1);
+        }
+        CHECK(d->val % 2, true);
+    }
+    CHECK(size(&hh), (size / 2));
+    /* More simply modifications don't require the and modify function. All
+       should be switched back to even now. */
+    for (size_t i = 0; i < size / 2; ++i)
+    {
+        def.key = (int)i;
+        def.val = (int)i;
+        struct val *const in = or_insert(entry_r(&hh, &def.key), &def.e);
+        in->val++;
+        /* All values in the array should be odd now */
+        CHECK((in->val % 2 == 0), true);
+    }
+    CHECK(size(&hh), (size / 2));
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_via_entry)
+{
+    /* Over allocate size now because we don't want to worry about resizing. */
+    size_t const size = 200;
+    ccc_handle_hash_map hh = hhm_init((struct val[200]){}, 200, e, key, NULL,
+                                      hhmap_int_last_digit, hhmap_id_eq, NULL);
+
+    /* Test entry or insert with for all even values. Default should be
+       inserted. All entries are hashed to last digit so many spread out
+       collisions. */
+    struct val def = {0};
+    for (size_t i = 0; i < size / 2; i += 2)
+    {
+        def.key = (int)i;
+        def.val = (int)i;
+        struct val const *const d
+            = insert_entry(entry_r(&hh, &def.key), &def.e);
+        CHECK((d != NULL), true);
+        CHECK(d->key, i);
+        CHECK(d->val, i);
+    }
+    CHECK(size(&hh), (size / 2) / 2);
+    /* The default insertion should not occur every other element. */
+    for (size_t i = 0; i < size / 2; ++i)
+    {
+        def.key = (int)i;
+        def.val = (int)i + 1;
+        struct val const *const d
+            = insert_entry(entry_r(&hh, &def.key), &def.e);
+        /* All values in the array should be odd now */
+        CHECK((d != NULL), true);
+        CHECK(d->val, i + 1);
+        if (i % 2)
+        {
+            CHECK(d->val % 2 == 0, true);
+        }
+        else
+        {
+            CHECK(d->val % 2, true);
+        }
+    }
+    CHECK(size(&hh), (size / 2));
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_via_entry_macros)
+{
+    /* Over allocate size now because we don't want to worry about resizing. */
+    size_t const size = 200;
+    ccc_handle_hash_map hh = hhm_init((struct val[200]){}, 200, e, key, NULL,
+                                      hhmap_int_last_digit, hhmap_id_eq, NULL);
+
+    /* Test entry or insert with for all even values. Default should be
+       inserted. All entries are hashed to last digit so many spread out
+       collisions. */
+    for (size_t i = 0; i < size / 2; i += 2)
+    {
+        struct val const *const d
+            = insert_entry(entry_r(&hh, &i), &(struct val){i, i, {}}.e);
+        CHECK((d != NULL), true);
+        CHECK(d->key, i);
+        CHECK(d->val, i);
+    }
+    CHECK(size(&hh), (size / 2) / 2);
+    /* The default insertion should not occur every other element. */
+    for (size_t i = 0; i < size / 2; ++i)
+    {
+        struct val const *const d
+            = insert_entry(entry_r(&hh, &i), &(struct val){i, i + 1, {}}.e);
+        /* All values in the array should be odd now */
+        CHECK((d != NULL), true);
+        CHECK(d->val, i + 1);
+        if (i % 2)
+        {
+            CHECK(d->val % 2 == 0, true);
+        }
+        else
+        {
+            CHECK(d->val % 2, true);
+        }
+    }
+    CHECK(size(&hh), (size / 2));
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_entry_api_macros)
+{
+    /* Over allocate size now because we don't want to worry about resizing. */
+    int const size = 200;
+    ccc_handle_hash_map hh = hhm_init((struct val[200]){}, 200, e, key, NULL,
+                                      hhmap_int_last_digit, hhmap_id_eq, NULL);
+
+    /* Test entry or insert with for all even values. Default should be
+       inserted. All entries are hashed to last digit so many spread out
+       collisions. */
+    for (int i = 0; i < size / 2; i += 2)
+    {
+        /* The macros support functions that will only execute if the or
+           insert branch executes. */
+        struct val const *const d
+            = hhm_or_insert_w(entry_r(&hh, &i), hhmap_create(i, i));
+        CHECK((d != NULL), true);
+        CHECK(d->key, i);
+        CHECK(d->val, i);
+    }
+    CHECK(size(&hh), (size / 2) / 2);
+    /* The default insertion should not occur every other element. */
+    for (int i = 0; i < size / 2; ++i)
+    {
+        struct val const *const d = hhm_or_insert_w(
+            and_modify(entry_r(&hh, &i), hhmap_modplus), hhmap_create(i, i));
+        /* All values in the array should be odd now */
+        CHECK((d != NULL), true);
+        CHECK(d->key, i);
+        if (i % 2)
+        {
+            CHECK(d->val, i);
+        }
+        else
+        {
+            CHECK(d->val, i + 1);
+        }
+        CHECK(d->val % 2, true);
+    }
+    CHECK(size(&hh), (size / 2));
+    /* More simply modifications don't require the and modify function. All
+       should be switched back to even now. */
+    for (int i = 0; i < size / 2; ++i)
+    {
+        struct val *v = hhm_or_insert_w(entry_r(&hh, &i), (struct val){});
+        CHECK(v != NULL, true);
+        v->val++;
+        /* All values in the array should be odd now */
+        CHECK(v->val % 2 == 0, true);
+    }
+    CHECK(size(&hh), (size / 2));
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_two_sum)
+{
+    ccc_handle_hash_map hh = hhm_init((struct val[20]){}, 20, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    int const addends[10] = {1, 3, -980, 6, 7, 13, 44, 32, 995, -1};
+    int const target = 15;
+    int solution_indices[2] = {-1, -1};
+    for (size_t i = 0; i < (sizeof(addends) / sizeof(addends[0])); ++i)
+    {
+        struct val const *const other_addend
+            = get_key_val(&hh, &(int){target - addends[i]});
+        if (other_addend)
+        {
+            solution_indices[0] = (int)i;
+            solution_indices[1] = other_addend->val;
+            break;
+        }
+        ccc_entry const e = insert_or_assign(
+            &hh, &(struct val){.key = addends[i], .val = i}.e);
+        CHECK(insert_error(&e), false);
+    }
+    CHECK(solution_indices[0], 8);
+    CHECK(solution_indices[1], 2);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_resize)
+{
+    size_t const prime_start = 11;
+    ccc_handle_hash_map hh = hhm_init(
+        (struct val *)malloc(sizeof(struct val) * prime_start), prime_start, e,
+        key, std_alloc, hhmap_int_to_u64, hhmap_id_eq, NULL);
+    CHECK(hhm_data(&hh) != NULL, true);
+
+    int const to_insert = 1000;
+    int const larger_prime = (int)hhm_next_prime(to_insert);
+    for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
+         ++i, shuffled_index = (shuffled_index + larger_prime) % to_insert)
+    {
+        struct val elem = {.key = shuffled_index, .val = i};
+        struct val *v = insert_entry(entry_r(&hh, &elem.key), &elem.e);
+        CHECK(v != NULL, true);
+        CHECK(v->key, shuffled_index);
+        CHECK(v->val, i);
+        CHECK(validate(&hh), true);
+    }
+    CHECK(size(&hh), to_insert);
+    for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
+         ++i, shuffled_index = (shuffled_index + larger_prime) % to_insert)
+    {
+        struct val swap_slot = {shuffled_index, shuffled_index, {}};
+        struct val const *const in_table
+            = insert_entry(entry_r(&hh, &swap_slot.key), &swap_slot.e);
+        CHECK(in_table != NULL, true);
+        CHECK(in_table->val, shuffled_index);
+    }
+    CHECK(hhm_clear_and_free(&hh, NULL), CCC_OK);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_resize_macros)
+{
+    size_t const prime_start = 11;
+    ccc_handle_hash_map hh = hhm_init(
+        (struct val *)malloc(sizeof(struct val) * prime_start), prime_start, e,
+        key, std_alloc, hhmap_int_to_u64, hhmap_id_eq, NULL);
+    CHECK(hhm_data(&hh) != NULL, true);
+    int const to_insert = 1000;
+    int const larger_prime = (int)hhm_next_prime(to_insert);
+    for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
+         ++i, shuffled_index = (shuffled_index + larger_prime) % to_insert)
+    {
+        struct val *v = insert_entry(entry_r(&hh, &shuffled_index),
+                                     &(struct val){shuffled_index, i, {}}.e);
+        CHECK(v != NULL, true);
+        CHECK(v->key, shuffled_index);
+        CHECK(v->val, i);
+    }
+    CHECK(size(&hh), to_insert);
+    for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
+         ++i, shuffled_index = (shuffled_index + larger_prime) % to_insert)
+    {
+        struct val const *const in_table = hhm_or_insert_w(
+            hhm_and_modify_w(entry_r(&hh, &shuffled_index), struct val,
+                             {
+                                 T->val = shuffled_index;
+                             }),
+            (struct val){});
+        CHECK(in_table != NULL, true);
+        CHECK(in_table->val, shuffled_index);
+        struct val *v
+            = hhm_or_insert_w(entry_r(&hh, &shuffled_index), (struct val){});
+        CHECK(v == NULL, false);
+        v->val = i;
+        v = get_key_val(&hh, &shuffled_index);
+        CHECK(v != NULL, true);
+        CHECK(v->val, i);
+    }
+    CHECK(hhm_clear_and_free(&hh, NULL), CCC_OK);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_resize_from_null)
+{
+    ccc_handle_hash_map hh = hhm_init((struct val *)NULL, 0, e, key, std_alloc,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    int const to_insert = 1000;
+    int const larger_prime = (int)hhm_next_prime(to_insert);
+    for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
+         ++i, shuffled_index = (shuffled_index + larger_prime) % to_insert)
+    {
+        struct val elem = {.key = shuffled_index, .val = i};
+        struct val *v = insert_entry(entry_r(&hh, &elem.key), &elem.e);
+        CHECK(v != NULL, true);
+        CHECK(v->key, shuffled_index);
+        CHECK(v->val, i);
+    }
+    CHECK(size(&hh), to_insert);
+    for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
+         ++i, shuffled_index = (shuffled_index + larger_prime) % to_insert)
+    {
+        struct val swap_slot = {shuffled_index, shuffled_index, {}};
+        struct val const *const in_table
+            = insert_entry(entry_r(&hh, &swap_slot.key), &swap_slot.e);
+        CHECK(in_table != NULL, true);
+        CHECK(in_table->val, shuffled_index);
+    }
+    CHECK(hhm_clear_and_free(&hh, NULL), CCC_OK);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_resize_from_null_macros)
+{
+    ccc_handle_hash_map hh = hhm_init((struct val *)NULL, 0, e, key, std_alloc,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+    int const to_insert = 1000;
+    int const larger_prime = (int)hhm_next_prime(to_insert);
+    for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
+         ++i, shuffled_index = (shuffled_index + larger_prime) % to_insert)
+    {
+        struct val *v = insert_entry(entry_r(&hh, &shuffled_index),
+                                     &(struct val){shuffled_index, i, {}}.e);
+        CHECK(v != NULL, true);
+        CHECK(v->key, shuffled_index);
+        CHECK(v->val, i);
+    }
+    CHECK(size(&hh), to_insert);
+    for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
+         ++i, shuffled_index = (shuffled_index + larger_prime) % to_insert)
+    {
+        struct val const *const in_table = hhm_or_insert_w(
+            hhm_and_modify_w(entry_r(&hh, &shuffled_index), struct val,
+                             {
+                                 T->val = shuffled_index;
+                             }),
+            (struct val){});
+        CHECK(in_table != NULL, true);
+        CHECK(in_table->val, shuffled_index);
+        struct val *v
+            = hhm_or_insert_w(entry_r(&hh, &shuffled_index), (struct val){});
+        CHECK(v == NULL, false);
+        v->val = i;
+        v = get_key_val(&hh, &shuffled_index);
+        CHECK(v == NULL, false);
+        CHECK(v->val, i);
+    }
+    CHECK(hhm_clear_and_free(&hh, NULL), CCC_OK);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_limit)
+{
+    int const size = 101;
+    ccc_handle_hash_map hh = hhm_init((struct val[101]){}, 101, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+
+    int const larger_prime = (int)hhm_next_prime(size);
+    int last_index = 0;
+    int shuffled_index = larger_prime % size;
+    for (int i = 0; i < size;
+         ++i, shuffled_index = (shuffled_index + larger_prime) % size)
+    {
+        struct val *v = insert_entry(entry_r(&hh, &shuffled_index),
+                                     &(struct val){shuffled_index, i, {}}.e);
+        if (!v)
+        {
+            break;
+        }
+        CHECK(v->key, shuffled_index);
+        CHECK(v->val, i);
+        last_index = shuffled_index;
+    }
+    size_t const final_size = size(&hh);
+    /* The last successful entry is still in the table and is overwritten. */
+    struct val v = {.key = last_index, .val = -1};
+    ccc_entry ent = insert(&hh, &v.e);
+    CHECK(unwrap(&ent) != NULL, true);
+    CHECK(insert_error(&ent), false);
+    CHECK(size(&hh), final_size);
+
+    v = (struct val){.key = last_index, .val = -2};
+    struct val *in_table = insert_entry(entry_r(&hh, &v.key), &v.e);
+    CHECK(in_table != NULL, true);
+    CHECK(in_table->val, -2);
+    CHECK(size(&hh), final_size);
+
+    in_table = insert_entry(entry_r(&hh, &last_index),
+                            &(struct val){.key = last_index, .val = -3}.e);
+    CHECK(in_table != NULL, true);
+    CHECK(in_table->val, -3);
+    CHECK(size(&hh), final_size);
+
+    /* The shuffled index key that failed insertion should fail again. */
+    v = (struct val){.key = shuffled_index, .val = -4};
+    in_table = insert_entry(entry_r(&hh, &v.key), &v.e);
+    CHECK(in_table == NULL, true);
+    CHECK(size(&hh), final_size);
+
+    in_table = insert_entry(entry_r(&hh, &shuffled_index),
+                            &(struct val){.key = shuffled_index, .val = -4}.e);
+    CHECK(in_table == NULL, true);
+    CHECK(size(&hh), final_size);
+
+    ent = insert(&hh, &v.e);
+    CHECK(unwrap(&ent) == NULL, true);
+    CHECK(insert_error(&ent), true);
+    CHECK(size(&hh), final_size);
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(hhmap_test_insert_and_find)
+{
+    int const size = 101;
+    ccc_handle_hash_map hh = hhm_init((struct val[101]){}, 101, e, key, NULL,
+                                      hhmap_int_to_u64, hhmap_id_eq, NULL);
+
+    for (int i = 0; i < size; i += 2)
+    {
+        ccc_entry e = try_insert(&hh, &(struct val){.key = i, .val = i}.e);
+        CHECK(occupied(&e), false);
+        CHECK(validate(&hh), true);
+        e = try_insert(&hh, &(struct val){.key = i, .val = i}.e);
+        CHECK(occupied(&e), true);
+        CHECK(validate(&hh), true);
+        struct val const *const v = unwrap(&e);
+        CHECK(v == NULL, false);
+        CHECK(v->key, i);
+        CHECK(v->val, i);
+    }
+    for (int i = 0; i < size; i += 2)
+    {
+        CHECK(contains(&hh, &i), true);
+        CHECK(occupied(entry_r(&hh, &i)), true);
+        CHECK(validate(&hh), true);
+    }
+    for (int i = 1; i < size; i += 2)
+    {
+        CHECK(contains(&hh, &i), false);
+        CHECK(occupied(entry_r(&hh, &i)), false);
+        CHECK(validate(&hh), true);
+    }
+    CHECK_END_FN();
+}
+
+int
+main()
+{
+    return CHECK_RUN(
+        hhmap_test_insert(), hhmap_test_insert_macros(),
+        hhmap_test_insert_and_find(), hhmap_test_insert_overwrite(),
+        hhmap_test_insert_then_bad_ideas(), hhmap_test_insert_via_entry(),
+        hhmap_test_insert_via_entry_macros(), hhmap_test_entry_api_functional(),
+        hhmap_test_entry_api_macros(), hhmap_test_two_sum(),
+        hhmap_test_resize(), hhmap_test_resize_macros(),
+        hhmap_test_resize_from_null(), hhmap_test_resize_from_null_macros(),
+        hhmap_test_insert_limit());
+}

--- a/tests/hhmap/test_hhmap_insert.c
+++ b/tests/hhmap/test_hhmap_insert.c
@@ -389,6 +389,8 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_resize)
         CHECK(v->val, i);
         bool const valid = validate(&hh);
         CHECK(valid, true);
+        bool const contain = contains(&hh, &shuffled_index);
+        CHECK(contain, true);
     }
     CHECK(size(&hh), to_insert);
     for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;

--- a/tests/hhmap/test_hhmap_lru.c
+++ b/tests/hhmap/test_hhmap_lru.c
@@ -1,0 +1,220 @@
+/** File: lru.c
+The leetcode lru problem in C. */
+#define HANDLE_HASH_MAP_USING_NAMESPACE_CCC
+#define DOUBLY_LINKED_LIST_USING_NAMESPACE_CCC
+#define TRAITS_USING_NAMESPACE_CCC
+
+#include "checkers.h"
+#include "doubly_linked_list.h"
+#include "handle_hash_map.h"
+#include "hhmap/hhmap_util.h"
+#include "traits.h"
+#include "types.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define REQS 11
+
+struct lru_cache
+{
+    ccc_handle_hash_map hh;
+    ccc_doubly_linked_list l;
+    size_t cap;
+};
+
+struct lru_elem
+{
+    ccc_hhmap_elem hash_elem;
+    dll_elem list_elem;
+    int key;
+    int val;
+};
+
+enum lru_call
+{
+    PUT,
+    GET,
+    HED,
+};
+
+struct lru_request
+{
+    enum lru_call call;
+    int key;
+    int val;
+    union
+    {
+        enum check_result (*putter)(struct lru_cache *, int, int);
+        enum check_result (*getter)(struct lru_cache *, int, int *);
+        struct lru_elem *(*header)(struct lru_cache *);
+    };
+};
+
+/* Disable me if tests start failing! */
+static bool const quiet = true;
+#define QUIET_PRINT(format_string...)                                          \
+    do                                                                         \
+    {                                                                          \
+        if (!quiet)                                                            \
+        {                                                                      \
+            printf(format_string);                                             \
+        }                                                                      \
+    } while (0)
+
+static bool
+lru_elem_cmp(ccc_key_cmp const cmp)
+{
+    struct lru_elem const *const lookup = cmp.user_type_rhs;
+    return lookup->key == *((int *)cmp.key_lhs);
+}
+
+static ccc_threeway_cmp
+cmp_by_key(ccc_cmp const cmp)
+{
+    struct lru_elem const *const kv_a = cmp.user_type_lhs;
+    struct lru_elem const *const kv_b = cmp.user_type_rhs;
+    return (kv_a->key > kv_b->key) - (kv_a->key < kv_b->key);
+}
+
+static struct lru_elem *
+lru_head(struct lru_cache *const lru)
+{
+    return dll_front(&lru->l);
+}
+
+#define CAP 3
+#define PRIME_HASH_SIZE 11
+static struct lru_elem map_buf[PRIME_HASH_SIZE];
+static_assert(PRIME_HASH_SIZE > CAP);
+
+/* This is a good opportunity to test the static initialization capabilities
+   of the hash table and list. */
+static struct lru_cache lru_cache = {
+    .cap = CAP,
+    .l
+    = dll_init(lru_cache.l, struct lru_elem, list_elem, NULL, cmp_by_key, NULL),
+    .hh = hhm_init(map_buf, sizeof(map_buf) / sizeof(map_buf[0]), hash_elem,
+                   key, NULL, hhmap_int_to_u64, lru_elem_cmp, NULL),
+};
+
+CHECK_BEGIN_STATIC_FN(lru_put, struct lru_cache *const lru, int const key,
+                      int const val)
+{
+    ccc_hhmap_handle *const ent = handle_r(&lru->hh, &key);
+    if (occupied(ent))
+    {
+        struct lru_elem *const found = hhm_at(&lru->hh, unwrap(ent));
+        found->key = key;
+        found->val = val;
+        ccc_result r = dll_splice(&lru->l, dll_begin_elem(&lru->l), &lru->l,
+                                  &found->list_elem);
+        CHECK(r, CCC_OK);
+    }
+    else
+    {
+        struct lru_elem *const new = hhm_at(
+            &lru->hh,
+            insert_handle(ent, &(struct lru_elem){.key = key}.hash_elem));
+        CHECK(new == NULL, false);
+        struct lru_elem *l_elem = dll_push_front(&lru->l, &new->list_elem);
+        CHECK(l_elem, new);
+
+        new->val = val;
+        if (size(&lru->l) > lru->cap)
+        {
+            struct lru_elem const *const to_drop = back(&lru->l);
+            CHECK(to_drop == NULL, false);
+            (void)pop_back(&lru->l);
+            ccc_handle const e
+                = remove_handle(handle_r(&lru->hh, &to_drop->key));
+            CHECK(occupied(&e), true);
+        }
+    }
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(lru_get, struct lru_cache *const lru, int const key,
+                      int *val)
+{
+    CHECK_ERROR(val != NULL, true);
+    struct lru_elem *const found
+        = hhm_at(&lru->hh, get_key_val(&lru->hh, &key));
+    if (!found)
+    {
+        *val = -1;
+    }
+    else
+    {
+        ccc_result r = dll_splice(&lru->l, dll_begin_elem(&lru->l), &lru->l,
+                                  &found->list_elem);
+        CHECK(r, CCC_OK);
+        *val = found->val;
+    }
+    CHECK_END_FN();
+}
+
+CHECK_BEGIN_STATIC_FN(run_lru_cache)
+{
+    QUIET_PRINT("LRU CAPACITY -> %zu\n", lru_cache.cap);
+    struct lru_request requests[REQS] = {
+        {PUT, .key = 1, .val = 1, .putter = lru_put},
+        {PUT, .key = 2, .val = 2, .putter = lru_put},
+        {GET, .key = 1, .val = 1, .getter = lru_get},
+        {PUT, .key = 3, .val = 3, .putter = lru_put},
+        {HED, .key = 3, .val = 3, .header = lru_head},
+        {PUT, .key = 4, .val = 4, .putter = lru_put},
+        {GET, .key = 2, .val = -1, .getter = lru_get},
+        {GET, .key = 3, .val = 3, .getter = lru_get},
+        {GET, .key = 4, .val = 4, .getter = lru_get},
+        {GET, .key = 2, .val = -1, .getter = lru_get},
+        {HED, .key = 4, .val = 4, .header = lru_head},
+    };
+    for (size_t i = 0; i < REQS; ++i)
+    {
+        switch (requests[i].call)
+        {
+        case PUT:
+        {
+            CHECK(requests[i].putter(&lru_cache, requests[i].key,
+                                     requests[i].val),
+                  PASS);
+            QUIET_PRINT("PUT -> {key: %d, val: %d}\n", requests[i].key,
+                        requests[i].val);
+            CHECK(validate(&lru_cache.hh), true);
+            CHECK(validate(&lru_cache.l), true);
+        }
+        break;
+        case GET:
+        {
+            QUIET_PRINT("GET -> {key: %d, val: %d}\n", requests[i].key,
+                        requests[i].val);
+            int val = 0;
+            CHECK(requests[i].getter(&lru_cache, requests[i].key, &val), PASS);
+            CHECK(val, requests[i].val);
+            CHECK(validate(&lru_cache.l), true);
+        }
+        break;
+        case HED:
+        {
+            QUIET_PRINT("HED -> {key: %d, val: %d}\n", requests[i].key,
+                        requests[i].val);
+            struct lru_elem const *const kv = requests[i].header(&lru_cache);
+            CHECK(kv != NULL, true);
+            CHECK(kv->key, requests[i].key);
+            CHECK(kv->val, requests[i].val);
+        }
+        break;
+        default:
+            break;
+        }
+    }
+    CHECK_END_FN();
+}
+
+int
+main()
+{
+    return CHECK_RUN(run_lru_cache());
+}

--- a/tests/hhmap/test_hhmap_lru.c
+++ b/tests/hhmap/test_hhmap_lru.c
@@ -4,16 +4,16 @@ The leetcode lru problem in C. */
 #define DOUBLY_LINKED_LIST_USING_NAMESPACE_CCC
 #define TRAITS_USING_NAMESPACE_CCC
 
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "checkers.h"
 #include "doubly_linked_list.h"
 #include "handle_hash_map.h"
 #include "hhmap/hhmap_util.h"
 #include "traits.h"
 #include "types.h"
-
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 #define REQS 11
 

--- a/tests/hhmap/test_hhmap_lru.c
+++ b/tests/hhmap/test_hhmap_lru.c
@@ -86,6 +86,10 @@ lru_head(struct lru_cache *const lru)
 
 #define CAP 3
 #define PRIME_HASH_SIZE 11
+/* This should have used the new c23 lifetime initialized compound literals
+   as a static array of structs directly in the initializer like this:
+   (static struct lru_elem)[PRIME_HASH_SIZE]{}, but the github workflow
+   compilers don't support this syntax yet. */
 static struct lru_elem map_buf[PRIME_HASH_SIZE];
 static_assert(PRIME_HASH_SIZE > CAP);
 


### PR DESCRIPTION
Newly implemented handle hash map offers handle stability for larger user data. The user data will only be written to the buffer once and offer handle stability meaning it will not be moved until the user removes the element. A handle is just an index so it remains valid even when resizing occurs. The new interface and types to support handles is implemented.