### PR TITLE
protect sentinel in linked lists invariantly

### DIFF
--- a/ccc/impl/impl_traits.h
+++ b/ccc/impl/impl_traits.h
@@ -49,10 +49,43 @@
                                                         try_insert_args)
 
 #define ccc_impl_try_insert_r(container_ptr, try_insert_args...)               \
-    &(ccc_entry)                                                               \
-    {                                                                          \
-        ccc_impl_try_insert(container_ptr, try_insert_args).impl_              \
-    }
+    _Generic((container_ptr),                                                  \
+        ccc_flat_hash_map                                                      \
+            *: &(ccc_entry){ccc_fhm_try_insert(                                \
+                                (ccc_flat_hash_map *)container_ptr,            \
+                                (ccc_fhmap_elem *)try_insert_args)             \
+                                .impl_},                                       \
+        ccc_handle_hash_map                                                    \
+            *: &(ccc_handle){ccc_hhm_try_insert(                               \
+                                 (ccc_handle_hash_map *)container_ptr,         \
+                                 (ccc_hhmap_elem *)try_insert_args)            \
+                                 .impl_},                                      \
+        ccc_ordered_map                                                        \
+            *: &(                                                              \
+                ccc_entry){ccc_om_try_insert((ccc_ordered_map *)container_ptr, \
+                                             (ccc_omap_elem *)try_insert_args) \
+                               .impl_},                                        \
+        ccc_ordered_multimap                                                   \
+            *: &(ccc_entry){ccc_omm_try_insert(                                \
+                                (ccc_ordered_multimap *)container_ptr,         \
+                                (ccc_ommap_elem *)try_insert_args)             \
+                                .impl_},                                       \
+        ccc_flat_ordered_map                                                   \
+            *: &(ccc_entry){ccc_fom_try_insert(                                \
+                                (ccc_flat_ordered_map *)container_ptr,         \
+                                (ccc_fomap_elem *)try_insert_args)             \
+                                .impl_},                                       \
+        ccc_flat_realtime_ordered_map                                          \
+            *: &(                                                              \
+                ccc_entry){ccc_frm_try_insert(                                 \
+                               (ccc_flat_realtime_ordered_map *)container_ptr, \
+                               (ccc_fromap_elem *)try_insert_args)             \
+                               .impl_},                                        \
+        ccc_realtime_ordered_map                                               \
+            *: &(ccc_entry){                                                   \
+                ccc_rom_try_insert((ccc_realtime_ordered_map *)container_ptr,  \
+                                   (ccc_romap_elem *)try_insert_args)          \
+                    .impl_})
 
 #define ccc_impl_insert_or_assign(container_ptr, insert_or_assign_args...)     \
     _Generic((container_ptr),                                                  \

--- a/src/doubly_linked_list.c
+++ b/src/doubly_linked_list.c
@@ -112,7 +112,10 @@ ccc_dll_pop_back(ccc_doubly_linked_list *const l)
     struct ccc_dll_elem_ *remove = l->sentinel_.p_;
     remove->p_->n_ = &l->sentinel_;
     l->sentinel_.p_ = remove->p_;
-    remove->n_ = remove->p_ = NULL;
+    if (remove != &l->sentinel_)
+    {
+        remove->n_ = remove->p_ = NULL;
+    }
     if (l->alloc_)
     {
         (void)l->alloc_(struct_base(l, remove), 0, l->aux_);
@@ -221,7 +224,10 @@ ccc_dll_extract(ccc_doubly_linked_list *const l,
     struct ccc_dll_elem_ const *const ret = elem_in_list->n_;
     elem_in_list->n_->p_ = elem_in_list->p_;
     elem_in_list->p_->n_ = elem_in_list->n_;
-    elem_in_list->n_ = elem_in_list->p_ = NULL;
+    if (elem_in_list != &l->sentinel_)
+    {
+        elem_in_list->n_ = elem_in_list->p_ = NULL;
+    }
     --l->sz_;
     return ret == &l->sentinel_ ? NULL : struct_base(l, ret);
 }
@@ -470,7 +476,10 @@ pop_front(struct ccc_dll_ *const dll)
     struct ccc_dll_elem_ *ret = dll->sentinel_.n_;
     dll->sentinel_.n_->p_ = &dll->sentinel_;
     dll->sentinel_.n_ = ret->n_;
-    ret->n_ = ret->p_ = NULL;
+    if (ret != &dll->sentinel_)
+    {
+        ret->n_ = ret->p_ = NULL;
+    }
     --dll->sz_;
     return ret;
 }
@@ -486,10 +495,15 @@ static inline size_t
 extract_range([[maybe_unused]] struct ccc_dll_ const *const l,
               struct ccc_dll_elem_ *begin, struct ccc_dll_elem_ *const end)
 {
-    begin->p_ = NULL;
+    if (begin != &l->sentinel_)
+    {
+        begin->p_ = NULL;
+    }
     size_t sz = len(l, begin, end);
-    assert(end != &l->sentinel_);
-    end->n_ = NULL;
+    if (end != &l->sentinel_)
+    {
+        end->n_ = NULL;
+    }
     return sz;
 }
 
@@ -497,12 +511,17 @@ static inline size_t
 erase_range(struct ccc_dll_ const *const l, struct ccc_dll_elem_ *begin,
             struct ccc_dll_elem_ *const end)
 {
-    begin->p_ = NULL;
+    if (begin != &l->sentinel_)
+    {
+        begin->p_ = NULL;
+    }
     if (!l->alloc_)
     {
         size_t const sz = len(l, begin, end);
-        assert(end != &l->sentinel_);
-        end->n_ = NULL;
+        if (end != &l->sentinel_)
+        {
+            end->n_ = NULL;
+        }
         return sz;
     }
     size_t sz = 1;

--- a/src/singly_linked_list.c
+++ b/src/singly_linked_list.c
@@ -151,7 +151,10 @@ ccc_sll_erase(ccc_singly_linked_list *const sll, ccc_sll_elem *const elem)
     }
     struct ccc_sll_elem_ const *const ret = elem->n_;
     before(sll, elem)->n_ = elem->n_;
-    elem->n_ = NULL;
+    if (elem != &sll->sentinel_)
+    {
+        elem->n_ = NULL;
+    }
     if (sll->alloc_)
     {
         (void)sll->alloc_(struct_base(sll, elem), 0, sll->aux_);
@@ -186,7 +189,10 @@ ccc_sll_extract(ccc_singly_linked_list *const sll, ccc_sll_elem *const elem)
     }
     struct ccc_sll_elem_ const *const ret = elem->n_;
     before(sll, elem)->n_ = elem->n_;
-    elem->n_ = NULL;
+    if (elem != &sll->sentinel_)
+    {
+        elem->n_ = NULL;
+    }
     --sll->sz_;
     return ret == &sll->sentinel_ ? NULL : struct_base(sll, ret);
 }
