### PR TITLE
Stable handles

### DIFF
--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -64,7 +64,7 @@ N + 1 capacity is required. */
 @param [in] size the size <= capacity.
 @param [in] cmp_order CCC_LES or CCC_GRT for min or max heap, respectively.
 @param [in] alloc_fn the allocation function or NULL if no allocation.
-@param [in] cmp_fn the user defined comarison function for user types.
+@param [in] cmp_fn the user defined comparison function for user types.
 @param [in] aux_data any auxiliary data needed for destruction of elements.
 @return the initilialized priority queue on the right hand side of an equality
 operator. (i.e. ccc_flat_priority_queue q = ccc_fpq_heapify_init(...);).
@@ -173,6 +173,17 @@ Note that this version of heapify copies elements from the input array. If an
 in place heapify is required use the initializer version of this method. */
 ccc_result ccc_fpq_heapify(ccc_flat_priority_queue *fpq, void *input_array,
                            size_t input_n, size_t input_elem_size);
+
+/** @brief Order n elements of the underlying fpq buffer as an fpq.
+@param [in] fpq a pointer to the flat priority queue.
+@param [in] n the number n of elements to be ordered. n + 1 must be <= capacity.
+@return the result of the heapify operation, ok if successful or an error if
+fpq is NULL or n is larger than the initialized capacity of the fpq.
+
+This is another method to order a heap that already has all the elements one
+needs sorted. The underlying buffer will be interpreted to have n valid elements
+starting at index 0 to index n - 1. */
+ccc_result ccc_fpq_heapify_inplace(ccc_flat_priority_queue *fpq, size_t n);
 
 /** @brief Many allocate memory for the fpq.
 @param [in] fpq a pointer to the priority queue.

--- a/ccc/handle_hash_map.h
+++ b/ccc/handle_hash_map.h
@@ -4,11 +4,14 @@
 A Handle Hash Map stores elements by hash value and allows the user to retrieve
 them by key in amortized O(1) while offering handle stability. A handle is an
 index into a slot of the table where the user data is originally placed upon
-insertion. It is guaranteed to remain in the same slot until deletion; however
-if resizing is allowed and occurs any handle to that data may become invalid.
-This comes at a slight space and implementation complexity cost when compared to
-the standard flat hash map offered in the collection. However, it is more
-beneficial for large structs and fixed table sizes to use this version.
+insertion. It is guaranteed to remain in the same slot until deletion, even if
+the table is resized by subsequent insertions. This comes at a slight space and
+implementation complexity cost when compared to the standard flat hash map
+offered in the collection, especially during resizing operations. However, it is
+more beneficial for large structs and fixed table sizes to use this version.
+The benefits are that when the handles exposed in the interface are saved by
+the user they offer the same guarantees as pointer stability except with the
+benefits of tightly grouped data in one array.
 
 For containers in this collection the user may have a variety of memory sources
 backing the containers. This container aims to be an equivalent stand in for

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -60,6 +60,11 @@ union ccc_hhmap_handle_
     struct ccc_hhash_handle_ impl_;
 };
 
+union ccc_hhmap_ref_
+{
+    size_t impl_;
+};
+
 #define ccc_impl_hhm_init(memory_ptr, capacity, hhash_elem_field, key_field,   \
                           alloc_fn, hash_fn, key_eq_fn, aux)                   \
     {                                                                          \
@@ -198,7 +203,8 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                 }                                                              \
             }                                                                  \
         }                                                                      \
-        hhm_or_ins_res_;                                                       \
+        ccc_impl_hhm_elem_at(hhm_or_ins_handl_ptr_->impl_.h_, hhm_or_ins_res_) \
+            ->slot_i_;                                                         \
     }))
 
 #define ccc_impl_hhm_insert_handle_w(handle_hash_map_handle_ptr,               \
@@ -237,7 +243,7 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                 }                                                              \
             }                                                                  \
         }                                                                      \
-        hhm_res_;                                                              \
+        ccc_impl_hhm_elem_at(hhm_ins_handl_ptr_->impl_.h_, hhm_res_)->slot_i_; \
     }))
 
 #define ccc_impl_hhm_try_insert_w(handle_hash_map_ptr, key, lazy_value...)     \
@@ -269,6 +275,9 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                     = hhm_key_;                                                \
             }                                                                  \
         }                                                                      \
+        hhm_try_insert_res_.i_ = ccc_impl_hhm_elem_at(handle_hash_map_ptr_,    \
+                                                      hhm_try_insert_res_.i_)  \
+                                     ->slot_i_;                                \
         hhm_try_insert_res_;                                                   \
     }))
 
@@ -325,6 +334,10 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                     = hhm_key_;                                                \
             }                                                                  \
         }                                                                      \
+        hhm_ins_or_assign_res_.i_                                              \
+            = ccc_impl_hhm_elem_at(handle_hash_map_ptr_,                       \
+                                   hhm_ins_or_assign_res_.i_)                  \
+                  ->slot_i_;                                                   \
         hhm_ins_or_assign_res_;                                                \
     }))
 

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -201,10 +201,13 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                     hhm_or_ins_res_ = ccc_impl_hhm_swaps(hhm_or_ins_handle_,   \
                                                          lazy_key_value);      \
                 }                                                              \
+                hhm_or_ins_res_                                                \
+                    = ccc_impl_hhm_elem_at(hhm_or_ins_handl_ptr_->impl_.h_,    \
+                                           hhm_or_ins_res_)                    \
+                          ->slot_i_;                                           \
             }                                                                  \
         }                                                                      \
-        ccc_impl_hhm_elem_at(hhm_or_ins_handl_ptr_->impl_.h_, hhm_or_ins_res_) \
-            ->slot_i_;                                                         \
+        hhm_or_ins_res_;                                                       \
     }))
 
 #define ccc_impl_hhm_insert_handle_w(handle_hash_map_handle_ptr,               \
@@ -241,9 +244,12 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                     hhm_res_                                                   \
                         = ccc_impl_hhm_swaps(hhm_ins_handl_, lazy_key_value);  \
                 }                                                              \
+                hhm_res_ = ccc_impl_hhm_elem_at(hhm_ins_handl_ptr_->impl_.h_,  \
+                                                hhm_res_)                      \
+                               ->slot_i_;                                      \
             }                                                                  \
         }                                                                      \
-        ccc_impl_hhm_elem_at(hhm_ins_handl_ptr_->impl_.h_, hhm_res_)->slot_i_; \
+        hhm_res_;                                                              \
     }))
 
 #define ccc_impl_hhm_try_insert_w(handle_hash_map_ptr, key, lazy_value...)     \
@@ -274,10 +280,11 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                         ->slot_i_))                                            \
                     = hhm_key_;                                                \
             }                                                                  \
+            hhm_try_insert_res_.i_                                             \
+                = ccc_impl_hhm_elem_at(handle_hash_map_ptr_,                   \
+                                       hhm_try_insert_res_.i_)                 \
+                      ->slot_i_;                                               \
         }                                                                      \
-        hhm_try_insert_res_.i_ = ccc_impl_hhm_elem_at(handle_hash_map_ptr_,    \
-                                                      hhm_try_insert_res_.i_)  \
-                                     ->slot_i_;                                \
         hhm_try_insert_res_;                                                   \
     }))
 
@@ -333,11 +340,11 @@ struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                         ->slot_i_))                                            \
                     = hhm_key_;                                                \
             }                                                                  \
+            hhm_ins_or_assign_res_.i_                                          \
+                = ccc_impl_hhm_elem_at(handle_hash_map_ptr_,                   \
+                                       hhm_ins_or_assign_res_.i_)              \
+                      ->slot_i_;                                               \
         }                                                                      \
-        hhm_ins_or_assign_res_.i_                                              \
-            = ccc_impl_hhm_elem_at(handle_hash_map_ptr_,                       \
-                                   hhm_ins_or_assign_res_.i_)                  \
-                  ->slot_i_;                                                   \
         hhm_ins_or_assign_res_;                                                \
     }))
 

--- a/src/flat_priority_queue.c
+++ b/src/flat_priority_queue.c
@@ -20,6 +20,7 @@ static void swap(struct ccc_fpq_ *, char tmp[], size_t, size_t);
 static size_t bubble_up(struct ccc_fpq_ *fpq, char tmp[], size_t i);
 static size_t bubble_down(struct ccc_fpq_ *, char tmp[], size_t);
 static size_t update_fixup(struct ccc_fpq_ *, void *e);
+static void inplace_heapify(struct ccc_fpq_ *fpq, size_t n);
 
 /*=====================       Interface      ================================*/
 
