### PR TITLE
Unused impl fns

### DIFF
--- a/ccc/impl/impl_buffer.h
+++ b/ccc/impl/impl_buffer.h
@@ -8,6 +8,8 @@
 
 #include "../types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 struct ccc_buf_
 {
@@ -19,11 +21,15 @@ struct ccc_buf_
     void *aux_;
 };
 
+/** @private */
 #define IMPL_BUF_NON_IMPL_BUF_DEFAULT_SIZE(...) __VA_ARGS__
+/** @private */
 #define IMPL_BUF_DEFAULT_SIZE(...) 0
+/** @private */
 #define IMPL_BUF_OPTIONAL_SIZE(...)                                            \
     __VA_OPT__(IMPL_BUF_NON_)##IMPL_BUF_DEFAULT_SIZE(__VA_ARGS__)
 
+/** @private */
 #define ccc_impl_buf_init(mem, alloc_fn, aux_data, capacity, ...)              \
     {                                                                          \
         .mem_ = (mem),                                                         \
@@ -34,8 +40,7 @@ struct ccc_buf_
         .aux_ = (aux_data),                                                    \
     }
 
-/* NOLINTBEGIN(readability-identifier-naming) */
-
+/** @private */
 #define ccc_impl_buf_emplace(ccc_buf_ptr, index, type_initializer...)          \
     (__extension__({                                                           \
         typeof(type_initializer) *buf_res_ = NULL;                             \
@@ -51,6 +56,7 @@ struct ccc_buf_
         buf_res_;                                                              \
     }))
 