@@ -312,7 +318,10 @@ pop_front(struct ccc_sll_ *const sll)
 {
     struct ccc_sll_elem_ *remove = sll->sentinel_.n_;
     sll->sentinel_.n_ = remove->n_;
-    remove->n_ = NULL;
+    if (remove != &sll->sentinel_)
+    {
+        remove->n_ = NULL;
+    }
     --sll->sz_;
     return remove;
 }
@@ -332,7 +341,10 @@ extract_range([[maybe_unused]] struct ccc_sll_ *const sll,
               struct ccc_sll_elem_ *begin, struct ccc_sll_elem_ *const end)
 {
     size_t const sz = len(sll, begin, end);
-    end->n_ = NULL;
+    if (end != &sll->sentinel_)
+    {
+        end->n_ = NULL;
+    }
     return sz;
 }
 
@@ -343,7 +355,10 @@ erase_range([[maybe_unused]] struct ccc_sll_ *const sll,
     if (!sll->alloc_)
     {
         size_t const sz = len(sll, begin, end);
-        end->n_ = NULL;
+        if (end != &sll->sentinel_)
+        {
+            end->n_ = NULL;
+        }
         return sz;
     }
     size_t sz = 1;


### PR DESCRIPTION
Better protections uses an if over assert. Sentinel must be protected in all cases even in release mode.