### PR TITLE
convert to `ccc_tribool`

### DIFF
--- a/ccc/buffer.h
+++ b/ccc/buffer.h
@@ -374,12 +374,12 @@ Note that size must be less than or equal to capacity. */
 
 /** @brief return true if the size of the buffer is 0.
 @param [in] buf the pointer to the buffer.
-@return true if the size is 0 false if not. */
+@return true if the size is 0 false if not. Error if buf is NULL. */
 [[nodiscard]] ccc_tribool ccc_buf_is_empty(ccc_buffer const *buf);
 
 /** @brief return true if the size of the buffer equals capacity.
 @param [in] buf the pointer to the buffer.
-@return true if the size equals the capacity. */
+@return true if the size equals the capacity. Error if buf is NULL. */
 [[nodiscard]] ccc_tribool ccc_buf_is_full(ccc_buffer const *buf);
 
 /**@}*/

--- a/ccc/buffer.h
+++ b/ccc/buffer.h
@@ -32,7 +32,6 @@ Then, the `ccc_` prefix can be dropped from all types and functions. */
 #define CCC_BUFFER_H
 
 /** @cond */
-#include <stdbool.h>
 #include <stddef.h>
 /** @endcond */
 
@@ -376,12 +375,12 @@ Note that size must be less than or equal to capacity. */
 /** @brief return true if the size of the buffer is 0.
 @param [in] buf the pointer to the buffer.
 @return true if the size is 0 false if not. */
-[[nodiscard]] bool ccc_buf_is_empty(ccc_buffer const *buf);
+[[nodiscard]] ccc_tribool ccc_buf_is_empty(ccc_buffer const *buf);
 
 /** @brief return true if the size of the buffer equals capacity.
 @param [in] buf the pointer to the buffer.
 @return true if the size equals the capacity. */
-[[nodiscard]] bool ccc_buf_is_full(ccc_buffer const *buf);
+[[nodiscard]] ccc_tribool ccc_buf_is_full(ccc_buffer const *buf);
 
 /**@}*/
 

--- a/ccc/doubly_linked_list.h
+++ b/ccc/doubly_linked_list.h
@@ -342,12 +342,12 @@ ccc_dll_end_sentinel(ccc_doubly_linked_list const *l);
 /** @brief Return if the size of the list is equal to 0. O(1).
 @param [in] l a pointer to the doubly linked list.
 @return true if the size is 0 or l is NULL, else false. */
-[[nodiscard]] bool ccc_dll_is_empty(ccc_doubly_linked_list const *l);
+[[nodiscard]] ccc_tribool ccc_dll_is_empty(ccc_doubly_linked_list const *l);
 
 /** @brief Validates internal state of the list.
 @param [in] l a pointer to the doubly linked list.
 @return true if invariants hold, false if not. */
-[[nodiscard]] bool ccc_dll_validate(ccc_doubly_linked_list const *l);
+[[nodiscard]] ccc_tribool ccc_dll_validate(ccc_doubly_linked_list const *l);
 
 /**@}*/
 

--- a/ccc/doubly_linked_list.h
+++ b/ccc/doubly_linked_list.h
@@ -341,12 +341,12 @@ ccc_dll_end_sentinel(ccc_doubly_linked_list const *l);
 
 /** @brief Return if the size of the list is equal to 0. O(1).
 @param [in] l a pointer to the doubly linked list.
-@return true if the size is 0 or l is NULL, else false. */
+@return true if the size is 0, else false. Error if l is NULL. */
 [[nodiscard]] ccc_tribool ccc_dll_is_empty(ccc_doubly_linked_list const *l);
 
 /** @brief Validates internal state of the list.
 @param [in] l a pointer to the doubly linked list.
-@return true if invariants hold, false if not. */
+@return true if invariants hold, false if not. Error if l is NULL. */
 [[nodiscard]] ccc_tribool ccc_dll_validate(ccc_doubly_linked_list const *l);
 
 /**@}*/

--- a/ccc/flat_double_ended_queue.h
+++ b/ccc/flat_double_ended_queue.h
@@ -351,7 +351,7 @@ empty. */
 
 /** @brief Return true if the size of the fdeq is 0. O(1).
 @param [in] fdeq a pointer to the fdeq.
-@return true if the size is 0 or fdeq is NULL or false. */
+@return true if the size is 0 or false. Error if fdeq is NULL. */
 [[nodiscard]] ccc_tribool
 ccc_fdeq_is_empty(ccc_flat_double_ended_queue const *fdeq);
 
@@ -379,7 +379,8 @@ the array may not point to valid data in terms of organization of the fdeq. */
 
 /** @brief Return true if the internal invariants of the fdeq.
 @param [in] fdeq a pointer to the fdeq.
-@return true if the internal invariants of the fdeq are held, else false. */
+@return true if the internal invariants of the fdeq are held, else false. Error
+if fdeq is NULL. */
 [[nodiscard]] ccc_tribool
 ccc_fdeq_validate(ccc_flat_double_ended_queue const *fdeq);
 

--- a/ccc/flat_double_ended_queue.h
+++ b/ccc/flat_double_ended_queue.h
@@ -352,7 +352,8 @@ empty. */
 /** @brief Return true if the size of the fdeq is 0. O(1).
 @param [in] fdeq a pointer to the fdeq.
 @return true if the size is 0 or fdeq is NULL or false. */
-[[nodiscard]] bool ccc_fdeq_is_empty(ccc_flat_double_ended_queue const *fdeq);
+[[nodiscard]] ccc_tribool
+ccc_fdeq_is_empty(ccc_flat_double_ended_queue const *fdeq);
 
 /** @brief Return the size of the fdeq. O(1).
 @param [in] fdeq a pointer to the fdeq.
@@ -379,7 +380,8 @@ the array may not point to valid data in terms of organization of the fdeq. */
 /** @brief Return true if the internal invariants of the fdeq.
 @param [in] fdeq a pointer to the fdeq.
 @return true if the internal invariants of the fdeq are held, else false. */
-[[nodiscard]] bool ccc_fdeq_validate(ccc_flat_double_ended_queue const *fdeq);
+[[nodiscard]] ccc_tribool
+ccc_fdeq_validate(ccc_flat_double_ended_queue const *fdeq);
 
 /**@}*/
 

--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -181,7 +181,8 @@ Test membership or obtain references to stored user types directly. */
 @param [in] h the flat hash table to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
 @return true if the struct containing key is stored, false if not. */
-[[nodiscard]] bool ccc_fhm_contains(ccc_flat_hash_map *h, void const *key);
+[[nodiscard]] ccc_tribool ccc_fhm_contains(ccc_flat_hash_map *h,
+                                           void const *key);
 
 /** @brief Returns a reference into the table at entry key.
 @param [in] h the flat hash map to search.
@@ -515,7 +516,7 @@ was removed. If Vacant, no prior entry existed to be removed. */
 /** @brief Returns the Vacant or Occupied status of the entry.
 @param [in] e the entry from a query to the table via function or macro.
 @return true if the entry is occupied, false if not. */
-[[nodiscard]] bool ccc_fhm_occupied(ccc_fhmap_entry const *e);
+[[nodiscard]] ccc_tribool ccc_fhm_occupied(ccc_fhmap_entry const *e);
 
 /** @brief Provides the status of the entry should an insertion follow.
 @param [in] e the entry from a query to the table via function or macro.
@@ -532,7 +533,7 @@ functions will indicate such a failure. One can also confirm an insertion error
 will occur from an entry with this function. For example, leaving this function
 in an assert for debug builds can be a helpful sanity check if the heap should
 correctly resize by default and errors are not usually expected. */
-[[nodiscard]] bool ccc_fhm_insert_error(ccc_fhmap_entry const *e);
+[[nodiscard]] ccc_tribool ccc_fhm_insert_error(ccc_fhmap_entry const *e);
 
 /** @brief Obtain the entry status from a container entry.
 @param [in] e a pointer to the entry.
@@ -610,7 +611,7 @@ Obtain the container state. */
 /** @brief Returns the size status of the table.
 @param [in] h the hash table.
 @return true if empty else false. */
-[[nodiscard]] bool ccc_fhm_is_empty(ccc_flat_hash_map const *h);
+[[nodiscard]] ccc_tribool ccc_fhm_is_empty(ccc_flat_hash_map const *h);
 
 /** @brief Returns the size of the table.
 @param [in] h the hash table.
@@ -644,7 +645,7 @@ within the capacity of the backing buffer. */
 /** @brief Validation of invariants for the hash table.
 @param [in] h the table to validate.
 @return true if all invariants hold, false if corruption occurs. */
-[[nodiscard]] bool ccc_fhm_validate(ccc_flat_hash_map const *h);
+[[nodiscard]] ccc_tribool ccc_fhm_validate(ccc_flat_hash_map const *h);
 
 /**@}*/
 

--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -180,7 +180,8 @@ Test membership or obtain references to stored user types directly. */
 /** @brief Searches the table for the presence of key.
 @param [in] h the flat hash table to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
-@return true if the struct containing key is stored, false if not. */
+@return true if the struct containing key is stored, false if not. Error if h or
+key is NULL. */
 [[nodiscard]] ccc_tribool ccc_fhm_contains(ccc_flat_hash_map *h,
                                            void const *key);
 