+/** @private */
 #define ccc_impl_buf_emplace_back(ccc_buf_ptr, type_initializer...)            \
     (__extension__({                                                           \
         typeof(type_initializer) *buf_res_ = NULL;                             \

--- a/ccc/impl/impl_doubly_linked_list.h
+++ b/ccc/impl/impl_doubly_linked_list.h
@@ -8,6 +8,8 @@
 
 #include "../types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 typedef struct ccc_dll_elem_
 {
@@ -27,11 +29,19 @@ struct ccc_dll_
     void *aux_;
 };
 
+/*=======================     Private Interface   ===========================*/
+
+/** @private */
 void ccc_impl_dll_push_back(struct ccc_dll_ *, struct ccc_dll_elem_ *);
+/** @private */
 void ccc_impl_dll_push_front(struct ccc_dll_ *, struct ccc_dll_elem_ *);
+/** @private */
 struct ccc_dll_elem_ *ccc_impl_dll_elem_in(struct ccc_dll_ const *,
                                            void const *user_struct);
 
+/*=======================     Macro Implementations   =======================*/
+
+/** @private */
 #define ccc_impl_dll_init(dll_name, struct_name, dll_elem_field, cmp_fn,       \
                           alloc_fn, aux_data)                                  \
     {                                                                          \
@@ -45,8 +55,7 @@ struct ccc_dll_elem_ *ccc_impl_dll_elem_in(struct ccc_dll_ const *,
         .aux_ = (aux_data),                                                    \
     }
 
-/* NOLINTBEGIN(readability-identifier-naming) */
-
+/** @private */
 #define ccc_impl_dll_emplace_back(dll_ptr, struct_initializer...)              \
     (__extension__({                                                           \
         typeof(struct_initializer) *dll_res_ = NULL;                           \
@@ -67,6 +76,7 @@ struct ccc_dll_elem_ *ccc_impl_dll_elem_in(struct ccc_dll_ const *,
         dll_res_;                                                              \
     }))
 
+/** @private */
 #define ccc_impl_dll_emplace_front(dll_ptr, struct_initializer...)             \
     (__extension__({                                                           \
         typeof(struct_initializer) *dll_res_;                                  \

--- a/ccc/impl/impl_flat_double_ended_queue.h
+++ b/ccc/impl/impl_flat_double_ended_queue.h
@@ -7,6 +7,8 @@
 
 #include "../buffer.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 struct ccc_fdeq_
 {
@@ -14,9 +16,15 @@ struct ccc_fdeq_
     size_t front_;
 };
 
+/*=======================    Private Interface   ============================*/
+/** @private */
 void *ccc_impl_fdeq_alloc_front(struct ccc_fdeq_ *);
+/** @private */
 void *ccc_impl_fdeq_alloc_back(struct ccc_fdeq_ *);
 
+/*=======================  Macro Implementations   ==========================*/
+
+/** @private */
 #define ccc_impl_fdeq_init(mem_ptr, alloc_fn, aux_data, capacity,              \
                            optional_size...)                                   \
     {                                                                          \
@@ -25,8 +33,7 @@ void *ccc_impl_fdeq_alloc_back(struct ccc_fdeq_ *);
         .front_ = 0,                                                           \
     }
 
-/* NOLINTBEGIN(readability-identifier-naming) */
-
+/** @private */
 #define ccc_impl_fdeq_emplace_back(fdeq_ptr, value...)                         \
     (__extension__({                                                           \
         __auto_type fdeq_ptr_ = (fdeq_ptr);                                    \
@@ -43,6 +50,7 @@ void *ccc_impl_fdeq_alloc_back(struct ccc_fdeq_ *);
         fdeq_emplace_ret_;                                                     \
     }))
 
+/** @private */
 #define ccc_impl_fdeq_emplace_front(fdeq_ptr, value...)                        \
     (__extension__({                                                           \
         __auto_type fdeq_ptr_ = (fdeq_ptr);                                    \

--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -50,20 +50,7 @@ union ccc_fhmap_entry_
     struct ccc_fhash_entry_ impl_;
 };
 
-/** @private */
-#define ccc_impl_fhm_init(memory_ptr, fhash_elem_field, key_field, hash_fn,    \
-                          key_eq_fn, alloc_fn, aux, capacity)                  \
-    {                                                                          \
-        .buf_                                                                  \
-        = (ccc_buffer)ccc_buf_init((memory_ptr), (alloc_fn), (aux), capacity), \
-        .hash_fn_ = (hash_fn),                                                 \
-        .eq_fn_ = (key_eq_fn),                                                 \
-        .key_offset_ = offsetof(typeof(*(memory_ptr)), key_field),             \
-        .hash_elem_offset_                                                     \
-        = offsetof(typeof(*(memory_ptr)), fhash_elem_field),                   \
-    }
-
-/*===============   Wrappers for Macros to Access Internals     =============*/
+/*======================    Private Interface    ============================*/
 
 /** @private */
 void ccc_impl_fhm_insert(struct ccc_fhmap_ *h, void const *e, uint64_t hash,
@@ -81,7 +68,20 @@ uint64_t *ccc_impl_fhm_hash_at(struct ccc_fhmap_ const *h, size_t i);
 /** @private */
 size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
 
-/*==================   Helper Macros for Repeated Logic     =================*/
+/*=====================   Macro Implementations     =========================*/
+
+/** @private */
+#define ccc_impl_fhm_init(memory_ptr, fhash_elem_field, key_field, hash_fn,    \
+                          key_eq_fn, alloc_fn, aux, capacity)                  \
+    {                                                                          \
+        .buf_                                                                  \
+        = (ccc_buffer)ccc_buf_init((memory_ptr), (alloc_fn), (aux), capacity), \
+        .hash_fn_ = (hash_fn),                                                 \
+        .eq_fn_ = (key_eq_fn),                                                 \
+        .key_offset_ = offsetof(typeof(*(memory_ptr)), key_field),             \
+        .hash_elem_offset_                                                     \
+        = offsetof(typeof(*(memory_ptr)), fhash_elem_field),                   \
+    }
 
 /** @private Internal helper assumes that swap_entry has already been evaluated
 once which it must have to make it to this point. */

--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -12,6 +12,8 @@
 #include "../types.h"
 #include "impl_types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 enum : uint64_t
 {
@@ -60,26 +62,23 @@ union ccc_fhmap_entry_
         = offsetof(typeof(*(memory_ptr)), fhash_elem_field),                   \
     }
 
-struct ccc_ent_ ccc_impl_fhm_find(struct ccc_fhmap_ const *, void const *key,
-                                  uint64_t hash);
+/*===============   Wrappers for Macros to Access Internals     =============*/
+
+/** @private */
 void ccc_impl_fhm_insert(struct ccc_fhmap_ *h, void const *e, uint64_t hash,
                          size_t cur_i);
-
+/** @private */
 struct ccc_fhash_entry_ ccc_impl_fhm_entry(struct ccc_fhmap_ *h,
                                            void const *key);
-struct ccc_fhash_entry_ *ccc_impl_fhm_and_modify(struct ccc_fhash_entry_ *e,
-                                                 ccc_update_fn *fn);
+/** @private */
 struct ccc_fhmap_elem_ *ccc_impl_fhm_in_slot(struct ccc_fhmap_ const *h,
                                              void const *slot);
+/** @private */
 void *ccc_impl_fhm_key_in_slot(struct ccc_fhmap_ const *h, void const *slot);
+/** @private */
 uint64_t *ccc_impl_fhm_hash_at(struct ccc_fhmap_ const *h, size_t i);
-size_t ccc_impl_fhm_distance(size_t capacity, size_t i, size_t j);
-ccc_result ccc_impl_fhm_maybe_resize(struct ccc_fhmap_ *);
-uint64_t ccc_impl_fhm_filter(struct ccc_fhmap_ const *, void const *key);
-void *ccc_impl_fhm_base(struct ccc_fhmap_ const *h);
+/** @private */
 size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
-
-/* NOLINTBEGIN(readability-identifier-naming) */
 
 /*==================   Helper Macros for Repeated Logic     =================*/
 

--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -50,6 +50,7 @@ union ccc_fhmap_entry_
     struct ccc_fhash_entry_ impl_;
 };
 
+/** @private */
 #define ccc_impl_fhm_init(memory_ptr, fhash_elem_field, key_field, hash_fn,    \
                           key_eq_fn, alloc_fn, aux, capacity)                  \
     {                                                                          \
@@ -82,8 +83,8 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
 
 /*==================   Helper Macros for Repeated Logic     =================*/
 
-/* Internal helper assumes that swap_entry has already been evaluated once
-   which it must have to make it to this point. */
+/** @private Internal helper assumes that swap_entry has already been evaluated
+once which it must have to make it to this point. */
 #define ccc_impl_fhm_swaps(swap_entry, lazy_key_value...)                      \
     (__extension__({                                                           \
         size_t fhm_i_                                                          \
@@ -119,6 +120,7 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
 
 /*=====================     Core Macro Implementations     ==================*/
 
+/** @private */
 #define ccc_impl_fhm_and_modify_w(flat_hash_map_entry_ptr, type_name,          \
                                   closure_over_T...)                           \
     (__extension__({                                                           \
@@ -140,6 +142,7 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
         fhm_mod_with_ent_;                                                     \
     }))
 
+/** @private */
 #define ccc_impl_fhm_or_insert_w(flat_hash_map_entry_ptr, lazy_key_value...)   \
     (__extension__({                                                           \
         __auto_type fhm_or_ins_ent_ptr_ = (flat_hash_map_entry_ptr);           \
@@ -164,6 +167,7 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
         fhm_or_ins_res_;                                                       \
     }))
 
+/** @private */
 #define ccc_impl_fhm_insert_entry_w(flat_hash_map_entry_ptr,                   \
                                     lazy_key_value...)                         \
     (__extension__({                                                           \
@@ -195,6 +199,7 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
         fhm_res_;                                                              \
     }))
 
+/** @private */
 #define ccc_impl_fhm_try_insert_w(flat_hash_map_ptr, key, lazy_value...)       \
     (__extension__({                                                           \
         struct ccc_fhmap_ *flat_hash_map_ptr_ = (flat_hash_map_ptr);           \
@@ -223,6 +228,7 @@ size_t ccc_impl_fhm_increment(size_t capacity, size_t i);
         fhm_try_insert_res_;                                                   \
     }))
 
+/** @private */
 #define ccc_impl_fhm_insert_or_assign_w(flat_hash_map_ptr, key, lazy_value...) \
     (__extension__({                                                           \
         struct ccc_fhmap_ *flat_hash_map_ptr_ = (flat_hash_map_ptr);           \

--- a/ccc/impl/impl_flat_priority_queue.h
+++ b/ccc/impl/impl_flat_priority_queue.h
@@ -1,6 +1,3 @@
-/* Author: Alexander Lopez
-   File: impl_flat_pqueue.h
-   ------------------------ */
 #ifndef CCC_IMPL_FLAT_PRIORITY_QUEUE_H
 #define CCC_IMPL_FLAT_PRIORITY_QUEUE_H
 
@@ -12,6 +9,8 @@
 #include "../buffer.h"
 #include "../types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 struct ccc_fpq_
 {
@@ -20,14 +19,18 @@ struct ccc_fpq_
     ccc_threeway_cmp order_;
 };
 
+/*========================    Private Interface     =========================*/
+
+/** @private */
 size_t ccc_impl_fpq_bubble_up(struct ccc_fpq_ *, char[], size_t);
+/** @private */
 void ccc_impl_fpq_in_place_heapify(struct ccc_fpq_ *, size_t n);
+/** @private */
 void *ccc_impl_fpq_update_fixup(struct ccc_fpq_ *, void *);
 
-/* NOLINTBEGIN(readability-identifier-naming) */
+/*======================    Macro Implementations    ========================*/
 
-/*=======================    Convenience Macros    ======================== */
-
+/** @private */
 #define ccc_impl_fpq_init(mem_ptr, cmp_order, cmp_fn, alloc_fn, aux_data,      \
                           capacity)                                            \
     {                                                                          \
@@ -36,6 +39,7 @@ void *ccc_impl_fpq_update_fixup(struct ccc_fpq_ *, void *);
         .order_ = (cmp_order),                                                 \
     }
 
+/** @private */
 #define ccc_impl_fpq_heapify_init(mem_ptr, cmp_order, cmp_fn, alloc_fn,        \
                                   aux_data, capacity, size)                    \
     (__extension__({                                                           \
@@ -47,9 +51,9 @@ void *ccc_impl_fpq_update_fixup(struct ccc_fpq_ *, void *);
         fpq_heapify_res_;                                                      \
     }))
 
-/* This macro "returns" a value thanks to clang and gcc statement expressions.
-   See documentation in the flat pqueue header for usage. The ugly details
-   of the macro are hidden here in the impl header. */
+/** @private This macro "returns" a value thanks to clang and gcc statement
+   expressions. See documentation in the flat pqueue header for usage. The ugly
+   details of the macro are hidden here in the impl header. */
 #define ccc_impl_fpq_emplace(fpq, type_initializer...)                         \
     (__extension__({                                                           \
         typeof(type_initializer) *fpq_res_;                                    \
@@ -87,8 +91,8 @@ void *ccc_impl_fpq_update_fixup(struct ccc_fpq_ *, void *);
         fpq_res_;                                                              \
     }))
 
-/* Only one update fn is needed because there is no advantage to updates if
-   it is known they are min/max increase/decrease etc. */
+/** @private Only one update fn is needed because there is no advantage to
+   updates if it is known they are min/max increase/decrease etc. */
 #define ccc_impl_fpq_update_w(fpq_ptr, T_ptr, update_closure_over_T...)        \
     (__extension__({                                                           \
         struct ccc_fpq_ *const fpq_ = (fpq_ptr);                               \
@@ -102,9 +106,11 @@ void *ccc_impl_fpq_update_fixup(struct ccc_fpq_ *, void *);
         fpq_update_res_;                                                       \
     }))
 
+/** @private */
 #define ccc_impl_fpq_increase_w(fpq_ptr, T_ptr, increase_closure_over_T...)    \
     ccc_impl_fpq_update_w(fpq_ptr, T_ptr, increase_closure_over_T)
 
+/** @private */
 #define ccc_impl_fpq_decrease_w(fpq_ptr, T_ptr, decrease_closure_over_T...)    \
     ccc_impl_fpq_update_w(fpq_ptr, T_ptr, decrease_closure_over_T)
 

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -66,6 +66,24 @@ union ccc_hhmap_ref_
     size_t impl_;
 };
 
+/*======================       Private Interface    =========================*/
+
+/** @private */
+ccc_handle_i ccc_impl_hhm_insert_meta(struct ccc_hhmap_ *h, uint64_t hash,
+                                      size_t cur_i);
+/** @private */
+struct ccc_hhash_handle_ ccc_impl_hhm_handle(struct ccc_hhmap_ *h,
+                                             void const *key);
+/** @private */
+void *ccc_impl_hhm_key_at(struct ccc_hhmap_ const *h, size_t i);
+/** @private */
+uint64_t *ccc_impl_hhm_hash_at(struct ccc_hhmap_ const *h, size_t i);
+/** @private */
+struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
+                                             size_t i);
+
+/*======================    Macro Implementations     =======================*/
+
 /** @private */
 #define ccc_impl_hhm_init(memory_ptr, hhash_elem_field, key_field, hash_fn,    \
                           key_eq_fn, alloc_fn, aux, capacity)                  \
@@ -82,24 +100,6 @@ union ccc_hhmap_ref_
 /** @private */
 #define ccc_impl_hhm_as(handle_hash_map_ptr, type_name, handle...)             \
     ((type_name *)ccc_buf_at(&(handle_hash_map_ptr)->buf_, (handle)))
-
-/*===============   Wrappers for Macros to Access Internals     =============*/
-
-/** @private */
-ccc_handle_i ccc_impl_hhm_insert_meta(struct ccc_hhmap_ *h, uint64_t hash,
-                                      size_t cur_i);
-/** @private */
-struct ccc_hhash_handle_ ccc_impl_hhm_handle(struct ccc_hhmap_ *h,
-                                             void const *key);
-/** @private */
-void *ccc_impl_hhm_key_at(struct ccc_hhmap_ const *h, size_t i);
-/** @private */
-uint64_t *ccc_impl_hhm_hash_at(struct ccc_hhmap_ const *h, size_t i);
-/** @private */
-struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
-                                             size_t i);
-
-/*==================   Helper Macros for Repeated Logic     =================*/
 
 /** @private Internal helper assumes that handle has already been evaluated
 once which it must have to make it to this point. */

--- a/ccc/impl/impl_handle_hash_map.h
+++ b/ccc/impl/impl_handle_hash_map.h
@@ -83,26 +83,19 @@ union ccc_hhmap_ref_
 #define ccc_impl_hhm_as(handle_hash_map_ptr, type_name, handle...)             \
     ((type_name *)ccc_buf_at(&(handle_hash_map_ptr)->buf_, (handle)))
 
-struct ccc_handl_ ccc_impl_hhm_find(struct ccc_hhmap_ const *, void const *key,
-                                    uint64_t hash);
+/*===============   Wrappers for Macros to Access Internals     =============*/
+
+/** @private */
 ccc_handle_i ccc_impl_hhm_insert_meta(struct ccc_hhmap_ *h, uint64_t hash,
                                       size_t cur_i);
-
+/** @private */
 struct ccc_hhash_handle_ ccc_impl_hhm_handle(struct ccc_hhmap_ *h,
                                              void const *key);
-struct ccc_hhash_handle_ *ccc_impl_hhm_and_modify(struct ccc_hhash_handle_ *e,
-                                                  ccc_update_fn *fn);
-struct ccc_hhmap_elem_ *ccc_impl_hhm_in_slot(struct ccc_hhmap_ const *h,
-                                             void const *slot);
+/** @private */
 void *ccc_impl_hhm_key_at(struct ccc_hhmap_ const *h, size_t i);
+/** @private */
 uint64_t *ccc_impl_hhm_hash_at(struct ccc_hhmap_ const *h, size_t i);
-size_t ccc_impl_hhm_distance(size_t capacity, size_t i, size_t j);
-ccc_result ccc_impl_hhm_maybe_resize(struct ccc_hhmap_ *);
-uint64_t ccc_impl_hhm_filter(struct ccc_hhmap_ const *, void const *key);
-void *ccc_impl_hhm_base(struct ccc_hhmap_ const *h);
-size_t ccc_impl_hhm_increment(size_t capacity, size_t i);
-void ccc_impl_hhm_copy_to_slot(struct ccc_hhmap_ *h, void *slot_dst,
-                               void const *slot_src);
+/** @private */
 struct ccc_hhmap_elem_ *ccc_impl_hhm_elem_at(struct ccc_hhmap_ const *h,
                                              size_t i);
 

--- a/ccc/impl/impl_handle_ordered_map.h
+++ b/ccc/impl/impl_handle_ordered_map.h
@@ -9,6 +9,8 @@
 #include "../types.h"
 #include "impl_types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private Runs the top down splay tree algorithm with the addition of a free
 list for providing new nodes within the buffer. The parent field normally
 tracks parent when in the tree for iteration purposes. When a node is removed
@@ -53,20 +55,24 @@ union ccc_homap_handle_
     struct ccc_htree_handle_ impl_;
 };
 
+/*===========================   Private Interface ===========================*/
+
+/** @private */
 void ccc_impl_hom_insert(struct ccc_homap_ *hom, size_t elem_i);
+/** @private */
 struct ccc_htree_handle_ ccc_impl_hom_handle(struct ccc_homap_ *hom,
                                              void const *key);
-void *ccc_impl_hom_key_from_node(struct ccc_homap_ const *hom,
-                                 struct ccc_homap_elem_ const *elem);
+/** @private */
 void *ccc_impl_hom_key_at(struct ccc_homap_ const *hom, size_t slot);
+/** @private */
 struct ccc_homap_elem_ *ccc_impl_homap_elem_at(struct ccc_homap_ const *hom,
                                                size_t slot);
+/** @private */
 size_t ccc_impl_hom_alloc_slot(struct ccc_homap_ *hom);
-
-/* NOLINTBEGIN(readability-identifier-naming) */
 
 /*========================     Initialization       =========================*/
 
+/** @private */
 #define ccc_impl_hom_init(mem_ptr, node_elem_field, key_elem_field,            \
                           key_cmp_fn, alloc_fn, aux_data, capacity)            \
     {                                                                          \
@@ -78,11 +84,13 @@ size_t ccc_impl_hom_alloc_slot(struct ccc_homap_ *hom);
         .cmp_ = (key_cmp_fn),                                                  \
     }
 
+/** @private */
 #define ccc_impl_hom_as(handle_ordered_map_ptr, type_name, handle...)          \
     ((type_name *)ccc_buf_at(&(handle_ordered_map_ptr)->buf_, (handle)))
 
 /*==================     Core Macro Implementations     =====================*/
 
+/** @private */
 #define ccc_impl_hom_and_modify_w(handle_ordered_map_handle_ptr, type_name,    \
                                   closure_over_T...)                           \
     (__extension__({                                                           \
@@ -105,6 +113,7 @@ size_t ccc_impl_hom_alloc_slot(struct ccc_homap_ *hom);
         hom_mod_hndl_;                                                         \
     }))
 
+/** @private */
 #define ccc_impl_hom_or_insert_w(handle_ordered_map_handle_ptr,                \
                                  lazy_key_value...)                            \
     (__extension__({                                                           \
@@ -135,6 +144,7 @@ size_t ccc_impl_hom_alloc_slot(struct ccc_homap_ *hom);
         hom_or_ins_ret_;                                                       \
     }))
 