@@ -58,6 +59,17 @@ ccc_fpq_heapify(ccc_flat_priority_queue *const fpq, void *const array,
     {
         (void)bubble_down(fpq, tmp, i);
     }
+    return CCC_OK;
+}
+
+ccc_result
+ccc_fpq_heapify_inplace(ccc_flat_priority_queue *fpq, size_t n)
+{
+    if (!fpq || n + 1 > ccc_buf_capacity(&fpq->buf_))
+    {
+        return CCC_INPUT_ERR;
+    }
+    inplace_heapify(fpq, n);
     return CCC_OK;
 }
 
@@ -360,6 +372,14 @@ ccc_impl_fpq_in_place_heapify(struct ccc_fpq_ *const fpq, size_t const n)
     {
         return;
     }
+    inplace_heapify(fpq, n);
+}
+
+/*====================     Static Helpers     ===============================*/
+
+static inline void
+inplace_heapify(struct ccc_fpq_ *const fpq, size_t const n)
+{
     (void)ccc_buf_size_set(&fpq->buf_, n);
     void *const tmp = ccc_buf_at(&fpq->buf_, n);
     for (size_t i = (n / 2) + 1; i--;)
@@ -367,8 +387,6 @@ ccc_impl_fpq_in_place_heapify(struct ccc_fpq_ *const fpq, size_t const n)
         (void)bubble_down(fpq, tmp, i);
     }
 }