@@ -515,12 +516,13 @@ was removed. If Vacant, no prior entry existed to be removed. */
 
 /** @brief Returns the Vacant or Occupied status of the entry.
 @param [in] e the entry from a query to the table via function or macro.
-@return true if the entry is occupied, false if not. */
+@return true if the entry is occupied, false if not. Error if e is NULL. */
 [[nodiscard]] ccc_tribool ccc_fhm_occupied(ccc_fhmap_entry const *e);
 
 /** @brief Provides the status of the entry should an insertion follow.
 @param [in] e the entry from a query to the table via function or macro.
-@return true if the next insertion of a new element will cause an error.
+@return true if the next insertion of a new element will cause an error. Error
+if e is null.
 
 Table resizing occurs upon calls to entry functions/macros or when trying
 to insert a new element directly. This is to provide stable entries from the
@@ -531,8 +533,7 @@ However, if a Vacant entry is returned and then a subsequent insertion function
 is used, it will not work if resizing has failed and the return of those
 functions will indicate such a failure. One can also confirm an insertion error
 will occur from an entry with this function. For example, leaving this function
-in an assert for debug builds can be a helpful sanity check if the heap should
-correctly resize by default and errors are not usually expected. */
+in an assert for debug builds can be a helpful sanity check. */
 [[nodiscard]] ccc_tribool ccc_fhm_insert_error(ccc_fhmap_entry const *e);
 
 /** @brief Obtain the entry status from a container entry.
@@ -610,7 +611,7 @@ Obtain the container state. */
 
 /** @brief Returns the size status of the table.
 @param [in] h the hash table.
-@return true if empty else false. */
+@return true if empty else false. Error if h is NULL. */
 [[nodiscard]] ccc_tribool ccc_fhm_is_empty(ccc_flat_hash_map const *h);
 
 /** @brief Returns the size of the table.
@@ -644,7 +645,8 @@ within the capacity of the backing buffer. */
 
 /** @brief Validation of invariants for the hash table.
 @param [in] h the table to validate.
-@return true if all invariants hold, false if corruption occurs. */
+@return true if all invariants hold, false if corruption occurs. Error if h is
+NULL. */
 [[nodiscard]] ccc_tribool ccc_fhm_validate(ccc_flat_hash_map const *h);
 
 /**@}*/

--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -370,7 +370,7 @@ range of the fpq. */
 
 /** @brief Returns true if the fpq is empty false if not. O(1).
 @param [in] fpq a pointer to the flat priority queue.
-@return true if the size is 0 or fpq is NULL, false if not empty.  */
+@return true if the size is 0, false if not empty. Error if fpq is NULL. */
 [[nodiscard]] ccc_tribool ccc_fpq_is_empty(ccc_flat_priority_queue const *fpq);
 
 /** @brief Returns the size of the fpq.
@@ -394,7 +394,7 @@ within the capacity of the backing buffer. */
 
 /** @brief Verifies the internal invariants of the fpq hold.
 @param [in] fpq a pointer to the flat priority queue.
-@return true if the fpq is valid false if fpq is NULL or invalid. */
+@return true if the fpq is valid false if invalid. Error if fpq is NULL. */
 [[nodiscard]] ccc_tribool ccc_fpq_validate(ccc_flat_priority_queue const *fpq);
 
 /** @brief Return the order used to initialize the fpq.

--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -17,7 +17,6 @@ All types and functions can then be written without the `ccc_` prefix. */
 #define CCC_FLAT_PRIORITY_QUEUE_H
 
 /** @cond */
-#include <stdbool.h>
 #include <stddef.h>
 /** @endcond */
 
@@ -372,7 +371,7 @@ range of the fpq. */
 /** @brief Returns true if the fpq is empty false if not. O(1).
 @param [in] fpq a pointer to the flat priority queue.
 @return true if the size is 0 or fpq is NULL, false if not empty.  */
-[[nodiscard]] bool ccc_fpq_is_empty(ccc_flat_priority_queue const *fpq);
+[[nodiscard]] ccc_tribool ccc_fpq_is_empty(ccc_flat_priority_queue const *fpq);
 
 /** @brief Returns the size of the fpq.
 @param [in] fpq a pointer to the flat priority queue.
@@ -396,7 +395,7 @@ within the capacity of the backing buffer. */
 /** @brief Verifies the internal invariants of the fpq hold.
 @param [in] fpq a pointer to the flat priority queue.
 @return true if the fpq is valid false if fpq is NULL or invalid. */
-[[nodiscard]] bool ccc_fpq_validate(ccc_flat_priority_queue const *fpq);
+[[nodiscard]] ccc_tribool ccc_fpq_validate(ccc_flat_priority_queue const *fpq);
 
 /** @brief Return the order used to initialize the fpq.
 @param [in] fpq a pointer to the flat priority queue.

--- a/ccc/handle_hash_map.h
+++ b/ccc/handle_hash_map.h
@@ -225,7 +225,8 @@ stored in the map. */
 /** @brief Searches the table for the presence of key.
 @param [in] h the handle hash table to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
-@return true if the struct containing key is stored, false if not. */
+@return true if the struct containing key is stored, false if not. Error if h or
+key is NULL. */
 [[nodiscard]] ccc_tribool ccc_hhm_contains(ccc_handle_hash_map *h,
                                            void const *key);
 
@@ -569,12 +570,13 @@ If the old table element is needed see the remove method. */
 
 /** @brief Returns the Vacant or Occupied status of the handle.
 @param [in] e the handle from a query to the table via function or macro.
-@return true if the handle is occupied, false if not. */
+@return true if the handle is occupied, false if not. Error if e is NULL. */
 [[nodiscard]] ccc_tribool ccc_hhm_occupied(ccc_hhmap_handle const *e);
 
 /** @brief Provides the status of the handle should an insertion follow.
 @param [in] e the handle from a query to the table via function or macro.
-@return true if the next insertion of a new element will cause an error.
+@return true if the next insertion of a new element will cause an error. Error
+if e is NULL.
 
 Table resizing occurs upon calls to handle functions/macros or when trying
 to insert a new element directly. This is to provide stable entries from the
@@ -585,8 +587,7 @@ However, if a Vacant handle is returned and then a subsequent insertion function
 is used, it will not work if resizing has failed and the return of those
 functions will indicate such a failure. One can also confirm an insertion error
 will occur from a handle with this function. For example, leaving this function
-in an assert for debug builds can be a helpful sanity check if the heap should
-correctly resize by default and errors are not usually expected. */
+in an assert for debug builds can be a helpful sanity check. */
 [[nodiscard]] ccc_tribool ccc_hhm_insert_error(ccc_hhmap_handle const *e);
 
 /** @brief Obtain the handle status from a container handle.
@@ -655,7 +656,7 @@ ccc_result ccc_hhm_next(ccc_hhmap_handle *iter);
 @param [in] iter a pointer to the current handle iterator.
 @return true if the handle iterator has reached the end of the table and
 iteration should stop, false if the iterator is valid and iteration should
-continue.
+continue. Error if iter is NULL.
 @warning if iter has reached the end unwrapping it will result in 0 or invalid
 handles and NULL references. */
 [[nodiscard]] ccc_tribool ccc_hhm_end(ccc_hhmap_handle const *iter);
@@ -668,7 +669,7 @@ Obtain the container state. */
 
 /** @brief Returns the size status of the table.
 @param [in] h the hash table.
-@return true if empty else false. */
+@return true if empty else false. Error if h is NULL. */
 [[nodiscard]] ccc_tribool ccc_hhm_is_empty(ccc_handle_hash_map const *h);
 
 /** @brief Returns the size of the table.
@@ -702,7 +703,8 @@ within the capacity of the backing buffer. */
 
 /** @brief Validation of invariants for the hash table.
 @param [in] h the table to validate.
-@return true if all invariants hold, false if corruption occurs. */
+@return true if all invariants hold, false if corruption occurs. Error if h is
+NULL. */
 [[nodiscard]] ccc_tribool ccc_hhm_validate(ccc_handle_hash_map const *h);
 
 /**@}*/

--- a/ccc/handle_hash_map.h
+++ b/ccc/handle_hash_map.h
@@ -46,7 +46,6 @@ All types and functions can then be written without the `ccc_` prefix. */
 #define CCC_HANDLE_HASH_MAP_H
 
 /** @cond */
-#include <stdbool.h>
 #include <stddef.h>
 /** @endcond */
 
@@ -227,7 +226,8 @@ stored in the map. */
 @param [in] h the handle hash table to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
 @return true if the struct containing key is stored, false if not. */
-[[nodiscard]] bool ccc_hhm_contains(ccc_handle_hash_map *h, void const *key);
+[[nodiscard]] ccc_tribool ccc_hhm_contains(ccc_handle_hash_map *h,
+                                           void const *key);
 
 /** @brief Returns a handle to the element stored at key if present.
 @param [in] h the handle hash map to search.
@@ -570,7 +570,7 @@ If the old table element is needed see the remove method. */
 /** @brief Returns the Vacant or Occupied status of the handle.
 @param [in] e the handle from a query to the table via function or macro.
 @return true if the handle is occupied, false if not. */
-[[nodiscard]] bool ccc_hhm_occupied(ccc_hhmap_handle const *e);
+[[nodiscard]] ccc_tribool ccc_hhm_occupied(ccc_hhmap_handle const *e);
 
 /** @brief Provides the status of the handle should an insertion follow.
 @param [in] e the handle from a query to the table via function or macro.
@@ -587,7 +587,7 @@ functions will indicate such a failure. One can also confirm an insertion error
 will occur from a handle with this function. For example, leaving this function
 in an assert for debug builds can be a helpful sanity check if the heap should
 correctly resize by default and errors are not usually expected. */
-[[nodiscard]] bool ccc_hhm_insert_error(ccc_hhmap_handle const *e);
+[[nodiscard]] ccc_tribool ccc_hhm_insert_error(ccc_hhmap_handle const *e);
 
 /** @brief Obtain the handle status from a container handle.
 @param [in] e a pointer to the handle.
@@ -658,7 +658,7 @@ iteration should stop, false if the iterator is valid and iteration should
 continue.
 @warning if iter has reached the end unwrapping it will result in 0 or invalid
 handles and NULL references. */
-[[nodiscard]] bool ccc_hhm_end(ccc_hhmap_handle const *iter);
+[[nodiscard]] ccc_tribool ccc_hhm_end(ccc_hhmap_handle const *iter);
 
 /**@}*/
 
@@ -669,7 +669,7 @@ Obtain the container state. */
 /** @brief Returns the size status of the table.
 @param [in] h the hash table.
 @return true if empty else false. */
-[[nodiscard]] bool ccc_hhm_is_empty(ccc_handle_hash_map const *h);
+[[nodiscard]] ccc_tribool ccc_hhm_is_empty(ccc_handle_hash_map const *h);
 
 /** @brief Returns the size of the table.
 @param [in] h the hash table.
@@ -703,7 +703,7 @@ within the capacity of the backing buffer. */
 /** @brief Validation of invariants for the hash table.
 @param [in] h the table to validate.
 @return true if all invariants hold, false if corruption occurs. */
-[[nodiscard]] bool ccc_hhm_validate(ccc_handle_hash_map const *h);
+[[nodiscard]] ccc_tribool ccc_hhm_validate(ccc_handle_hash_map const *h);
 
 /**@}*/
 