+/** @private */
 #define ccc_impl_hom_insert_handle_w(handle_ordered_map_handle_ptr,            \
                                      lazy_key_value...)                        \
     (__extension__({                                                           \
@@ -174,6 +184,7 @@ size_t ccc_impl_hom_alloc_slot(struct ccc_homap_ *hom);
         hom_ins_hndl_ret_;                                                     \
     }))
 
+/** @private */
 #define ccc_impl_hom_try_insert_w(handle_ordered_map_ptr, key, lazy_value...)  \
     (__extension__({                                                           \
         __auto_type hom_try_ins_map_ptr_ = (handle_ordered_map_ptr);           \
@@ -212,6 +223,7 @@ size_t ccc_impl_hom_alloc_slot(struct ccc_homap_ *hom);
         hom_try_ins_hndl_ret_;                                                 \
     }))
 
+/** @private */
 #define ccc_impl_hom_insert_or_assign_w(handle_ordered_map_ptr, key,           \
                                         lazy_value...)                         \
     (__extension__({                                                           \

--- a/ccc/impl/impl_handle_realtime_ordered_map.h
+++ b/ccc/impl/impl_handle_realtime_ordered_map.h
@@ -10,6 +10,8 @@
 #include "../types.h"
 #include "impl_types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private Runs the standard WAVL tree algorithms with the addition of
 a free list. The parent field tracks the parent for an allocated node in the
 tree that the user has inserted into the array. When the user removes a node
@@ -55,21 +57,25 @@ union ccc_hromap_handle_
     struct ccc_hrtree_handle_ impl_;
 };
 
-void *ccc_impl_hrm_key_from_node(struct ccc_hromap_ const *hrm,
-                                 struct ccc_hromap_elem_ const *elem);
+/*========================  Private Interface  ==============================*/
+
+/** @private */
 void *ccc_impl_hrm_key_at(struct ccc_hromap_ const *hrm, size_t slot);
+/** @private */
 struct ccc_hromap_elem_ *ccc_impl_hrm_elem_at(struct ccc_hromap_ const *hrm,
                                               size_t i);
+/** @private */
 struct ccc_hrtree_handle_ ccc_impl_hrm_handle(struct ccc_hromap_ const *hrm,
                                               void const *key);
+/** @private */
 void ccc_impl_hrm_insert(struct ccc_hromap_ *hrm, size_t parent_i,
                          ccc_threeway_cmp last_cmp, size_t elem_i);
+/** @private */
 size_t ccc_impl_hrm_alloc_slot(struct ccc_hromap_ *hrm);
-
-/* NOLINTBEGIN(readability-identifier-naming) */
 
 /*=========================      Initialization     =========================*/
 
+/** @private */
 #define ccc_impl_hrm_init(memory_ptr, node_elem_field, key_elem_field,         \
                           key_cmp_fn, alloc_fn, aux_data, capacity)            \
     {                                                                          \
@@ -81,12 +87,14 @@ size_t ccc_impl_hrm_alloc_slot(struct ccc_hromap_ *hrm);
         .cmp_ = (key_cmp_fn),                                                  \
     }
 
+/** @private */
 #define ccc_impl_hrm_as(handle_realtime_ordered_map_ptr, type_name, handle...) \
     ((type_name *)ccc_buf_at(&(handle_realtime_ordered_map_ptr)->buf_,         \
                              (handle)))
 
 /*==================     Core Macro Implementations     =====================*/
 
+/** @private */
 #define ccc_impl_hrm_and_modify_w(handle_realtime_ordered_map_handle_ptr,      \
                                   type_name, closure_over_T...)                \
     (__extension__({                                                           \
@@ -109,6 +117,7 @@ size_t ccc_impl_hrm_alloc_slot(struct ccc_hromap_ *hrm);
         hrm_mod_hndl_;                                                         \
     }))
 