-
-/*====================     Static Helpers     ===============================*/
 
 /* Fixes the position of element e after its key value has been changed. */
 static inline size_t

--- a/src/handle_hash_map.c
+++ b/src/handle_hash_map.c
@@ -158,7 +158,7 @@ ccc_hhm_at(ccc_handle_hash_map const *const h, ccc_handle_i i)
     {
         return NULL;
     }
-    return ccc_buf_at(&h->buf_, elem_at(h, i)->slot_i_);
+    return ccc_buf_at(&h->buf_, i);
 }
 
 bool
@@ -218,7 +218,7 @@ ccc_hhm_insert_handle(ccc_hhmap_handle const *const e,
             ccc_buf_at(&e->impl_.h_->buf_,
                        elem_at(e->impl_.h_, e->impl_.handle_.i_)->slot_i_),
             struct_base(e->impl_.h_, elem));
-        return e->impl_.handle_.i_;
+        return elem_at(e->impl_.h_, e->impl_.handle_.i_)->slot_i_;
     }
     if (e->impl_.handle_.stats_ & CCC_INSERT_ERROR)
     {
@@ -230,7 +230,7 @@ ccc_hhm_insert_handle(ccc_hhmap_handle const *const e,
         e->impl_.h_,
         ccc_buf_at(&e->impl_.h_->buf_, elem_at(e->impl_.h_, ins)->slot_i_),
         user_struct);
-    return ins;
+    return elem_at(e->impl_.h_, ins)->slot_i_;
 }
 
 ccc_handle_i
@@ -244,7 +244,7 @@ ccc_hhm_get_key_val(ccc_handle_hash_map *const h, void const *const key)
     struct ccc_handl_ e = find(h, key, filter(h, key));
     if (e.stats_ & CCC_OCCUPIED)
     {
-        return e.i_;
+        return elem_at(h, e.i_)->slot_i_;
     }
     return 0;
 }
@@ -303,15 +303,17 @@ ccc_hhm_insert(ccc_handle_hash_map *const h, ccc_hhmap_elem *const out_handle)
         swap_user_data(
             h, ccc_buf_at(&h->buf_, elem_at(h, ent.handle_.i_)->slot_i_),
             user_data);
-        return (ccc_handle){{.i_ = ent.handle_.i_, .stats_ = CCC_OCCUPIED}};
+        return (ccc_handle){{.i_ = elem_at(h, ent.handle_.i_)->slot_i_,
+                             .stats_ = CCC_OCCUPIED}};
     }
     if (ent.handle_.stats_ & CCC_INSERT_ERROR)
     {
-        return (ccc_handle){{.i_ = ent.handle_.i_, .stats_ = CCC_INSERT_ERROR}};
+        return (ccc_handle){{.i_ = elem_at(h, ent.handle_.i_)->slot_i_,
+                             .stats_ = CCC_INSERT_ERROR}};
     }
     ccc_handle_i const ins = insert_meta(h, ent.hash_, ent.handle_.i_);
     copy_to_slot(h, ccc_buf_at(&h->buf_, elem_at(h, ins)->slot_i_), user_data);
-    return (ccc_handle){{.i_ = ins, .stats_ = CCC_VACANT}};
+    return (ccc_handle){{.i_ = elem_at(h, ins)->slot_i_, .stats_ = CCC_VACANT}};
 }
 
 ccc_handle