--- a/ccc/handle_ordered_map.h
+++ b/ccc/handle_ordered_map.h
@@ -33,7 +33,6 @@ All types and functions can then be written without the `ccc_` prefix. */
 #define CCC_HANDLE_ORDERED_MAP_H
 
 /** @cond */
-#include <stdbool.h>
 #include <stddef.h>
 /** @endcond */
 
@@ -204,8 +203,8 @@ stored in the map. */
 @param [in] hom the map to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
 @return true if the struct containing key is stored, false if not. */
-[[nodiscard]] bool ccc_hom_contains(ccc_handle_ordered_map *hom,
-                                    void const *key);
+[[nodiscard]] ccc_tribool ccc_hom_contains(ccc_handle_ordered_map *hom,
+                                           void const *key);
 
 /** @brief Returns a reference into the map at handle key.
 @param [in] hom the ordered map to search.
@@ -521,13 +520,13 @@ was removed. If Vacant, no prior handle existed to be removed. */
 /** @brief Returns the Vacant or Occupied status of the handle.
 @param [in] h the handle from a query to the map via function or macro.
 @return true if the handle is occupied, false if not. */
-[[nodiscard]] bool ccc_hom_occupied(ccc_homap_handle const *h);
+[[nodiscard]] ccc_tribool ccc_hom_occupied(ccc_homap_handle const *h);
 
 /** @brief Provides the status of the handle should an insertion follow.
 @param [in] h the handle from a query to the table via function or macro.
 @return true if a handle obtained from an insertion attempt failed to insert
 due to an allocation failure when allocation success was expected. */
-[[nodiscard]] bool ccc_hom_insert_error(ccc_homap_handle const *h);
+[[nodiscard]] ccc_tribool ccc_hom_insert_error(ccc_homap_handle const *h);
 
 /** @brief Obtain the handle status from a container handle.
 @param [in] h a pointer to the handle.
@@ -721,12 +720,12 @@ within the capacity of the backing buffer. */
 /** @brief Returns the size status of the map.
 @param [in] hom the map.
 @return true if empty else false. */
-[[nodiscard]] bool ccc_hom_is_empty(ccc_handle_ordered_map const *hom);
+[[nodiscard]] ccc_tribool ccc_hom_is_empty(ccc_handle_ordered_map const *hom);
 
 /** @brief Validation of invariants for the map.
 @param [in] hom the map to validate.
 @return true if all invariants hold, false if corruption occurs. */
-[[nodiscard]] bool ccc_hom_validate(ccc_handle_ordered_map const *hom);
+[[nodiscard]] ccc_tribool ccc_hom_validate(ccc_handle_ordered_map const *hom);
 
 /**@}*/
 

--- a/ccc/handle_ordered_map.h
+++ b/ccc/handle_ordered_map.h
@@ -202,7 +202,8 @@ stored in the map. */
 /** @brief Searches the map for the presence of key.
 @param [in] hom the map to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
-@return true if the struct containing key is stored, false if not. */
+@return true if the struct containing key is stored, false if not. Error if hom
+or key is NULL. */
 [[nodiscard]] ccc_tribool ccc_hom_contains(ccc_handle_ordered_map *hom,
                                            void const *key);
 
@@ -519,13 +520,14 @@ was removed. If Vacant, no prior handle existed to be removed. */
 
 /** @brief Returns the Vacant or Occupied status of the handle.
 @param [in] h the handle from a query to the map via function or macro.
-@return true if the handle is occupied, false if not. */
+@return true if the handle is occupied, false if not. Error if h is NULL. */
 [[nodiscard]] ccc_tribool ccc_hom_occupied(ccc_homap_handle const *h);
 
 /** @brief Provides the status of the handle should an insertion follow.
 @param [in] h the handle from a query to the table via function or macro.
 @return true if a handle obtained from an insertion attempt failed to insert
-due to an allocation failure when allocation success was expected. */
+due to an allocation failure when allocation success was expected. Error if h is
+NULL. */
 [[nodiscard]] ccc_tribool ccc_hom_insert_error(ccc_homap_handle const *h);
 
 /** @brief Obtain the handle status from a container handle.
@@ -719,12 +721,13 @@ within the capacity of the backing buffer. */
 
 /** @brief Returns the size status of the map.
 @param [in] hom the map.
-@return true if empty else false. */
+@return true if empty else false. Error if hom is NULL. */
 [[nodiscard]] ccc_tribool ccc_hom_is_empty(ccc_handle_ordered_map const *hom);
 
 /** @brief Validation of invariants for the map.
 @param [in] hom the map to validate.
-@return true if all invariants hold, false if corruption occurs. */
+@return true if all invariants hold, false if corruption occurs. Error if home
+is NULL.  */
 [[nodiscard]] ccc_tribool ccc_hom_validate(ccc_handle_ordered_map const *hom);
 
 /**@}*/

--- a/ccc/handle_realtime_ordered_map.h
+++ b/ccc/handle_realtime_ordered_map.h
@@ -32,7 +32,6 @@ All types and functions can then be written without the `ccc_` prefix. */
 #define CCC_HANDLE_REALTIME_ORDERED_MAP_H
 
 /** @cond */
-#include <stdbool.h>
 #include <stddef.h>
 /** @endcond */
 
@@ -207,8 +206,8 @@ stored in the map. */
 @param [in] hrm the map to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
 @return true if the struct containing key is stored, false if not. */
-[[nodiscard]] bool ccc_hrm_contains(ccc_handle_realtime_ordered_map const *hrm,
-                                    void const *key);
+[[nodiscard]] ccc_tribool
+ccc_hrm_contains(ccc_handle_realtime_ordered_map const *hrm, void const *key);
 
 /** @brief Returns a reference into the map at handle key.
 @param [in] hrm the ordered map to search.
@@ -546,13 +545,13 @@ insertions. */
 /** @brief Returns the Vacant or Occupied status of the handle.
 @param [in] h the handle from a query to the map via function or macro.
 @return true if the handle is occupied, false if not. */
-[[nodiscard]] bool ccc_hrm_occupied(ccc_hromap_handle const *h);
+[[nodiscard]] ccc_tribool ccc_hrm_occupied(ccc_hromap_handle const *h);
 
 /** @brief Provides the status of the handle should an insertion follow.
 @param [in] h the handle from a query to the table via function or macro.
 @return true if a handle obtained from an insertion attempt failed to insert
 due to an allocation failure when allocation success was expected. */
-[[nodiscard]] bool ccc_hrm_insert_error(ccc_hromap_handle const *h);
+[[nodiscard]] ccc_tribool ccc_hrm_insert_error(ccc_hromap_handle const *h);
 
 /** @brief Obtain the handle status from a container handle.
 @param [in] h a pointer to the handle.
@@ -722,7 +721,8 @@ Obtain the container state. */
 /** @brief Returns the size status of the map.
 @param [in] hrm the map.
 @return true if empty else false. */
-[[nodiscard]] bool ccc_hrm_is_empty(ccc_handle_realtime_ordered_map const *hrm);
+[[nodiscard]] ccc_tribool
+ccc_hrm_is_empty(ccc_handle_realtime_ordered_map const *hrm);
 
 /** @brief Returns the size of the map
 @param [in] hrm the map.
@@ -747,7 +747,8 @@ within the capacity of the backing buffer. */
 /** @brief Validation of invariants for the map.
 @param [in] hrm the map to validate.
 @return true if all invariants hold, false if corruption occurs. */
-[[nodiscard]] bool ccc_hrm_validate(ccc_handle_realtime_ordered_map const *hrm);
+[[nodiscard]] ccc_tribool
+ccc_hrm_validate(ccc_handle_realtime_ordered_map const *hrm);
 
 /**@}*/
 

--- a/ccc/handle_realtime_ordered_map.h
+++ b/ccc/handle_realtime_ordered_map.h
@@ -205,7 +205,8 @@ stored in the map. */
 /** @brief Searches the map for the presence of key.
 @param [in] hrm the map to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
-@return true if the struct containing key is stored, false if not. */
+@return true if the struct containing key is stored, false if not. Error if hrm
+or key is NULL. */
 [[nodiscard]] ccc_tribool
 ccc_hrm_contains(ccc_handle_realtime_ordered_map const *hrm, void const *key);
 
@@ -544,13 +545,14 @@ insertions. */
 
 /** @brief Returns the Vacant or Occupied status of the handle.
 @param [in] h the handle from a query to the map via function or macro.
-@return true if the handle is occupied, false if not. */
+@return true if the handle is occupied, false if not. Error if h is NULL. */
 [[nodiscard]] ccc_tribool ccc_hrm_occupied(ccc_hromap_handle const *h);
 
 /** @brief Provides the status of the handle should an insertion follow.
 @param [in] h the handle from a query to the table via function or macro.
 @return true if a handle obtained from an insertion attempt failed to insert
-due to an allocation failure when allocation success was expected. */
+due to an allocation failure when allocation success was expected. Error if h is
+NULL. */
 [[nodiscard]] ccc_tribool ccc_hrm_insert_error(ccc_hromap_handle const *h);
 
 /** @brief Obtain the handle status from a container handle.
@@ -720,7 +722,7 @@ Obtain the container state. */
 
 /** @brief Returns the size status of the map.
 @param [in] hrm the map.
-@return true if empty else false. */
+@return true if empty else false. Error if hrm is NULL. */
 [[nodiscard]] ccc_tribool
 ccc_hrm_is_empty(ccc_handle_realtime_ordered_map const *hrm);
 
@@ -746,7 +748,8 @@ within the capacity of the backing buffer. */
 
 /** @brief Validation of invariants for the map.
 @param [in] hrm the map to validate.
-@return true if all invariants hold, false if corruption occurs. */
+@return true if all invariants hold, false if corruption occurs. Error if hrm is
+NULL. */
 [[nodiscard]] ccc_tribool
 ccc_hrm_validate(ccc_handle_realtime_ordered_map const *hrm);
 