+/** @private */
 #define ccc_impl_hrm_or_insert_w(handle_realtime_ordered_map_handle_ptr,       \
                                  lazy_key_value...)                            \
     (__extension__({                                                           \
@@ -141,6 +150,7 @@ size_t ccc_impl_hrm_alloc_slot(struct ccc_hromap_ *hrm);
         hrm_or_ins_ret_;                                                       \
     }))
 
+/** @private */
 #define ccc_impl_hrm_insert_handle_w(handle_realtime_ordered_map_handle_ptr,   \
                                      lazy_key_value...)                        \
     (__extension__({                                                           \
@@ -181,6 +191,7 @@ size_t ccc_impl_hrm_alloc_slot(struct ccc_hromap_ *hrm);
         hrm_ins_hndl_ret_;                                                     \
     }))
 
+/** @private */
 #define ccc_impl_hrm_try_insert_w(handle_realtime_ordered_map_ptr, key,        \
                                   lazy_value...)                               \
     (__extension__({                                                           \
@@ -221,6 +232,7 @@ size_t ccc_impl_hrm_alloc_slot(struct ccc_hromap_ *hrm);
         hrm_try_ins_hndl_ret_;                                                 \
     }))
 
+/** @private */
 #define ccc_impl_hrm_insert_or_assign_w(handle_realtime_ordered_map_ptr, key,  \
                                         lazy_value...)                         \
     (__extension__({                                                           \

--- a/ccc/impl/impl_ordered_map.h
+++ b/ccc/impl/impl_ordered_map.h
@@ -7,6 +7,8 @@
 
 #include "impl_tree.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 union ccc_ordered_map_
 {
@@ -25,23 +27,27 @@ union ccc_omap_entry_
     struct ccc_tree_entry_ impl_;
 };
 
+/** @private */
 #define ccc_impl_om_init(tree_name, struct_name, node_elem_field,              \
                          key_elem_field, key_cmp_fn, alloc_fn, aux_data)       \
     ccc_tree_init(tree_name, struct_name, node_elem_field, key_elem_field,     \
                   key_cmp_fn, alloc_fn, aux_data)
 
+/*==========================  Private Interface  ============================*/
+
+/** @private */
 void *ccc_impl_om_key_in_slot(struct ccc_tree_ const *t, void const *slot);
+/** @private */
 ccc_node_ *ccc_impl_omap_elem_in_slot(struct ccc_tree_ const *t,
                                       void const *slot);
-void *ccc_impl_om_key_from_node(struct ccc_tree_ const *t, ccc_node_ const *n);
-
+/** @private */
 struct ccc_tree_entry_ ccc_impl_om_entry(struct ccc_tree_ *t, void const *key);
+/** @private */
 void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
-
-/* NOLINTBEGIN(readability-identifier-naming) */
 
 /*==================   Helper Macros for Repeated Logic     =================*/
 
+/** @private */
 #define ccc_impl_om_new(ordered_map_entry)                                     \
     (__extension__({                                                           \
         void *om_ins_alloc_ret_ = NULL;                                        \
@@ -55,6 +61,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
         om_ins_alloc_ret_;                                                     \
     }))
 
+/** @private */
 #define ccc_impl_om_insert_key_val(ordered_map_entry, new_mem,                 \
                                    lazy_key_value...)                          \
     (__extension__({                                                           \
@@ -67,6 +74,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
         }                                                                      \
     }))
 