@@ -327,7 +329,8 @@ ccc_hhm_try_insert(ccc_handle_hash_map *const h,
         = container_handle(h, key_in_slot(h, user_data));
     if (ent.handle_.stats_ & CCC_OCCUPIED)
     {
-        return (ccc_handle){{.i_ = ent.handle_.i_, .stats_ = CCC_OCCUPIED}};
+        return (ccc_handle){{.i_ = elem_at(h, ent.handle_.i_)->slot_i_,
+                             .stats_ = CCC_OCCUPIED}};
     }
     if (ent.handle_.stats_ & CCC_INSERT_ERROR)
     {
@@ -335,7 +338,7 @@ ccc_hhm_try_insert(ccc_handle_hash_map *const h,
     }
     ccc_handle_i const ins = insert_meta(h, ent.hash_, ent.handle_.i_);
     copy_to_slot(h, ccc_buf_at(&h->buf_, elem_at(h, ins)->slot_i_), user_data);
-    return (ccc_handle){{.i_ = ins, .stats_ = CCC_VACANT}};
+    return (ccc_handle){{.i_ = elem_at(h, ins)->slot_i_, .stats_ = CCC_VACANT}};
 }
 
 ccc_handle
@@ -354,7 +357,8 @@ ccc_hhm_insert_or_assign(ccc_handle_hash_map *const h,
         copy_to_slot(h,
                      ccc_buf_at(&h->buf_, elem_at(h, ent.handle_.i_)->slot_i_),
                      user_base);
-        return (ccc_handle){{.i_ = ent.handle_.i_, .stats_ = CCC_OCCUPIED}};
+        return (ccc_handle){{.i_ = elem_at(h, ent.handle_.i_)->slot_i_,
+                             .stats_ = CCC_OCCUPIED}};
     }
     if (ent.handle_.stats_ & CCC_INSERT_ERROR)
     {
@@ -362,7 +366,7 @@ ccc_hhm_insert_or_assign(ccc_handle_hash_map *const h,
     }
     ccc_handle_i const ins = insert_meta(h, ent.hash_, ent.handle_.i_);
     copy_to_slot(h, ccc_buf_at(&h->buf_, elem_at(h, ins)->slot_i_), user_base);
-    return (ccc_handle){{.i_ = ins, .stats_ = CCC_VACANT}};
+    return (ccc_handle){{.i_ = elem_at(h, ins)->slot_i_, .stats_ = CCC_VACANT}};
 }
 
 ccc_handle
@@ -394,7 +398,7 @@ ccc_hhm_or_insert(ccc_hhmap_handle const *const e, ccc_hhmap_elem *const elem)
     }
     if (e->impl_.handle_.stats_ & CCC_OCCUPIED)
     {
-        return e->impl_.handle_.i_;
+        return elem_at(e->impl_.h_, e->impl_.handle_.i_)->slot_i_;
     }
     if (e->impl_.handle_.stats_ & CCC_INSERT_ERROR)
     {
@@ -407,7 +411,7 @@ ccc_hhm_or_insert(ccc_hhmap_handle const *const e, ccc_hhmap_elem *const elem)
         e->impl_.h_,
         ccc_buf_at(&e->impl_.h_->buf_, elem_at(e->impl_.h_, ins)->slot_i_),
         user_struct);
-    return ins;
+    return elem_at(e->impl_.h_, ins)->slot_i_;
 }
 
 ccc_handle_i
@@ -417,7 +421,7 @@ ccc_hhm_unwrap(ccc_hhmap_handle const *const e)
     {
         return 0;
     }
-    return e->impl_.handle_.i_;
+    return elem_at(e->impl_.h_, e->impl_.handle_.i_)->slot_i_;
 }
 
 bool