--- a/ccc/impl/impl_priority_queue.h
+++ b/ccc/impl/impl_priority_queue.h
@@ -77,12 +77,12 @@ void ccc_impl_pq_decrease_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
 #define ccc_impl_pq_update_w(pq_ptr, pq_elem_ptr, update_closure_over_T...)    \
     (__extension__({                                                           \
         struct ccc_pq_ *const pq_ = (pq_ptr);                                  \
-        bool pq_update_res_ = false;                                           \
+        ccc_tribool pq_update_res_ = CCC_FALSE;                                \
         struct ccc_pq_elem_ *const pq_elem_ptr_ = (pq_elem_ptr);               \
         if (pq_ && pq_elem_ptr_ && pq_elem_ptr_->next_sibling_                 \
             && pq_elem_ptr_->prev_sibling_)                                    \
         {                                                                      \
-            pq_update_res_ = true;                                             \
+            pq_update_res_ = CCC_TRUE;                                         \
             {update_closure_over_T} ccc_impl_pq_update_fixup(pq_,              \
                                                              pq_elem_ptr_);    \
         }                                                                      \
@@ -93,12 +93,12 @@ void ccc_impl_pq_decrease_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
                                increase_closure_over_T...)                     \
     (__extension__({                                                           \
         struct ccc_pq_ *const pq_ = (pq_ptr);                                  \
-        bool pq_increase_res_ = false;                                         \
+        ccc_tribool pq_increase_res_ = CCC_FALSE;                              \
         struct ccc_pq_elem_ *const pq_elem_ptr_ = (pq_elem_ptr);               \
         if (pq_ && pq_elem_ptr_ && pq_elem_ptr_->next_sibling_                 \
             && pq_elem_ptr_->prev_sibling_)                                    \
         {                                                                      \
-            pq_increase_res_ = true;                                           \
+            pq_increase_res_ = CCC_TRUE;                                       \
             {increase_closure_over_T} ccc_impl_pq_increase_fixup(              \
                 pq_, pq_elem_ptr_);                                            \
         }                                                                      \
@@ -109,12 +109,12 @@ void ccc_impl_pq_decrease_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
                                decrease_closure_over_T...)                     \
     (__extension__({                                                           \
         struct ccc_pq_ *const pq_ = (pq_ptr);                                  \
-        bool pq_decrease_res_ = false;                                         \
+        ccc_tribool pq_decrease_res_ = CCC_FALSE;                              \
         struct ccc_pq_elem_ *const pq_elem_ptr_ = (pq_elem_ptr);               \
         if (pq_ && pq_elem_ptr_ && pq_elem_ptr_->next_sibling_                 \
             && pq_elem_ptr_->prev_sibling_)                                    \
         {                                                                      \
-            pq_decrease_res_ = true;                                           \
+            pq_decrease_res_ = CCC_TRUE;                                       \
             {decrease_closure_over_T} ccc_impl_pq_decrease_fixup(              \
                 pq_, pq_elem_ptr_);                                            \
         }                                                                      \

--- a/ccc/ordered_map.h
+++ b/ccc/ordered_map.h
@@ -85,7 +85,8 @@ Test membership or obtain references to stored user types directly. */
 /** @brief Searches the map for the presence of key.
 @param [in] om the map to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
-@return true if the struct containing key is stored, false if not. */
+@return true if the struct containing key is stored, false if not. Error if om
+or key is NULL. */
 [[nodiscard]] ccc_tribool ccc_om_contains(ccc_ordered_map *om, void const *key);
 
 /** @brief Returns a reference into the map at entry key.
@@ -421,13 +422,14 @@ free or use as needed. */
 
 /** @brief Returns the Vacant or Occupied status of the entry.
 @param [in] e the entry from a query to the map via function or macro.
-@return true if the entry is occupied, false if not. */
+@return true if the entry is occupied, false if not. Error if e is NULL. */
 [[nodiscard]] ccc_tribool ccc_om_occupied(ccc_omap_entry const *e);
 
 /** @brief Provides the status of the entry should an insertion follow.
 @param [in] e the entry from a query to the table via function or macro.
 @return true if an entry obtained from an insertion attempt failed to insert
-due to an allocation failure when allocation success was expected. */
+due to an allocation failure when allocation success was expected. Error if e is
+NULL. */
 [[nodiscard]] ccc_tribool ccc_om_insert_error(ccc_omap_entry const *e);
 
 /** @brief Obtain the entry status from a container entry.
@@ -590,7 +592,7 @@ Obtain the container state. */
 
 /** @brief Returns the size status of the map.
 @param [in] om the map.
-@return true if empty else false. */
+@return true if empty else false. Error if om is NULL. */
 [[nodiscard]] ccc_tribool ccc_om_is_empty(ccc_ordered_map const *om);
 
 /** @brief Returns the size of the map
@@ -600,7 +602,8 @@ Obtain the container state. */
 
 /** @brief Validation of invariants for the map.
 @param [in] om the map to validate.
-@return true if all invariants hold, false if corruption occurs. */
+@return true if all invariants hold, false if corruption occurs. Error if om is
+NULL. */
 [[nodiscard]] ccc_tribool ccc_om_validate(ccc_ordered_map const *om);
 
 /**@}*/

--- a/ccc/ordered_map.h
+++ b/ccc/ordered_map.h
@@ -22,7 +22,6 @@ All types and functions can then be written without the `ccc_` prefix. */
 #define CCC_ORDERED_MAP_H
 
 /** @cond */
-#include <stdbool.h>
 #include <stddef.h>
 /** @endcond */
 
@@ -87,7 +86,7 @@ Test membership or obtain references to stored user types directly. */
 @param [in] om the map to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
 @return true if the struct containing key is stored, false if not. */
-[[nodiscard]] bool ccc_om_contains(ccc_ordered_map *om, void const *key);
+[[nodiscard]] ccc_tribool ccc_om_contains(ccc_ordered_map *om, void const *key);
 
 /** @brief Returns a reference into the map at entry key.
 @param [in] om the ordered map to search.
@@ -423,13 +422,13 @@ free or use as needed. */
 /** @brief Returns the Vacant or Occupied status of the entry.
 @param [in] e the entry from a query to the map via function or macro.
 @return true if the entry is occupied, false if not. */
-[[nodiscard]] bool ccc_om_occupied(ccc_omap_entry const *e);
+[[nodiscard]] ccc_tribool ccc_om_occupied(ccc_omap_entry const *e);
 
 /** @brief Provides the status of the entry should an insertion follow.
 @param [in] e the entry from a query to the table via function or macro.
 @return true if an entry obtained from an insertion attempt failed to insert
 due to an allocation failure when allocation success was expected. */
-[[nodiscard]] bool ccc_om_insert_error(ccc_omap_entry const *e);
+[[nodiscard]] ccc_tribool ccc_om_insert_error(ccc_omap_entry const *e);
 
 /** @brief Obtain the entry status from a container entry.
 @param [in] e a pointer to the entry.
@@ -592,7 +591,7 @@ Obtain the container state. */
 /** @brief Returns the size status of the map.
 @param [in] om the map.
 @return true if empty else false. */
-[[nodiscard]] bool ccc_om_is_empty(ccc_ordered_map const *om);
+[[nodiscard]] ccc_tribool ccc_om_is_empty(ccc_ordered_map const *om);
 
 /** @brief Returns the size of the map
 @param [in] om the map.
@@ -602,7 +601,7 @@ Obtain the container state. */
 /** @brief Validation of invariants for the map.
 @param [in] om the map to validate.
 @return true if all invariants hold, false if corruption occurs. */
-[[nodiscard]] bool ccc_om_validate(ccc_ordered_map const *om);
+[[nodiscard]] ccc_tribool ccc_om_validate(ccc_ordered_map const *om);
 
 /**@}*/
 

--- a/ccc/ordered_multimap.h
+++ b/ccc/ordered_multimap.h
@@ -33,7 +33,6 @@ All types and functions can then be written without the `ccc_` prefix. */
 #define CCC_ORDERED_MULTIMAP_H
 
 /** @cond */
-#include <stdbool.h>
 #include <stddef.h>
 /** @endcond */
 
@@ -103,7 +102,8 @@ Test membership or obtain references to stored user types directly. */
 @param [in] mm a pointer to the multimap.
 @param [in] key a pointer to the key to be searched.
 @return true if the multimap contains at least one entry at key, else false. */
-[[nodiscard]] bool ccc_omm_contains(ccc_ordered_multimap *mm, void const *key);
+[[nodiscard]] ccc_tribool ccc_omm_contains(ccc_ordered_multimap *mm,
+                                           void const *key);
 
 /** @brief Returns a reference to the user type stored at key. Amortized O(lg
 N).
@@ -383,7 +383,7 @@ freed by the user. */
 /** @brief Indicates if an entry is Occupied or Vacant.
 @param [in] e a pointer to the multimap entry.
 @return true if the entry is Occupied, false if it is Vacant. */
-[[nodiscard]] bool ccc_omm_occupied(ccc_ommap_entry const *e);
+[[nodiscard]] ccc_tribool ccc_omm_occupied(ccc_ommap_entry const *e);
 
 /** @brief Unwraps the provided entry. An Occupied entry will point to the user
 type stored in the map, a Vacant entry will be NULL.
@@ -398,7 +398,7 @@ Interface series of operations.
 
 Note that this will most commonly occur if the container is permitted to
 allocate but the allocation has failed. */
-[[nodiscard]] bool ccc_omm_insert_error(ccc_ommap_entry const *e);
+[[nodiscard]] ccc_tribool ccc_omm_insert_error(ccc_ommap_entry const *e);
 
 /** @brief Indicates if a function used to generate the provided entry
 encountered bad arguments that prevented the operation of the function.
@@ -407,7 +407,7 @@ encountered bad arguments that prevented the operation of the function.
 
 Note bad arguments usually mean NULL pointers were passed to functions expecting
 non-NULL arguments. */
-[[nodiscard]] bool ccc_omm_input_error(ccc_ommap_entry const *e);
+[[nodiscard]] ccc_tribool ccc_omm_input_error(ccc_ommap_entry const *e);
 
 /** @brief Obtain the entry status from a container entry.
 @param [in] e a pointer to the entry.
@@ -503,9 +503,9 @@ but NULL is possible if aux is not needed.
 @return true if the key update was successful, false if bad arguments are
 provided, it is possible to prove the key_val_handle is not tracked by the map,
 or the map is empty. */
-[[nodiscard]] bool ccc_omm_update(ccc_ordered_multimap *mm,
-                                  ccc_ommap_elem *key_val_handle,
-                                  ccc_update_fn *fn, void *aux);
+[[nodiscard]] ccc_tribool ccc_omm_update(ccc_ordered_multimap *mm,
+                                         ccc_ommap_elem *key_val_handle,
+                                         ccc_update_fn *fn, void *aux);
 
 /** @brief Increases an element key that is currently tracked directly as a
 member of the map. Amortized O(lg N).
@@ -518,9 +518,9 @@ value but NULL is possible if aux is not needed.
 @return true if the key increase was successful, false if bad arguments are
 provided, it is possible to prove the key_val_handle is not tracked by the map,
 or the map is empty. */
-[[nodiscard]] bool ccc_omm_increase(ccc_ordered_multimap *mm,
-                                    ccc_ommap_elem *key_val_handle,
-                                    ccc_update_fn *fn, void *aux);
+[[nodiscard]] ccc_tribool ccc_omm_increase(ccc_ordered_multimap *mm,
+                                           ccc_ommap_elem *key_val_handle,
+                                           ccc_update_fn *fn, void *aux);
 
 /** @brief Decreases an element key that is currently tracked directly as a
 member of the map. Amortized O(lg N).
@@ -533,9 +533,9 @@ value but NULL is possible if aux is not needed.
 @return true if the key decrease was successful, false if bad arguments are
 provided, it is possible to prove the key_val_handle is not tracked by the map,
 or the map is empty. */
-[[nodiscard]] bool ccc_omm_decrease(ccc_ordered_multimap *mm,
-                                    ccc_ommap_elem *key_val_handle,
-                                    ccc_update_fn *fn, void *aux);
+[[nodiscard]] ccc_tribool ccc_omm_decrease(ccc_ordered_multimap *mm,
+                                           ccc_ommap_elem *key_val_handle,
+                                           ccc_update_fn *fn, void *aux);
 
 /**@}*/
 
@@ -712,7 +712,7 @@ Obtain the container state. */
 /** @brief Returns true if the multimap is empty. O(1).
 @param [in] mm a pointer to the multimap.
 @return true if empty, false if mm is NULL or mm is empty. */
-[[nodiscard]] bool ccc_omm_is_empty(ccc_ordered_multimap const *mm);
+[[nodiscard]] ccc_tribool ccc_omm_is_empty(ccc_ordered_multimap const *mm);
 
 /** @brief Returns true if the multimap is empty. O(1).
 @param [in] mm a pointer to the multimap.
@@ -722,7 +722,7 @@ Obtain the container state. */
 /** @brief Returns true if the multimap is empty.
 @param [in] mm a pointer to the multimap.
 @return true if invariants of the data structure are preserved, else false. */
-[[nodiscard]] bool ccc_omm_validate(ccc_ordered_multimap const *mm);
+[[nodiscard]] ccc_tribool ccc_omm_validate(ccc_ordered_multimap const *mm);
 
 /**@}*/
 

--- a/ccc/ordered_multimap.h
+++ b/ccc/ordered_multimap.h
@@ -101,7 +101,8 @@ Test membership or obtain references to stored user types directly. */
 /** @brief Returns the membership of key in the multimap. Amortized O(lg N).
 @param [in] mm a pointer to the multimap.
 @param [in] key a pointer to the key to be searched.
-@return true if the multimap contains at least one entry at key, else false. */
+@return true if the multimap contains at least one entry at key, else false.
+Error if mm or key is NULL. */
 [[nodiscard]] ccc_tribool ccc_omm_contains(ccc_ordered_multimap *mm,
                                            void const *key);
 
@@ -382,7 +383,8 @@ freed by the user. */
 
 /** @brief Indicates if an entry is Occupied or Vacant.
 @param [in] e a pointer to the multimap entry.
-@return true if the entry is Occupied, false if it is Vacant. */
+@return true if the entry is Occupied, false if it is Vacant. Error if e is
+NULL. */
 [[nodiscard]] ccc_tribool ccc_omm_occupied(ccc_ommap_entry const *e);
 
 /** @brief Unwraps the provided entry. An Occupied entry will point to the user
@@ -394,7 +396,7 @@ type stored in the map, a Vacant entry will be NULL.
 /** @brief Indicates if an insertion error occurs.
 @param [in] e a pointer to the multimap entry.
 @return true if an insertion error occured preventing completing of an Entry
-Interface series of operations.
+Interface series of operations. Error if e is NULL.
 
 Note that this will most commonly occur if the container is permitted to
 allocate but the allocation has failed. */
@@ -403,7 +405,8 @@ allocate but the allocation has failed. */
 /** @brief Indicates if a function used to generate the provided entry
 encountered bad arguments that prevented the operation of the function.
 @param [in] e a pointer to the multimap entry.
-@return true if bad function arguments were provided, otherwise false.
+@return true if bad function arguments were provided, otherwise false. Error if
+e is NULL.
 
 Note bad arguments usually mean NULL pointers were passed to functions expecting
 non-NULL arguments. */
@@ -500,9 +503,9 @@ user type that the user knows is currently in the map.
 @param [in] fn the function used to update an element key in the map.
 @param [in] aux any auxiliary data needed for the update. Usually a new value
 but NULL is possible if aux is not needed.
-@return true if the key update was successful, false if bad arguments are
-provided, it is possible to prove the key_val_handle is not tracked by the map,
-or the map is empty. */
+@return true if the key update was successful. Error is returned if bad
+arguments are provided or it can be deduced that key_val_handle is not a member
+of the container. */
 [[nodiscard]] ccc_tribool ccc_omm_update(ccc_ordered_multimap *mm,
                                          ccc_ommap_elem *key_val_handle,
                                          ccc_update_fn *fn, void *aux);
@@ -515,9 +518,9 @@ user type that the user knows is currently in the map.
 @param [in] fn the function used to increase an element key in the map.
 @param [in] aux any auxiliary data needed for the key increase. Usually a new
 value but NULL is possible if aux is not needed.
-@return true if the key increase was successful, false if bad arguments are
-provided, it is possible to prove the key_val_handle is not tracked by the map,
-or the map is empty. */
+@return true if the key increase was successful. Error is returned if bad
+arguments are provided or it can be deduced that key_val_handle is not a member
+of the container. */
 [[nodiscard]] ccc_tribool ccc_omm_increase(ccc_ordered_multimap *mm,
                                            ccc_ommap_elem *key_val_handle,
                                            ccc_update_fn *fn, void *aux);
@@ -530,9 +533,9 @@ user type that the user knows is currently in the map.
 @param [in] fn the function used to decrease an element key in the map.
 @param [in] aux any auxiliary data needed for the key decrease. Usually a new
 value but NULL is possible if aux is not needed.
-@return true if the key decrease was successful, false if bad arguments are
-provided, it is possible to prove the key_val_handle is not tracked by the map,
-or the map is empty. */
+@return true if the key decrease was successful. Error is returned if bad
+arguments are provided or it can be deduced that key_val_handle is not a member
+of the container. */
 [[nodiscard]] ccc_tribool ccc_omm_decrease(ccc_ordered_multimap *mm,
                                            ccc_ommap_elem *key_val_handle,
                                            ccc_update_fn *fn, void *aux);
@@ -711,7 +714,7 @@ Obtain the container state. */
 
 /** @brief Returns true if the multimap is empty. O(1).
 @param [in] mm a pointer to the multimap.
-@return true if empty, false if mm is NULL or mm is empty. */
+@return true if empty, false if mm is not empty. Error if mm is NULL. */
 [[nodiscard]] ccc_tribool ccc_omm_is_empty(ccc_ordered_multimap const *mm);
 
 /** @brief Returns true if the multimap is empty. O(1).
@@ -721,7 +724,8 @@ Obtain the container state. */
 
 /** @brief Returns true if the multimap is empty.
 @param [in] mm a pointer to the multimap.
-@return true if invariants of the data structure are preserved, else false. */
+@return true if invariants of the data structure are preserved, else false.
+Error if mm is NULL. */
 [[nodiscard]] ccc_tribool ccc_omm_validate(ccc_ordered_multimap const *mm);
 
 /**@}*/

--- a/ccc/priority_queue.h
+++ b/ccc/priority_queue.h
@@ -19,7 +19,6 @@ All types and functions can then be written without the `ccc_` prefix. */
 #define CCC_PRIORITY_QUEUE_H
 
 /** @cond */
-#include <stdbool.h>
 #include <stddef.h>
 /** @endcond */
 
@@ -133,8 +132,8 @@ function can deduce elem is not in the pq.
 Note that this operation may incur unnecessary overhead if the user can't
 deduce if an increase or decrease is occurring. See the increase and decrease
 operations. O(1) best case, O(lgN) worst case. */
-bool ccc_pq_update(ccc_priority_queue *pq, ccc_pq_elem *elem, ccc_update_fn *fn,
-                   void *aux);
+ccc_tribool ccc_pq_update(ccc_priority_queue *pq, ccc_pq_elem *elem,
+                          ccc_update_fn *fn, void *aux);
 
 /** @brief Update the priority in the user type stored in the container.
 @param [in] pq_ptr a pointer to the priority queue.
@@ -182,8 +181,8 @@ value. If this is a max heap O(1), otherwise O(lgN).
 
 While the best case operation is O(1) the impact of restructuring on future pops
 from the pq creates an amortized o(lgN) runtime for this function. */
-bool ccc_pq_increase(ccc_priority_queue *pq, ccc_pq_elem *elem,
-                     ccc_update_fn *fn, void *aux);
+ccc_tribool ccc_pq_increase(ccc_priority_queue *pq, ccc_pq_elem *elem,
+                            ccc_update_fn *fn, void *aux);
 
 /** @brief Increases the priority of the user type stored in the container.
 @param [in] pq_ptr a pointer to the priority queue.
@@ -234,8 +233,8 @@ value. If this is a min heap O(1), otherwise O(lgN).
 
 While the best case operation is O(1) the impact of restructuring on future pops
 from the pq creates an amortized o(lgN) runtime for this function. */
-bool ccc_pq_decrease(ccc_priority_queue *pq, ccc_pq_elem *elem,
-                     ccc_update_fn *fn, void *aux);
+ccc_tribool ccc_pq_decrease(ccc_priority_queue *pq, ccc_pq_elem *elem,
+                            ccc_update_fn *fn, void *aux);
 
 /** @brief Decreases the priority of the user type stored in the container.
 @param [in] pq_ptr a pointer to the priority queue.
@@ -306,7 +305,7 @@ Obtain state from the container. */
 /** @brief Returns true if the priority queue is empty false if not. O(1).
 @param [in] pq a pointer to the priority queue.
 @return true if the size is 0 or pq is NULL, false if not empty.  */
-[[nodiscard]] bool ccc_pq_is_empty(ccc_priority_queue const *pq);
+[[nodiscard]] ccc_tribool ccc_pq_is_empty(ccc_priority_queue const *pq);
 
 /** @brief Returns the size of the priority queue.
 @param [in] pq a pointer to the priority queue.
@@ -316,7 +315,7 @@ Obtain state from the container. */
 /** @brief Verifies the internal invariants of the pq hold.
 @param [in] pq a pointer to the priority queue.
 @return true if the pq is valid false if pq is NULL or invalid. */
-[[nodiscard]] bool ccc_pq_validate(ccc_priority_queue const *pq);
+[[nodiscard]] ccc_tribool ccc_pq_validate(ccc_priority_queue const *pq);
 
 /** @brief Return the order used to initialize the pq.
 @param [in] pq a pointer to the priority queue.

--- a/ccc/priority_queue.h
+++ b/ccc/priority_queue.h
@@ -125,7 +125,7 @@ ccc_result ccc_pq_erase(ccc_priority_queue *pq, ccc_pq_elem *elem);
 @param [in] elem a pointer to the intrusive element in the user type.
 @param [in] fn the update function to act on the type wrapping elem.
 @param [in] aux any auxiliary data needed for the update function.
-@return true if the update occurred false if parameters were invalid or the
+@return true if the update occurred. Error if parameters were invalid or the
 function can deduce elem is not in the pq.
 @warning the user must ensure elem is in the pq.
 
@@ -142,7 +142,7 @@ ccc_tribool ccc_pq_update(ccc_priority_queue *pq, ccc_pq_elem *elem,
 on the user type which wraps pq_elem_ptr (optionally wrapping {code here} in
 braces may help with formatting). This closure may safely modify the key used to
 track the user element's priority in the priority queue.
-@return true if the update occurred false if parameters were invalid or the
+@return true if the update occurred. Error if parameters were invalid or the
 function can deduce elem is not in the pq.
 @warning the user must ensure elem is in the pq and pq_elem_ptr points to the
 intrusive element in the same user type that is being updated.
@@ -170,7 +170,7 @@ operations. O(1) best case, O(lgN) worst case. */
 @param [in] elem a pointer to the intrusive element in the user type.
 @param [in] fn the update function to act on the type wrapping elem.
 @param [in] aux any auxiliary data needed for the update function.
-@return true if the increase occurred false if parameters were invalid or the
+@return true if the increase occurred. Error if parameters were invalid or the
 function can deduce elem is not in the pq.
 @warning the data structure will be in an invalid state if the user decreases
 the priority by mistake in this function.
@@ -191,7 +191,7 @@ ccc_tribool ccc_pq_increase(ccc_priority_queue *pq, ccc_pq_elem *elem,
 execute on the user type which wraps pq_elem_ptr (optionally wrapping {code
 here} in braces may help with formatting). This closure may safely increase the
 key used to track the user element's priority in the priority queue.
-@return true if the increase occurred false if parameters were invalid or the
+@return true if the increase occurred. Error if parameters were invalid or the
 function can deduce elem is not in the pq.
 @warning the user must ensure elem is in the pq and pq_elem_ptr points to the
 intrusive element in the same user type that is being increased. The data
@@ -224,7 +224,7 @@ from the pq creates an amortized o(lgN) runtime for this function. */
 @param [in] elem a pointer to the intrusive element in the user type.
 @param [in] fn the update function to act on the type wrapping elem.
 @param [in] aux any auxiliary data needed for the update function.
-@return true if the decrease occurred false if parameters were invalid or the
+@return true if the decrease occurred. Error if parameters were invalid or the
 function can deduce elem is not in the pq.
 
 Note that this is optimal update technique if the priority queue has been
@@ -243,7 +243,7 @@ ccc_tribool ccc_pq_decrease(ccc_priority_queue *pq, ccc_pq_elem *elem,
 execute on the user type which wraps pq_elem_ptr (optionally wrapping {code
 here} in braces may help with formatting). This closure may safely decrease the
 key used to track the user element's priority in the priority queue.
-@return true if the decrease occurred false if parameters were invalid or the
+@return true if the decrease occurred. Error if parameters were invalid or the
 function can deduce elem is not in the pq.
 @warning the user must ensure elem is in the pq and pq_elem_ptr points to the
 intrusive element in the same user type that is being decreased. The data
@@ -304,7 +304,7 @@ Obtain state from the container. */
 
 /** @brief Returns true if the priority queue is empty false if not. O(1).
 @param [in] pq a pointer to the priority queue.
-@return true if the size is 0 or pq is NULL, false if not empty.  */
+@return true if the size is 0, false if not empty. Error if pq is NULL. */
 [[nodiscard]] ccc_tribool ccc_pq_is_empty(ccc_priority_queue const *pq);
 
 /** @brief Returns the size of the priority queue.
@@ -314,7 +314,7 @@ Obtain state from the container. */
 
 /** @brief Verifies the internal invariants of the pq hold.
 @param [in] pq a pointer to the priority queue.
-@return true if the pq is valid false if pq is NULL or invalid. */
+@return true if the pq is valid false if pq is invalid. Error if pq is NULL. */
 [[nodiscard]] ccc_tribool ccc_pq_validate(ccc_priority_queue const *pq);
 
 /** @brief Return the order used to initialize the pq.

--- a/ccc/realtime_ordered_map.h
+++ b/ccc/realtime_ordered_map.h
@@ -85,8 +85,8 @@ Test membership or obtain references to stored user types directly. */
 @param [in] rom the map to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
 @return true if the struct containing key is stored, false if not. */
-[[nodiscard]] bool ccc_rom_contains(ccc_realtime_ordered_map const *rom,
-                                    void const *key);
+[[nodiscard]] ccc_tribool ccc_rom_contains(ccc_realtime_ordered_map const *rom,
+                                           void const *key);
 
 /** @brief Returns a reference into the map at entry key.
 @param [in] rom the ordered map to search.
@@ -431,13 +431,13 @@ free or use as needed. */
 /** @brief Returns the Vacant or Occupied status of the entry.
 @param [in] e the entry from a query to the map via function or macro.
 @return true if the entry is occupied, false if not. */
-[[nodiscard]] bool ccc_rom_insert_error(ccc_romap_entry const *e);
+[[nodiscard]] ccc_tribool ccc_rom_insert_error(ccc_romap_entry const *e);
 
 /** @brief Provides the status of the entry should an insertion follow.
 @param [in] e the entry from a query to the table via function or macro.
 @return true if an entry obtained from an insertion attempt failed to insert
 due to an allocation failure when allocation success was expected. */
-[[nodiscard]] bool ccc_rom_occupied(ccc_romap_entry const *e);
+[[nodiscard]] ccc_tribool ccc_rom_occupied(ccc_romap_entry const *e);
 
 /** @brief Obtain the entry status from a container entry.
 @param [in] e a pointer to the entry.
@@ -608,12 +608,12 @@ Obtain the container state. */
 /** @brief Returns the size status of the map.
 @param [in] rom the map.
 @return true if empty else false. */
-[[nodiscard]] bool ccc_rom_is_empty(ccc_realtime_ordered_map const *rom);
+[[nodiscard]] ccc_tribool ccc_rom_is_empty(ccc_realtime_ordered_map const *rom);
 
 /** @brief Validation of invariants for the map.
 @param [in] rom the map to validate.
 @return true if all invariants hold, false if corruption occurs. */
-[[nodiscard]] bool ccc_rom_validate(ccc_realtime_ordered_map const *rom);
+[[nodiscard]] ccc_tribool ccc_rom_validate(ccc_realtime_ordered_map const *rom);
 
 /**@}*/
 

--- a/ccc/realtime_ordered_map.h
+++ b/ccc/realtime_ordered_map.h
@@ -84,7 +84,8 @@ Test membership or obtain references to stored user types directly. */
 /** @brief Searches the map for the presence of key.
 @param [in] rom the map to be searched.
 @param [in] key pointer to the key matching the key type of the user struct.
-@return true if the struct containing key is stored, false if not. */
+@return true if the struct containing key is stored, false if not. Error if rom
+or key is NULL.*/
 [[nodiscard]] ccc_tribool ccc_rom_contains(ccc_realtime_ordered_map const *rom,
                                            void const *key);
 
@@ -430,13 +431,14 @@ free or use as needed. */
 
 /** @brief Returns the Vacant or Occupied status of the entry.
 @param [in] e the entry from a query to the map via function or macro.
-@return true if the entry is occupied, false if not. */
+@return true if the entry is occupied, false if not. Error if e is NULL. */
 [[nodiscard]] ccc_tribool ccc_rom_insert_error(ccc_romap_entry const *e);
 
 /** @brief Provides the status of the entry should an insertion follow.
 @param [in] e the entry from a query to the table via function or macro.
 @return true if an entry obtained from an insertion attempt failed to insert
-due to an allocation failure when allocation success was expected. */
+due to an allocation failure when allocation success was expected. Error if e is
+NULL. */
 [[nodiscard]] ccc_tribool ccc_rom_occupied(ccc_romap_entry const *e);
 
 /** @brief Obtain the entry status from a container entry.
@@ -607,12 +609,13 @@ Obtain the container state. */
 
 /** @brief Returns the size status of the map.
 @param [in] rom the map.
-@return true if empty else false. */
+@return true if empty else false. Error if rom is NULL. */
 [[nodiscard]] ccc_tribool ccc_rom_is_empty(ccc_realtime_ordered_map const *rom);
 
 /** @brief Validation of invariants for the map.
 @param [in] rom the map to validate.
-@return true if all invariants hold, false if corruption occurs. */
+@return true if all invariants hold, false if corruption occurs. Error if rom is
+NULL. */
 [[nodiscard]] ccc_tribool ccc_rom_validate(ccc_realtime_ordered_map const *rom);
 
 /**@}*/

--- a/ccc/singly_linked_list.h
+++ b/ccc/singly_linked_list.h
@@ -274,13 +274,13 @@ ccc_sll_begin_sentinel(ccc_singly_linked_list const *sll);
 
 /** @brief Return true if the list is empty. O(1).
 @param [in] sll a pointer to the singly linked list.
-@return true if the size is 0 or sll is NULL otherwise false. */
-[[nodiscard]] bool ccc_sll_is_empty(ccc_singly_linked_list const *sll);
+@return true if size is 0 otherwise false. Error returned if sll is NULL. */
+[[nodiscard]] ccc_tribool ccc_sll_is_empty(ccc_singly_linked_list const *sll);
 
 /** @brief Returns true if the invariants of the list hold.
 @param [in] sll a pointer to the singly linked list.
-@return true if the list is valid, else false. */
-[[nodiscard]] bool ccc_sll_validate(ccc_singly_linked_list const *sll);
+@return true if list is valid, else false. Error returned if sll is NULL. */
+[[nodiscard]] ccc_tribool ccc_sll_validate(ccc_singly_linked_list const *sll);
 
 /**@}*/
 

--- a/ccc/types.h
+++ b/ccc/types.h
@@ -10,7 +10,6 @@ the allocation function interface. */
 #define CCC_TYPES_H
 
 /** @cond */
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 /** @endcond */
@@ -285,9 +284,11 @@ typedef void ccc_destructor_fn(ccc_user_type);
 
 /** @brief A callback function to determining equality between two stored keys.
 
-The function should return true if the key and key field in the user type are
-equivalent, else false. */
-typedef bool ccc_key_eq_fn(ccc_key_cmp);
+The function should return CCC_TRUE if the key and key field in the user type
+are equivalent, else CCC_FALSE.
+@note a callback need not return CCC_BOOL_ERR as the container code always
+provides data to the arguments of the function invariantly. */
+typedef ccc_tribool ccc_key_eq_fn(ccc_key_cmp);
 
 /** @brief A callback function for three-way comparing two stored keys.
 
@@ -310,23 +311,23 @@ The generic interface for associative container entries. */
 
 /** @brief Determine if an entry is Occupied in the container.
 @param [in] e the pointer to the entry obtained from a container.
-@return true if Occupied false if Vacant. */
-bool ccc_entry_occupied(ccc_entry const *e);
+@return true if Occupied false if Vacant. Error if e is NULL. */
+ccc_tribool ccc_entry_occupied(ccc_entry const *e);
 
 /** @brief Determine if an insertion error has occurred when a function that
 attempts to insert a value in a container is used.
 @param [in] e the pointer to the entry obtained from a container insert.
 @return true if an insertion error occurred usually meaning a insertion should
 have occurred but the container did not have permission to allocate new memory
-or allocation failed. */
-bool ccc_entry_insert_error(ccc_entry const *e);
+or allocation failed. Error if e is NULL. */
+ccc_tribool ccc_entry_insert_error(ccc_entry const *e);
 
 /** @brief Determine if an input error has occurred for a function that
 generates an entry.
 @param [in] e the pointer to the entry obtained from a container function.
 @return true if an input error occurred usually meaning an invalid argument such
-as a NULL pointer was provided to a function. */
-bool ccc_entry_input_error(ccc_entry const *e);
+as a NULL pointer was provided to a function. Error if e is NULL. */
+ccc_tribool ccc_entry_input_error(ccc_entry const *e);
 
 /** @brief Unwraps the provided entry providing a reference to the user type
 obtained from the operation that provides the entry.
@@ -342,23 +343,23 @@ void *ccc_entry_unwrap(ccc_entry const *e);
 
 /** @brief Determine if an handle is Occupied in the container.
 @param [in] e the pointer to the handle obtained from a container.
-@return true if Occupied false if Vacant. */
-bool ccc_handle_occupied(ccc_handle const *e);
+@return true if Occupied false if Vacant. Error if e is NULL. */
+ccc_tribool ccc_handle_occupied(ccc_handle const *e);
 
 /** @brief Determine if an insertion error has occurred when a function that
 attempts to insert a value in a container is used.
 @param [in] e the pointer to the handle obtained from a container insert.
 @return true if an insertion error occurred usually meaning a insertion should
 have occurred but the container did not have permission to allocate new memory
-or allocation failed. */
-bool ccc_handle_insert_error(ccc_handle const *e);
+or allocation failed. Error if e is NULL. */
+ccc_tribool ccc_handle_insert_error(ccc_handle const *e);
 
 /** @brief Determine if an input error has occurred for a function that
 generates an handle.
 @param [in] e the pointer to the handle obtained from a container function.
 @return true if an input error occurred usually meaning an invalid argument such
-as a NULL pointer was provided to a function. */
-bool ccc_handle_input_error(ccc_handle const *e);
+as a NULL pointer was provided to a function. Error if e is NULL. */
+ccc_tribool ccc_handle_input_error(ccc_handle const *e);
 
 /** @brief Unwraps the provided handle providing a reference to the user type
 obtained from the operation that provides the handle.

--- a/samples/graph.c
+++ b/samples/graph.c
@@ -284,7 +284,7 @@ static struct path_request parse_path_request(struct graph *, str_view);
 static void help(void);
 
 static threeway_cmp cmp_pq_costs(cmp);
-static bool eq_parent_cells(key_cmp);
+static ccc_tribool eq_parent_cells(key_cmp);
 static uint64_t hash_parent_cells(user_key point_struct);
 static uint64_t hash_64_bits(uint64_t);
 
@@ -1040,7 +1040,7 @@ build_path_outline(struct graph *graph)
 
 /*====================    Data Structure Helpers    =========================*/
 
-static bool
+static ccc_tribool
 eq_parent_cells(key_cmp const c)
 {
     struct path_backtrack_cell const *const pc = c.user_type_rhs;

--- a/samples/maze.c
+++ b/samples/maze.c
@@ -139,7 +139,7 @@ static void help(void);
 static struct point rand_point(struct maze const *);
 static threeway_cmp cmp_priority_cells(cmp);
 static struct int_conversion parse_digits(str_view);
-static bool prim_cell_eq(key_cmp);
+static ccc_tribool prim_cell_eq(key_cmp);
 static uint64_t point_hash_fn(user_key);
 static uint64_t hash_64_bits(uint64_t);
 
@@ -298,7 +298,7 @@ animate_maze(struct maze *maze)
 
 /*===================     Container Support Code     ========================*/
 
-static bool
+static ccc_tribool
 prim_cell_eq(key_cmp const c)
 {
     struct point const *const lhs = c.key_lhs;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1,4 +1,3 @@
-#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -205,16 +204,28 @@ ccc_buf_elem_size(ccc_buffer const *const buf)
     return buf ? buf->elem_sz_ : 0;
 }
 
-bool
-ccc_buf_full(ccc_buffer const *const buf)
-{
-    return buf ? buf->sz_ == buf->capacity_ : false;
-}
-
-bool
+ccc_tribool
 ccc_buf_is_empty(ccc_buffer const *const buf)
 {
-    return buf ? !buf->sz_ : true;
+    if (!buf)
+    {
+        return CCC_BOOL_ERR;
+    }
+    return !buf->sz_;
+}
+
+ccc_tribool
+ccc_buf_is_full(ccc_buffer const *const buf)
+{
+    if (!buf)
+    {
+        return CCC_BOOL_ERR;
+    }
+    if (!buf->capacity_)
+    {
+        return CCC_FALSE;
+    }
+    return buf->sz_ == buf->capacity_ ? CCC_TRUE : CCC_FALSE;
 }
 
 void *

--- a/src/doubly_linked_list.c
+++ b/src/doubly_linked_list.c
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -375,10 +374,10 @@ ccc_dll_size(ccc_doubly_linked_list const *const l)
     return l ? l->sz_ : 0;
 }
 
-bool
+ccc_tribool
 ccc_dll_is_empty(ccc_doubly_linked_list const *const l)
 {
-    return l ? !l->sz_ : true;
+    return l ? !l->sz_ : CCC_TRUE;
 }
 
 ccc_result
@@ -403,12 +402,12 @@ ccc_dll_clear(ccc_doubly_linked_list *const l, ccc_destructor_fn *fn)
     return CCC_OK;
 }
 
-bool
+ccc_tribool
 ccc_dll_validate(ccc_doubly_linked_list const *const l)
 {
     if (!l)
     {
-        return false;
+        return CCC_BOOL_ERR;
     }
     size_t size = 0;
     for (struct ccc_dll_elem_ const *e = l->sentinel_.n_; e != &l->sentinel_;
@@ -416,11 +415,11 @@ ccc_dll_validate(ccc_doubly_linked_list const *const l)
     {
         if (size >= l->sz_)
         {
-            return false;
+            return CCC_FALSE;
         }
         if (!e || !e->n_ || !e->p_ || e->n_ == e || e->p_ == e)
         {
-            return false;
+            return CCC_FALSE;
         }
     }
     return size == l->sz_;

--- a/src/flat_double_ended_queue.c
+++ b/src/flat_double_ended_queue.c
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -159,10 +158,14 @@ ccc_fdeq_back(ccc_flat_double_ended_queue const *const fdeq)
     return ccc_buf_at(&fdeq->buf_, last_elem_index(fdeq));
 }
 
-bool
+ccc_tribool
 ccc_fdeq_is_empty(ccc_flat_double_ended_queue const *const fdeq)
 {
-    return !fdeq || !ccc_buf_size(&fdeq->buf_);
+    if (!fdeq)
+    {
+        return CCC_BOOL_ERR;
+    }
+    return !ccc_buf_size(&fdeq->buf_);
 }
 
 size_t
@@ -356,42 +359,46 @@ ccc_fdeq_clear_and_free(ccc_flat_double_ended_queue *const fdeq,
     return ccc_buf_alloc(&fdeq->buf_, 0, fdeq->buf_.alloc_);
 }
 
-bool
+ccc_tribool
 ccc_fdeq_validate(ccc_flat_double_ended_queue const *const fdeq)
 {
+    if (!fdeq)
+    {
+        return CCC_BOOL_ERR;
+    }
     if (ccc_fdeq_is_empty(fdeq))
     {
-        return true;
+        return CCC_TRUE;
     }
     void *iter = ccc_fdeq_begin(fdeq);
     if (ccc_buf_i(&fdeq->buf_, iter) != (ptrdiff_t)fdeq->front_)
     {
-        return false;
+        return CCC_FALSE;
     }
     size_t size = 0;
     for (; iter != ccc_fdeq_end(fdeq); iter = ccc_fdeq_next(fdeq, iter), ++size)
     {
         if (size >= ccc_fdeq_size(fdeq))
         {
-            return false;
+            return CCC_FALSE;
         }
     }
     if (size != ccc_fdeq_size(fdeq))
     {
-        return false;
+        return CCC_FALSE;
     }
     size = 0;
     iter = ccc_fdeq_rbegin(fdeq);
     if (ccc_buf_i(&fdeq->buf_, iter) != (ptrdiff_t)last_elem_index(fdeq))
     {
-        return false;
+        return CCC_FALSE;
     }
     for (; iter != ccc_fdeq_rend(fdeq);
          iter = ccc_fdeq_rnext(fdeq, iter), ++size)
     {
         if (size >= ccc_fdeq_size(fdeq))
         {
-            return false;
+            return CCC_FALSE;
         }
     }
     return size == ccc_fdeq_size(fdeq);
@@ -416,7 +423,7 @@ ccc_impl_fdeq_alloc_front(struct ccc_fdeq_ *const fdeq)
 static inline void *
 alloc_front(struct ccc_fdeq_ *const fdeq)
 {
-    bool const full = maybe_resize(fdeq, 0) != CCC_OK;
+    ccc_tribool const full = maybe_resize(fdeq, 0) != CCC_OK;
     /* Should have been able to resize. Bad error. */
     if (fdeq->buf_.alloc_ && full)
     {
@@ -434,7 +441,7 @@ alloc_front(struct ccc_fdeq_ *const fdeq)
 static inline void *
 alloc_back(struct ccc_fdeq_ *const fdeq)
 {
-    bool const full = maybe_resize(fdeq, 0) != CCC_OK;
+    ccc_tribool const full = maybe_resize(fdeq, 0) != CCC_OK;
     /* Should have been able to resize. Bad error. */
     if (fdeq->buf_.alloc_ && full)
     {
@@ -457,7 +464,7 @@ static inline ccc_result
 push_back_range(struct ccc_fdeq_ *const fdeq, size_t const n, char const *elems)
 {
     size_t const elem_sz = ccc_buf_elem_size(&fdeq->buf_);
-    bool const full = maybe_resize(fdeq, n) != CCC_OK;
+    ccc_tribool const full = maybe_resize(fdeq, n) != CCC_OK;
     size_t const cap = ccc_buf_capacity(&fdeq->buf_);
     if (fdeq->buf_.alloc_ && full)
     {
@@ -498,7 +505,7 @@ push_front_range(struct ccc_fdeq_ *const fdeq, size_t const n,
                  char const *elems)
 {
     size_t const elem_sz = ccc_buf_elem_size(&fdeq->buf_);
-    bool const full = maybe_resize(fdeq, n) != CCC_OK;
+    ccc_tribool const full = maybe_resize(fdeq, n) != CCC_OK;
     size_t const cap = ccc_buf_capacity(&fdeq->buf_);
     if (fdeq->buf_.alloc_ && full)
     {
@@ -536,7 +543,7 @@ push_range(struct ccc_fdeq_ *const fdeq, char const *const pos, size_t n,
            char const *elems)
 {
     size_t const elem_sz = ccc_buf_elem_size(&fdeq->buf_);
-    bool const full = maybe_resize(fdeq, n) != CCC_OK;
+    ccc_tribool const full = maybe_resize(fdeq, n) != CCC_OK;
     if (fdeq->buf_.alloc_ && full)
     {
         return NULL;

--- a/src/singly_linked_list.c
+++ b/src/singly_linked_list.c
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -263,20 +262,24 @@ ccc_sll_clear(ccc_singly_linked_list *const sll, ccc_destructor_fn *const fn)
     return CCC_OK;
 }
 
-bool
+ccc_tribool
 ccc_sll_validate(ccc_singly_linked_list const *const sll)
 {
+    if (!sll)
+    {
+        return CCC_BOOL_ERR;
+    }
     size_t size = 0;
     for (struct ccc_sll_elem_ *e = sll->sentinel_.n_; e != &sll->sentinel_;
          e = e->n_, ++size)
     {
         if (size >= sll->sz_)
         {
-            return false;
+            return CCC_FALSE;
         }
         if (!e || !e->n_ || e->n_ == e)
         {
-            return false;
+            return CCC_FALSE;
         }
     }
     return size == sll->sz_;
@@ -288,10 +291,14 @@ ccc_sll_size(ccc_singly_linked_list const *const sll)
     return sll ? sll->sz_ : 0;
 }
 
-bool
+ccc_tribool
 ccc_sll_is_empty(ccc_singly_linked_list const *const sll)
 {
-    return sll ? !sll->sz_ : true;
+    if (!sll)
+    {
+        return CCC_BOOL_ERR;
+    }
+    return !sll->sz_;
 }
 
 /*=========================    Private Interface   ==========================*/

--- a/src/types.c
+++ b/src/types.c
@@ -19,22 +19,34 @@ static char const *const result_msgs[CCC_RESULTS_SIZE] = {
 
 /*============================   Interface    ===============================*/
 
-bool
+ccc_tribool
 ccc_entry_occupied(ccc_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_OCCUPIED : false;
+    if (!e)
+    {
+        return CCC_BOOL_ERR;
+    }
+    return (e->impl_.stats_ & CCC_OCCUPIED) != 0;
 }
 
-bool
+ccc_tribool
 ccc_entry_insert_error(ccc_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_INSERT_ERROR : false;
+    if (!e)
+    {
+        return CCC_BOOL_ERR;
+    }
+    return (e->impl_.stats_ & CCC_INSERT_ERROR) != 0;
 }
 
-bool
+ccc_tribool
 ccc_entry_input_error(ccc_entry const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_INPUT_ERROR : false;
+    if (!e)
+    {
+        return CCC_BOOL_ERR;
+    }
+    return (e->impl_.stats_ & CCC_INPUT_ERROR) != 0;
 }
 
 void *
@@ -47,22 +59,34 @@ ccc_entry_unwrap(ccc_entry const *const e)
     return e->impl_.stats_ & CCC_NO_UNWRAP ? NULL : e->impl_.e_;
 }
 
-bool
+ccc_tribool
 ccc_handle_occupied(ccc_handle const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_OCCUPIED : false;
+    if (!e)
+    {
+        return CCC_BOOL_ERR;
+    }
+    return (e->impl_.stats_ & CCC_OCCUPIED) != 0;
 }
 
-bool
+ccc_tribool
 ccc_handle_insert_error(ccc_handle const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_INSERT_ERROR : false;
+    if (!e)
+    {
+        return CCC_BOOL_ERR;
+    }
+    return (e->impl_.stats_ & CCC_INSERT_ERROR) != 0;
 }
 
-bool
+ccc_tribool
 ccc_handle_input_error(ccc_handle const *const e)
 {
-    return e ? e->impl_.stats_ & CCC_INPUT_ERROR : false;
+    if (!e)
+    {
+        return CCC_BOOL_ERR;
+    }
+    return (e->impl_.stats_ & CCC_INPUT_ERROR) != 0;
 }
 
 ccc_handle_i

--- a/tests/fhmap/fhmap_util.c
+++ b/tests/fhmap/fhmap_util.c
@@ -16,7 +16,7 @@ fhmap_int_last_digit(ccc_user_key const n)
     return *((int *)n.user_key) % 10;
 }
 
-bool
+ccc_tribool
 fhmap_id_eq(ccc_key_cmp const cmp)
 {
     struct val const *const va = cmp.user_type_rhs;

--- a/tests/fhmap/fhmap_util.h
+++ b/tests/fhmap/fhmap_util.h
@@ -16,7 +16,7 @@ struct val
 uint64_t fhmap_int_zero(ccc_user_key);
 uint64_t fhmap_int_last_digit(ccc_user_key);
 uint64_t fhmap_int_to_u64(ccc_user_key);
-bool fhmap_id_eq(ccc_key_cmp);
+ccc_tribool fhmap_id_eq(ccc_key_cmp);
 
 void fhmap_modplus(ccc_user_type);
 struct val fhmap_create(int id, int val);

--- a/tests/fhmap/test_fhmap_lru.c
+++ b/tests/fhmap/test_fhmap_lru.c
@@ -70,7 +70,7 @@ static bool const quiet = true;
         }                                                                      \
     } while (0)
 
-static bool
+static ccc_tribool
 lru_lookup_cmp(ccc_key_cmp const cmp)
 {
     struct lru_lookup const *const lookup = cmp.user_type_rhs;

--- a/tests/hhmap/hhmap_util.c
+++ b/tests/hhmap/hhmap_util.c
@@ -1,7 +1,6 @@
 #include "hhmap_util.h"
 #include "types.h"
 
-#include <stdbool.h>
 #include <stdint.h>
 
 uint64_t
@@ -16,7 +15,7 @@ hhmap_int_last_digit(ccc_user_key const n)
     return *((int *)n.user_key) % 10;
 }
 
-bool
+ccc_tribool
 hhmap_id_eq(ccc_key_cmp const cmp)
 {
     struct val const *const va = cmp.user_type_rhs;

--- a/tests/hhmap/hhmap_util.h
+++ b/tests/hhmap/hhmap_util.h
@@ -16,7 +16,7 @@ struct val
 uint64_t hhmap_int_zero(ccc_user_key);
 uint64_t hhmap_int_last_digit(ccc_user_key);
 uint64_t hhmap_int_to_u64(ccc_user_key);
-bool hhmap_id_eq(ccc_key_cmp);
+ccc_tribool hhmap_id_eq(ccc_key_cmp);
 
 void hhmap_modplus(ccc_user_type);
 struct val hhmap_create(int id, int val);

--- a/tests/hhmap/test_hhmap_lru.c
+++ b/tests/hhmap/test_hhmap_lru.c
@@ -63,7 +63,7 @@ static bool const quiet = true;
         }                                                                      \
     } while (0)
 
-static bool
+static ccc_tribool
 lru_elem_cmp(ccc_key_cmp const cmp)
 {
     struct lru_elem const *const lookup = cmp.user_type_rhs;


### PR DESCRIPTION
Convert all interfaces to `ccc_tribool` to provide more appropriate return values. A simple `bool` is insufficient for a 3rd party that must accept arguments from the user. A third state for errors that do not have to do with the true false contract of a function must be allowed.