+/** @private */
 #define ccc_impl_om_insert_and_copy_key(om_insert_entry, om_insert_entry_ret,  \
                                         key, lazy_value...)                    \
     (__extension__({                                                           \
@@ -91,6 +99,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
 
 /*=====================     Core Macro Implementations     ==================*/
 
+/** @private */
 #define ccc_impl_om_and_modify_w(ordered_map_entry_ptr, type_name,             \
                                  closure_over_T...)                            \
     (__extension__({                                                           \
@@ -112,6 +121,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
         om_mod_ent_;                                                           \
     }))
 
+/** @private */
 #define ccc_impl_om_or_insert_w(ordered_map_entry_ptr, lazy_key_value...)      \
     (__extension__({                                                           \
         __auto_type or_ins_entry_ptr_ = (ordered_map_entry_ptr);               \
@@ -134,6 +144,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
         or_ins_ret_;                                                           \
     }))
 
+/** @private */
 #define ccc_impl_om_insert_entry_w(ordered_map_entry_ptr, lazy_key_value...)   \
     (__extension__({                                                           \
         __auto_type ins_entry_ptr_ = (ordered_map_entry_ptr);                  \
@@ -162,6 +173,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
         om_ins_ent_ret_;                                                       \
     }))
 
+/** @private */
 #define ccc_impl_om_try_insert_w(ordered_map_ptr, key, lazy_value...)          \
     (__extension__({                                                           \
         __auto_type try_ins_map_ptr_ = (ordered_map_ptr);                      \
@@ -186,6 +198,7 @@ void *ccc_impl_om_insert(struct ccc_tree_ *t, ccc_node_ *n);
         om_try_ins_ent_ret_;                                                   \
     }))
 
+/** @private */
 #define ccc_impl_om_insert_or_assign_w(ordered_map_ptr, key, lazy_value...)    \
     (__extension__({                                                           \
         __auto_type ins_or_assign_map_ptr_ = (ordered_map_ptr);                \

--- a/ccc/impl/impl_ordered_multimap.h
+++ b/ccc/impl/impl_ordered_multimap.h
@@ -7,6 +7,8 @@
 
 #include "impl_tree.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 union ccc_ordered_multimap_
 {
@@ -25,22 +27,29 @@ union ccc_ommap_entry_
     struct ccc_tree_entry_ impl_;
 };
 
+/*==========================  Private Interface  ============================*/
+
+/** @private */
+void *ccc_impl_omm_key_in_slot(struct ccc_tree_ const *t, void const *slot);
+/** @private */
+ccc_node_ *ccc_impl_ommap_elem_in_slot(struct ccc_tree_ const *t,
+                                       void const *slot);
+/** @private */
+struct ccc_tree_entry_ ccc_impl_omm_entry(struct ccc_tree_ *t, void const *key);
+/** @private */
+void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
+
+/*==========================   Initialization  ==============================*/
+
+/** @private */
 #define ccc_impl_omm_init(tree_name, struct_name, node_elem_field,             \
                           key_elem_field, key_cmp_fn, alloc_fn, aux_data)      \
     ccc_tree_init(tree_name, struct_name, node_elem_field, key_elem_field,     \
                   key_cmp_fn, alloc_fn, aux_data)
 
-void *ccc_impl_omm_key_in_slot(struct ccc_tree_ const *t, void const *slot);
-ccc_node_ *ccc_impl_ommap_elem_in_slot(struct ccc_tree_ const *t,
-                                       void const *slot);
-void *ccc_impl_omm_key_from_node(struct ccc_tree_ const *t, ccc_node_ const *n);
-struct ccc_tree_entry_ ccc_impl_omm_entry(struct ccc_tree_ *t, void const *key);
-void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
-
-/* NOLINTBEGIN(readability-identifier-naming) */
-
 /*==================   Helper Macros for Repeated Logic     =================*/
 
+/** @private */
 #define ccc_impl_omm_new(ordered_map_entry)                                    \
     (__extension__({                                                           \
         void *omm_ins_alloc_ret_ = NULL;                                       \
@@ -54,6 +63,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
         omm_ins_alloc_ret_;                                                    \
     }))
 
+/** @private */
 #define ccc_impl_omm_insert_key_val(ordered_map_entry, new_mem,                \
                                     lazy_key_value...)                         \
     (__extension__({                                                           \
@@ -67,6 +77,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
         }                                                                      \
     }))
 
+/** @private */
 #define ccc_impl_omm_insert_and_copy_key(                                      \
     omm_insert_entry, omm_insert_entry_ret, key, lazy_value...)                \
     (__extension__({                                                           \
@@ -91,6 +102,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
 
 /*=====================     Core Macro Implementations     ==================*/
 
+/** @private */
 #define ccc_impl_omm_and_modify_w(ordered_map_entry_ptr, type_name,            \
                                   closure_over_T...)                           \
     (__extension__({                                                           \
@@ -112,6 +124,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
         omm_mod_ent_;                                                          \
     }))
 
+/** @private */
 #define ccc_impl_omm_or_insert_w(ordered_map_entry_ptr, lazy_key_value...)     \
     (__extension__({                                                           \
         __auto_type omm_or_ins_ent_ptr_ = (ordered_map_entry_ptr);             \
@@ -134,6 +147,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
         or_ins_ret_;                                                           \
     }))
 
+/** @private */
 #define ccc_impl_omm_insert_entry_w(ordered_map_entry_ptr, lazy_key_value...)  \
     (__extension__({                                                           \
         __auto_type omm_ins_ent_ptr_ = (ordered_map_entry_ptr);                \
@@ -148,6 +162,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
         omm_ins_ent_ret_;                                                      \
     }))
 
+/** @private */
 #define ccc_impl_omm_try_insert_w(ordered_map_ptr, key, lazy_value...)         \
     (__extension__({                                                           \
         __auto_type omm_try_ins_ptr_ = (ordered_map_ptr);                      \
@@ -172,6 +187,7 @@ void *ccc_impl_omm_multimap_insert(struct ccc_tree_ *t, ccc_node_ *n);
         omm_try_ins_ent_ret_;                                                  \
     }))
 
+/** @private */
 #define ccc_impl_omm_insert_or_assign_w(ordered_map_ptr, key, lazy_value...)   \
     (__extension__({                                                           \
         __auto_type omm_ins_or_assign_ptr_ = (ordered_map_ptr);                \

--- a/ccc/impl/impl_priority_queue.h
+++ b/ccc/impl/impl_priority_queue.h
@@ -7,6 +7,8 @@
 
 #include "../types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 struct ccc_pq_elem_
 {
@@ -29,8 +31,22 @@ struct ccc_pq_
     void *aux_;
 };
 
-/* NOLINTBEGIN(readability-identifier-naming) */
+/*=========================  Private Interface     ==========================*/
 
+/** @private */
+void ccc_impl_pq_push(struct ccc_pq_ *, struct ccc_pq_elem_ *);
+/** @private */
+struct ccc_pq_elem_ *ccc_impl_pq_elem_in(struct ccc_pq_ const *, void const *);
+/** @private */
+void ccc_impl_pq_update_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
+/** @private */
+void ccc_impl_pq_increase_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
+/** @private */
+void ccc_impl_pq_decrease_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
+
+/*=========================  Macro Implementations     ======================*/
+
+/** @private */
 #define ccc_impl_pq_init(struct_name, pq_elem_field, pq_order, cmp_fn,         \
                          alloc_fn, aux_data)                                   \
     {                                                                          \
@@ -44,12 +60,7 @@ struct ccc_pq_
         .aux_ = (aux_data),                                                    \
     }
 
-void ccc_impl_pq_push(struct ccc_pq_ *, struct ccc_pq_elem_ *);
-struct ccc_pq_elem_ *ccc_impl_pq_elem_in(struct ccc_pq_ const *, void const *);
-void ccc_impl_pq_update_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
-void ccc_impl_pq_increase_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
-void ccc_impl_pq_decrease_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
-
+/** @private */
 #define ccc_impl_pq_emplace(pq_ptr, lazy_value...)                             \
     (__extension__({                                                           \
         typeof(lazy_value) *pq_res_ = NULL;                                    \
@@ -74,6 +85,7 @@ void ccc_impl_pq_decrease_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
         pq_res_;                                                               \
     }))
 
+/** @private */
 #define ccc_impl_pq_update_w(pq_ptr, pq_elem_ptr, update_closure_over_T...)    \
     (__extension__({                                                           \
         struct ccc_pq_ *const pq_ = (pq_ptr);                                  \
@@ -89,6 +101,7 @@ void ccc_impl_pq_decrease_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
         pq_update_res_;                                                        \
     }))
 
+/** @private */
 #define ccc_impl_pq_increase_w(pq_ptr, pq_elem_ptr,                            \
                                increase_closure_over_T...)                     \
     (__extension__({                                                           \
@@ -105,6 +118,7 @@ void ccc_impl_pq_decrease_fixup(struct ccc_pq_ *, struct ccc_pq_elem_ *);
         pq_increase_res_;                                                      \
     }))
 
+/** @private */
 #define ccc_impl_pq_decrease_w(pq_ptr, pq_elem_ptr,                            \
                                decrease_closure_over_T...)                     \
     (__extension__({                                                           \

--- a/ccc/impl/impl_realtime_ordered_map.h
+++ b/ccc/impl/impl_realtime_ordered_map.h
@@ -9,6 +9,8 @@
 #include "../types.h"
 #include "impl_types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 typedef struct ccc_romap_elem_
 {
@@ -45,6 +47,25 @@ union ccc_romap_entry_
     struct ccc_rtree_entry_ impl_;
 };
 
+/*=========================   Private Interface  ============================*/
+
+/** @private */
+void *ccc_impl_rom_key_in_slot(struct ccc_romap_ const *rom, void const *slot);
+/** @private */
+struct ccc_romap_elem_ *
+ccc_impl_romap_elem_in_slot(struct ccc_romap_ const *rom, void const *slot);
+/** @private */
+struct ccc_rtree_entry_ ccc_impl_rom_entry(struct ccc_romap_ const *rom,
+                                           void const *key);
+/** @private */
+void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
+                          struct ccc_romap_elem_ *parent,
+                          ccc_threeway_cmp last_cmp,
+                          struct ccc_romap_elem_ *out_handle);
+
+/*==========================   Initialization     ===========================*/
+
+/** @private */
 #define ccc_impl_rom_init(map_name, struct_name, node_elem_field,              \
                           key_elem_field, key_cmp_fn, alloc_fn, aux_data)      \
     {                                                                          \
@@ -61,22 +82,9 @@ union ccc_romap_entry_
         .aux_ = (aux_data),                                                    \
     }
 
-void *ccc_impl_rom_key_from_node(struct ccc_romap_ const *rom,
-                                 struct ccc_romap_elem_ const *elem);
-void *ccc_impl_rom_key_in_slot(struct ccc_romap_ const *rom, void const *slot);
-struct ccc_romap_elem_ *
-ccc_impl_romap_elem_in_slot(struct ccc_romap_ const *rom, void const *slot);
-struct ccc_rtree_entry_ ccc_impl_rom_entry(struct ccc_romap_ const *rom,
-                                           void const *key);
-void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
-                          struct ccc_romap_elem_ *parent,
-                          ccc_threeway_cmp last_cmp,
-                          struct ccc_romap_elem_ *out_handle);
-
-/* NOLINTBEGIN(readability-identifier-naming) */
-
 /*==================   Helper Macros for Repeated Logic     =================*/
 
+/** @private */
 #define ccc_impl_rom_new(realtime_ordered_map_entry)                           \
     (__extension__({                                                           \
         void *rom_ins_alloc_ret_ = NULL;                                       \
@@ -91,6 +99,7 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
         rom_ins_alloc_ret_;                                                    \
     }))
 
+/** @private */
 #define ccc_impl_rom_insert_key_val(realtime_ordered_map_entry, new_mem,       \
                                     lazy_key_value...)                         \
     (__extension__({                                                           \
@@ -108,6 +117,7 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
         }                                                                      \
     }))
 
+/** @private */
 #define ccc_impl_rom_insert_and_copy_key(                                      \
     rom_insert_entry, rom_insert_entry_ret, key, lazy_value...)                \
     (__extension__({                                                           \
@@ -135,6 +145,7 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
 
 /*==================     Core Macro Implementations     =====================*/
 
+/** @private */
 #define ccc_impl_rom_and_modify_w(realtime_ordered_map_entry_ptr, type_name,   \
                                   closure_over_T...)                           \
     (__extension__({                                                           \
@@ -156,6 +167,7 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
         rom_mod_ent_;                                                          \
     }))
 
+/** @private */
 #define ccc_impl_rom_or_insert_w(realtime_ordered_map_entry_ptr,               \
                                  lazy_key_value...)                            \
     (__extension__({                                                           \
@@ -179,6 +191,7 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
         rom_or_ins_ret_;                                                       \
     }))
 
+/** @private */
 #define ccc_impl_rom_insert_entry_w(realtime_ordered_map_entry_ptr,            \
                                     lazy_key_value...)                         \
     (__extension__({                                                           \
@@ -209,6 +222,7 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
         rom_ins_ent_ret_;                                                      \
     }))
 