@@ -948,6 +952,10 @@ copy_to_slot(struct ccc_hhmap_ *const h, void *const slot_dst,
      - Gather all available free slots remaining in the new capacity table and
        link them to every empty metadata slot in the table ensuring every
        metadata entry has a unique slot as its backing storage space.
+     - By the end of these operations every metadata slot should point to its
+       own unique backing storage slot. All metadata for old data from the old
+       table should point to the same slots as backing stores even if the
+       metadata is now in a different slot itself.
 
    Best algorithm I could come up with is O(NlgN) time with no auxiliary space.
    We repurpose the old hash table to help sort and distribute the free slots in
@@ -1015,27 +1023,28 @@ maybe_resize(struct ccc_hhmap_ *const h)
     for (size_t slot = 0; slot < ccc_buf_capacity(&h->buf_); ++slot)
     {
         struct ccc_hhmap_elem_ const *const e = elem_at(h, slot);
-        if (e->hash_ != CCC_HHM_EMPTY)
+        if (e->hash_ == CCC_HHM_EMPTY)
         {
-            struct ccc_handl_ const new_ent
-                = find(&new_hash, key_at(h, e->slot_i_), e->hash_);
-            ccc_handle_i const ins
-                = insert_meta(&new_hash, e->hash_, new_ent.i_);
-            /* Old handle linking. */
-            elem_at(&new_hash, ins)->slot_i_ = e->slot_i_;
+            continue;
         }
+        struct ccc_handl_ const new_ent
+            = find(&new_hash, key_at(h, e->slot_i_), e->hash_);
+        ccc_handle_i const ins = insert_meta(&new_hash, e->hash_, new_ent.i_);
+        /* Old handle linking. */
+        elem_at(&new_hash, ins)->slot_i_ = e->slot_i_;
     }
     /* Repurpose old hash table to tell us which slots are take in new table. */
     size_t allocated_slots = 0;
     for (size_t slot = 0; slot < ccc_buf_capacity(&h->buf_); ++slot)
     {
         struct ccc_hhmap_elem_ const *const e = elem_at(h, slot);
-        if (e->hash_ != CCC_HHM_EMPTY)
+        if (e->hash_ == CCC_HHM_EMPTY)
         {
-            size_t const taken = e->slot_i_;
-            elem_at(h, allocated_slots)->slot_i_ = taken;
-            ++allocated_slots;
+            continue;
         }
+        size_t const taken = e->slot_i_;
+        elem_at(h, allocated_slots)->slot_i_ = taken;
+        ++allocated_slots;
     }
     /* We will use an in place O(n) heapify to tell us where the free slot runs
        are between allocated slots. Consider what happens if we have N sorted
@@ -1047,22 +1056,23 @@ maybe_resize(struct ccc_hhmap_ *const h)
          slot < ccc_buf_capacity(&new_hash.buf_); ++slot)
     {
         struct ccc_hhmap_elem_ *const e = elem_at(&new_hash, slot);
-        if (e->hash_ == CCC_HHM_EMPTY)
+        if (e->hash_ != CCC_HHM_EMPTY)
         {
-            /* Continually pop from the heap until the free slot finds a gap
-               between occupied slots or there are no longer taken slots.
-               The taken slots will naturally run out because the new capacity
-               is greater than the old. This is the worst part, an O(lgN)
-               operation in the resizing scheme. */
-            while (allocated_slots && free_slot == elem_at(h, 0)->slot_i_)
-            {
-                ++free_slot;
-                pop_slot(h, allocated_slots);
-                --allocated_slots;
-            }
-            e->slot_i_ = free_slot;
-            ++free_slot;
+            continue;
         }
+        /* Continually pop from the heap until the free slot finds a gap
+           between occupied slots or there are no longer taken slots.
+           The taken slots will naturally run out because the new capacity
+           is greater than the old. This is the worst part, an O(lgN)
+           operation in the resizing scheme. */
+        while (allocated_slots && free_slot == elem_at(h, 0)->slot_i_)
+        {
+            ++free_slot;
+            pop_slot(h, allocated_slots);
+            --allocated_slots;
+        }
+        e->slot_i_ = free_slot;
+        ++free_slot;
     }
     if (ccc_buf_alloc(&h->buf_, 0, h->buf_.alloc_) != CCC_OK)
     {

--- a/tests/hhmap/test_hhmap_insert.c
+++ b/tests/hhmap/test_hhmap_insert.c
@@ -412,8 +412,7 @@ CHECK_BEGIN_STATIC_FN(hhmap_test_resize)
         CHECK(in_table->val, shuffled_index);
         CHECK(size(&hh), to_insert);
     }
-    CHECK(hhm_clear_and_free(&hh, NULL), CCC_OK);
-    CHECK_END_FN();
+    CHECK_END_FN(hhm_clear_and_free(&hh, NULL););
 }
 
 CHECK_BEGIN_STATIC_FN(hhmap_test_resize_macros)


### PR DESCRIPTION
Implements the full promise of the handle hash map interface. Every handle returned is stable for the entire lifetime of the user data. The user's struct data will not move from the provided slot until deleted, even if resizing occurs. This means that through the use of index (aka handle), rather than a pointer, we offer one location where user data lives even while running Robin Hood Hashing on a low overhead user provided table. 

The extra cost of this is only one additional metadata field and a slightly slower resizing operation. Fixed size tables are always encouraged but we can look into how to improve resizing.