+/** @private */
 #define ccc_impl_rom_try_insert_w(realtime_ordered_map_ptr, key,               \
                                   lazy_value...)                               \
     (__extension__({                                                           \
@@ -233,6 +247,7 @@ void *ccc_impl_rom_insert(struct ccc_romap_ *rom,
         rom_try_ins_ent_ret_;                                                  \
     }))
 
+/** @private */
 #define ccc_impl_rom_insert_or_assign_w(realtime_ordered_map_ptr, key,         \
                                         lazy_value...)                         \
     (__extension__({                                                           \

--- a/ccc/impl/impl_singly_linked_list.h
+++ b/ccc/impl/impl_singly_linked_list.h
@@ -8,6 +8,8 @@
 
 #include "../types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private */
 typedef struct ccc_sll_elem_
 {
@@ -26,6 +28,14 @@ struct ccc_sll_
     void *aux_;
 };
 
+/*=========================   Private Interface  ============================*/
+
+/** @private */
+void ccc_impl_sll_push_front(struct ccc_sll_ *, struct ccc_sll_elem_ *);
+
+/*======================   Macro Implementations     ========================*/
+
+/** @private */
 #define ccc_impl_sll_init(sll_name, struct_name, sll_elem_field, cmp_fn,       \
                           alloc_fn, aux_data)                                  \
     {                                                                          \
@@ -38,10 +48,7 @@ struct ccc_sll_
         .aux_ = (aux_data),                                                    \
     }
 
-void ccc_impl_sll_push_front(struct ccc_sll_ *, struct ccc_sll_elem_ *);
-
-/* NOLINTBEGIN(readability-identifier-naming) */
-
+/** @private */
 #define ccc_impl_sll_emplace_front(list_ptr, struct_initializer...)            \
     (__extension__({                                                           \
         typeof(struct_initializer) *sll_res_ = NULL;                           \

--- a/ccc/impl/impl_traits.h
+++ b/ccc/impl/impl_traits.h
@@ -18,7 +18,7 @@
 #include "../types.h"
 /* NOLINTEND */
 
-/*======================     Entry Interface   ==============================*/
+/*====================     Entry/Handle Interface   =========================*/
 
 #define ccc_impl_swap_entry(container_ptr, swap_args...)                       \
     _Generic((container_ptr),                                                  \

--- a/ccc/impl/impl_tree.h
+++ b/ccc/impl/impl_tree.h
@@ -18,6 +18,8 @@
 #include "../types.h"
 #include "impl_types.h"
 
+/* NOLINTBEGIN(readability-identifier-naming) */
+
 /** @private This node type will support more expressive implementations of a
    standard map and multimap. The array of pointers is to support unifying left
    and right symmetric cases. The union is only relevant to the multimap.
@@ -70,6 +72,7 @@ struct ccc_tree_entry_
     struct ccc_ent_ entry_;
 };
 
+/** @private */
 #define ccc_tree_init(tree_name, struct_name, node_elem_field, key_elem_field, \
                       key_cmp_fn, alloc_fn, aux_data)                          \
     {                                                                          \
@@ -87,5 +90,7 @@ struct ccc_tree_entry_
             .key_offset_ = offsetof(struct_name, key_elem_field),              \
         },                                                                     \
     }
+
+/* NOLINTEND(readability-identifier-naming) */
 
 #endif /* CCC_IMPL_TREE_H */

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -672,31 +672,11 @@ ccc_impl_fhm_entry(struct ccc_fhmap_ *const h, void const *const key)
     return container_entry(h, key);
 }
 
-struct ccc_fhash_entry_ *
-ccc_impl_fhm_and_modify(struct ccc_fhash_entry_ *const e,
-                        ccc_update_fn *const fn)
-{
-    return and_modify(e, fn);
-}
-
-struct ccc_ent_
-ccc_impl_fhm_find(struct ccc_fhmap_ const *const h, void const *const key,
-                  uint64_t const hash)
-{
-    return find(h, key, hash);
-}
-
 void
 ccc_impl_fhm_insert(struct ccc_fhmap_ *const h, void const *const e,
                     uint64_t const hash, size_t cur_i)
 {
     insert(h, e, hash, cur_i);
-}
-
-ccc_result
-ccc_impl_fhm_maybe_resize(struct ccc_fhmap_ *const h)
-{
-    return maybe_resize(h);
 }
 
 struct ccc_fhmap_elem_ *
@@ -713,33 +693,15 @@ ccc_impl_fhm_key_in_slot(struct ccc_fhmap_ const *const h,
 }
 
 size_t
-ccc_impl_fhm_distance(size_t const capacity, size_t const i, size_t const j)
-{
-    return distance(capacity, i, j);
-}
-
-size_t
 ccc_impl_fhm_increment(size_t const capacity, size_t const i)
 {
     return increment(capacity, i);
-}
-
-void *
-ccc_impl_fhm_base(struct ccc_fhmap_ const *const h)
-{
-    return ccc_buf_begin(&h->buf_);
 }
 
 uint64_t *
 ccc_impl_fhm_hash_at(struct ccc_fhmap_ const *const h, size_t const i)
 {
     return hash_at(h, i);
-}
-
-uint64_t
-ccc_impl_fhm_filter(struct ccc_fhmap_ const *const h, void const *const key)
-{
-    return filter(h, key);
 }
 
 /*=======================     Static Helpers    =============================*/

--- a/src/handle_hash_map.c
+++ b/src/handle_hash_map.c
@@ -727,37 +727,11 @@ ccc_impl_hhm_handle(struct ccc_hhmap_ *const h, void const *const key)
     return container_handle(h, key);
 }
 
-struct ccc_hhash_handle_ *
-ccc_impl_hhm_and_modify(struct ccc_hhash_handle_ *const e,
-                        ccc_update_fn *const fn)
-{
-    return and_modify(e, fn);
-}
-
-struct ccc_handl_
-ccc_impl_hhm_find(struct ccc_hhmap_ const *const h, void const *const key,
-                  uint64_t const hash)
-{
-    return find(h, key, hash);
-}
-
 ccc_handle_i
 ccc_impl_hhm_insert_meta(struct ccc_hhmap_ *const h, uint64_t const hash,
                          size_t cur_i)
 {
     return insert_meta(h, hash, cur_i);
-}
-
-ccc_result
-ccc_impl_hhm_maybe_resize(struct ccc_hhmap_ *const h)
-{
-    return maybe_resize(h);
-}
-
-struct ccc_hhmap_elem_ *
-ccc_impl_hhm_in_slot(struct ccc_hhmap_ const *const h, void const *const slot)
-{
-    return elem_in_slot(h, slot);
 }
 
 void *
@@ -766,41 +740,10 @@ ccc_impl_hhm_key_at(struct ccc_hhmap_ const *h, size_t const i)
     return (char *)ccc_buf_at(&h->buf_, i) + h->key_offset_;
 }
 
-size_t
-ccc_impl_hhm_distance(size_t const capacity, size_t const i, size_t const j)
-{
-    return distance(capacity, i, j);
-}
-
-size_t
-ccc_impl_hhm_increment(size_t const capacity, size_t const i)
-{
-    return increment(capacity, i);
-}
-
-void *
-ccc_impl_hhm_base(struct ccc_hhmap_ const *const h)
-{
-    return ccc_buf_begin(&h->buf_);
-}
-
 uint64_t *
 ccc_impl_hhm_hash_at(struct ccc_hhmap_ const *const h, size_t const i)
 {
     return hash_at(h, i);
-}
-
-uint64_t
-ccc_impl_hhm_filter(struct ccc_hhmap_ const *const h, void const *const key)
-{
-    return filter(h, key);
-}
-
-void
-ccc_impl_hhm_copy_to_slot(struct ccc_hhmap_ *const h, void *const slot_dst,
-                          void const *const slot_src)
-{
-    copy_to_slot(h, slot_dst, slot_src);
 }
 
 struct ccc_hhmap_elem_ *

--- a/src/handle_ordered_map.c
+++ b/src/handle_ordered_map.c
@@ -589,13 +589,6 @@ ccc_impl_hom_handle(struct ccc_homap_ *const hom, void const *const key)
 }
 
 void *
-ccc_impl_hom_key_from_node(struct ccc_homap_ const *const hom,
-                           struct ccc_homap_elem_ const *const elem)
-{
-    return key_from_node(hom, elem);
-}
-
-void *
 ccc_impl_hom_key_at(struct ccc_homap_ const *const hom, size_t const slot)
 {
     return key_at(hom, slot);

--- a/src/handle_realtime_ordered_map.c
+++ b/src/handle_realtime_ordered_map.c
@@ -648,13 +648,6 @@ ccc_impl_hrm_handle(struct ccc_hromap_ const *const hrm, void const *const key)
 }
 
 void *
-ccc_impl_hrm_key_from_node(struct ccc_hromap_ const *const hrm,
-                           struct ccc_hromap_elem_ const *const elem)
-{
-    return key_from_node(hrm, elem);
-}
-
-void *
 ccc_impl_hrm_key_at(struct ccc_hromap_ const *const hrm, size_t const slot)
 {
     return key_at(hrm, slot);

--- a/src/ordered_map.c
+++ b/src/ordered_map.c
@@ -474,13 +474,6 @@ ccc_impl_om_key_in_slot(struct ccc_tree_ const *const t, void const *const slot)
     return key_in_slot(t, slot);
 }
 
-void *
-ccc_impl_om_key_from_node(struct ccc_tree_ const *const t,
-                          struct ccc_node_ const *const n)
-{
-    return key_from_node(t, n);
-}
-
 struct ccc_node_ *
 ccc_impl_omap_elem_in_slot(struct ccc_tree_ const *const t, void const *slot)
 {
@@ -874,14 +867,12 @@ are_subtrees_valid(struct ccc_tree_ const *const t, struct tree_range_ const r,
         return CCC_TRUE;
     }
     if (r.low != nil
-        && cmp(t, ccc_impl_om_key_from_node(t, r.low), r.root, t->cmp_)
-               != CCC_LES)
+        && cmp(t, key_from_node(t, r.low), r.root, t->cmp_) != CCC_LES)
     {
         return CCC_FALSE;
     }
     if (r.high != nil
-        && cmp(t, ccc_impl_om_key_from_node(t, r.high), r.root, t->cmp_)
-               != CCC_GRT)
+        && cmp(t, key_from_node(t, r.high), r.root, t->cmp_) != CCC_GRT)
     {
         return CCC_FALSE;
     }

--- a/src/ordered_multimap.c
+++ b/src/ordered_multimap.c
@@ -621,13 +621,6 @@ ccc_impl_omm_key_in_slot(struct ccc_tree_ const *const t,
     return key_in_slot(t, slot);
 }
 
-void *
-ccc_impl_omm_key_from_node(struct ccc_tree_ const *const t,
-                           struct ccc_node_ const *const n)
-{
-    return key_from_node(t, n);
-}
-
 struct ccc_node_ *
 ccc_impl_ommap_elem_in_slot(struct ccc_tree_ const *const t,
                             void const *const slot)

--- a/src/realtime_ordered_map.c
+++ b/src/realtime_ordered_map.c
@@ -559,13 +559,6 @@ ccc_impl_rom_insert(struct ccc_romap_ *const rom,
 }
 
 void *
-ccc_impl_rom_key_from_node(struct ccc_romap_ const *const rom,
-                           struct ccc_romap_elem_ const *const elem)
-{
-    return key_from_node(rom, elem);
-}
-
-void *
 ccc_impl_rom_key_in_slot(struct ccc_romap_ const *const rom,
                          void const *const slot)
 {


### PR DESCRIPTION
Unused functions in the impl headers that were hard to notice are eliminated. Cuts bloat. Also headers have appropriate private annotation for doxygen and lsps.