### PR TITLE
add any prefix to types with any fields and function types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ Here is an examples from `buffer.h` (may not be in sync with current code).
 ```c
 ccc_result
 ccc_buf_alloc(ccc_buffer *const buf, size_t const capacity,
-              ccc_alloc_fn *const fn)
+              ccc_any_alloc_fn *const fn)
 {
     if (!buf)
     {

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ struct int_elem
 };
 
 static ccc_threeway_cmp
-int_cmp(ccc_any_cmp const cmp)
+int_cmp(ccc_any_type_cmp const cmp)
 {
     struct int_elem const *const lhs = cmp.any_type_lhs;
     struct int_elem const *const rhs = cmp.any_type_rhs;
@@ -340,7 +340,7 @@ main(void)
 #include "ccc/traits.h"
 
 ccc_threeway_cmp
-int_cmp(ccc_any_cmp const ints)
+int_cmp(ccc_any_type_cmp const ints)
 {
     int const lhs = *(int *)ints.any_type_lhs;
     int const rhs = *(int *)ints.any_type_rhs;
@@ -680,7 +680,7 @@ struct val
 };
 
 static ccc_threeway_cmp
-val_cmp(ccc_any_cmp const cmp)
+val_cmp(ccc_any_type_cmp const cmp)
 {
     struct val const *const lhs = cmp.any_type_lhs;
     struct val const *const rhs = cmp.any_type_rhs;
@@ -801,7 +801,7 @@ struct int_elem
 };
 
 static ccc_threeway_cmp
-int_cmp(ccc_any_cmp const cmp)
+int_cmp(ccc_any_type_cmp const cmp)
 {
     struct int_elem const *const lhs = cmp.any_type_lhs;
     struct int_elem const *const rhs = cmp.any_type_rhs;
@@ -1037,7 +1037,7 @@ struct id *new_id = generate_id();
 struct id *new_front = ccc_dll_push_front(&id_list, &new_id->id_elem);
 /* Or when writing a comparison callback. */
 ccc_threeway_cmp
-id_cmp(ccc_any_cmp const cmp)
+id_cmp(ccc_any_type_cmp const cmp)
 {
     struct id const *const lhs = cmp.any_type_lhs;
     struct id const *const rhs = cmp.any_type_rhs;

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Currently, this library supports a `FetchContent` or manual installation via CMa
 ## Quick Start
 
 - Read the [DOCS](https://agl-alexglopez.github.io/ccc).
-- Read [types.h](https://agl-alexglopez.github.io/ccc/types_8h.html) to understand the `ccc_alloc_fn` interface.
+- Read [types.h](https://agl-alexglopez.github.io/ccc/types_8h.html) to understand the `ccc_any_alloc_fn` interface.
 - Read the [header](https://agl-alexglopez.github.io/ccc/files.html) for the desired container to understand its functionality.
 - Read about generic [traits.h](https://agl-alexglopez.github.io/ccc/traits_8h.html) shared across containers to make code more succinct.
 - Read [CONTRIBUTING.md](CONTRIBUTING.md) if interested in project structure, tools, and todos.
@@ -191,7 +191,7 @@ struct int_elem
 };
 
 static ccc_threeway_cmp
-int_cmp(ccc_cmp const cmp)
+int_cmp(ccc_any_cmp const cmp)
 {
     struct int_elem const *const lhs = cmp.any_type_lhs;
     struct int_elem const *const rhs = cmp.any_type_rhs;
@@ -281,11 +281,11 @@ fhmap_int_to_u64(ccc_any_key const k)
     return x;
 }
 
-bool
-fhmap_id_eq(ccc_key_cmp const cmp)
+ccc_tribool
+fhmap_id_eq(ccc_any_key_cmp const cmp)
 {
     struct key_val const *const va = cmp.any_type_rhs;
-    return va->key == *((int *)cmp.key_lhs);
+    return va->key == *((int *)cmp.any_key_lhs);
 }
 
 /* This fix map will be a 'small_fixed_map' used to store struct val. */
@@ -340,7 +340,7 @@ main(void)
 #include "ccc/traits.h"
 
 ccc_threeway_cmp
-int_cmp(ccc_cmp const ints)
+int_cmp(ccc_any_cmp const ints)
 {
     int const lhs = *(int *)ints.any_type_lhs;
     int const rhs = *(int *)ints.any_type_rhs;
@@ -394,10 +394,10 @@ struct kval
 };
 
 static ccc_threeway_cmp
-kval_cmp(ccc_key_cmp const cmp)
+kval_cmp(ccc_any_key_cmp const cmp)
 {
     struct kval const *const rhs = cmp.any_type_rhs;
-    int const key_lhs = *((int *)cmp.key_lhs);
+    int const key_lhs = *((int *)cmp.any_key_lhs);
     return (key_lhs > rhs->key) - (key_lhs < rhs->key);
 }
 
@@ -466,10 +466,10 @@ struct kval
 };
 
 static ccc_threeway_cmp
-kval_cmp(ccc_key_cmp const cmp)
+kval_cmp(ccc_any_key_cmp const cmp)
 {
     struct kval const *const rhs = cmp.any_type_rhs;
-    int const key_lhs = *((int *)cmp.key_lhs);
+    int const key_lhs = *((int *)cmp.any_key_lhs);
     return (key_lhs > rhs->key) - (key_lhs < rhs->key);
 }
 
@@ -536,9 +536,9 @@ struct name
 };
 
 ccc_threeway_cmp
-kval_cmp(ccc_key_cmp cmp)
+kval_cmp(ccc_any_key_cmp cmp)
 {
-    char const *const key = *(char **)cmp.key_lhs;
+    char const *const key = *(char **)cmp.any_key_lhs;
     struct name const *const rhs = cmp.any_type_rhs;
     int const res = strcmp(key, rhs->name);
     if (res == 0)
@@ -605,9 +605,9 @@ struct name
 };
 
 ccc_threeway_cmp
-kval_cmp(ccc_key_cmp cmp)
+kval_cmp(ccc_any_key_cmp cmp)
 {
-    char const *const key = *(char **)cmp.key_lhs;
+    char const *const key = *(char **)cmp.any_key_lhs;
     struct name const *const rhs = cmp.any_type_rhs;
     int const res = strcmp(key, rhs->name);
     if (res == 0)
@@ -680,7 +680,7 @@ struct val
 };
 
 static ccc_threeway_cmp
-val_cmp(ccc_cmp const cmp)
+val_cmp(ccc_any_cmp const cmp)
 {
     struct val const *const lhs = cmp.any_type_lhs;
     struct val const *const rhs = cmp.any_type_rhs;
@@ -729,10 +729,10 @@ struct kval
 };
 
 static ccc_threeway_cmp
-kval_cmp(ccc_key_cmp const cmp)
+kval_cmp(ccc_any_key_cmp const cmp)
 {
     struct kval const *const rhs = cmp.any_type_rhs;
-    int const key_lhs = *((int *)cmp.key_lhs);
+    int const key_lhs = *((int *)cmp.any_key_lhs);
     return (key_lhs > rhs->key) - (key_lhs < rhs->key);
 }
 
@@ -801,7 +801,7 @@ struct int_elem
 };
 
 static ccc_threeway_cmp
-int_cmp(ccc_cmp const cmp)
+int_cmp(ccc_any_cmp const cmp)
 {
     struct int_elem const *const lhs = cmp.any_type_lhs;
     struct int_elem const *const rhs = cmp.any_type_rhs;
@@ -1037,7 +1037,7 @@ struct id *new_id = generate_id();
 struct id *new_front = ccc_dll_push_front(&id_list, &new_id->id_elem);
 /* Or when writing a comparison callback. */
 ccc_threeway_cmp
-id_cmp(ccc_cmp const cmp)
+id_cmp(ccc_any_cmp const cmp)
 {
     struct id const *const lhs = cmp.any_type_lhs;
     struct id const *const rhs = cmp.any_type_rhs;
@@ -1189,7 +1189,7 @@ Using the first method in your code may expand the code evaluated in different `
 When allocation is required, this collection offers the following interface. The user provides this function to containers upon initialization.
 
 ```c
-typedef void *ccc_alloc_fn(void *ptr, size_t size, void *aux);
+typedef void *ccc_any_alloc_fn(void *ptr, size_t size, void *aux);
 ```
 
 An allocation function implements the following behavior, where ptr is pointer to memory, size is number of bytes to allocate, and aux is a reference to any supplementary information required for allocation, deallocation, or reallocation. The aux parameter is passed to a container upon its initialization and the programmer may choose how to best utilize this reference (read on for more on aux).

--- a/ccc/bitset.h
+++ b/ccc/bitset.h
@@ -206,7 +206,7 @@ copying between maps without allocation permission.
 These options allow users to stay consistent across containers with their
 memory management strategies. */
 ccc_result ccc_bs_copy(ccc_bitset *dst, ccc_bitset const *src,
-                       ccc_alloc_fn *fn);
+                       ccc_any_alloc_fn *fn);
 
 /** @brief Reserves space for at least to_add more bits.
 @param [in] bs a pointer to the bit set.
@@ -225,7 +225,7 @@ If the bit set has been initialized with no allocation permission and no memory
 this function can serve as a one-time reservation. This is helpful when a fixed
 size is needed but that size is only known dynamically at runtime. To free the
 bit set in such a case see the ccc_bs_clear_and_free_reserve function. */
-ccc_result ccc_bs_reserve(ccc_bitset *bs, size_t to_add, ccc_alloc_fn *fn);
+ccc_result ccc_bs_reserve(ccc_bitset *bs, size_t to_add, ccc_any_alloc_fn *fn);
 
 /**@}*/
 
@@ -758,7 +758,7 @@ the allocation function when called.
 @return the result of free operation. OK if success, or an error status to
 indicate the error.
 @warning It is an error to call this function on a bs that was not reserved
-with the provided ccc_alloc_fn. The bs must have existing memory to free.
+with the provided ccc_any_alloc_fn. The bs must have existing memory to free.
 
 This function covers the edge case of reserving a dynamic capacity for a bs
 at runtime but denying the bs allocation permission to resize. This can help
@@ -772,7 +772,7 @@ to reserve memory so to is it required to free memory.
 
 This function will work normally if called on a bs with allocation permission
 however the normal ccc_bs_clear_and_free is sufficient for that use case. */
-ccc_result ccc_bs_clear_and_free_reserve(ccc_bitset *bs, ccc_alloc_fn *fn);
+ccc_result ccc_bs_clear_and_free_reserve(ccc_bitset *bs, ccc_any_alloc_fn *fn);
 
 /**@}*/
 

--- a/ccc/buffer.h
+++ b/ccc/buffer.h
@@ -73,7 +73,7 @@ Initialize the container with memory, callbacks, and permissions. */
 /** @brief Initialize a contiguous buffer of user a specified type, allocation
 policy, capacity, and optional starting size.
 @param [in] mem_ptr the pointer to existing memory or ((Type *)NULL).
-@param [in] alloc_fn ccc_alloc_fn or NULL if no allocation is permitted.
+@param [in] alloc_fn ccc_any_alloc_fn or NULL if no allocation is permitted.
 @param [in] aux_data any auxiliary data needed for managing buffer memory.
 @param [in] capacity the capacity of memory at mem_ptr.
 @param [in] optional_size optional starting size of the buffer <= capacity.
@@ -115,7 +115,7 @@ managing allocations and resizing directly. If an allocation function has
 been provided than the use of this function should be rare as the buffer
 will reallocate more memory when necessary. */
 [[nodiscard]] ccc_result ccc_buf_alloc(ccc_buffer *buf, size_t capacity,
-                                       ccc_alloc_fn *fn);
+                                       ccc_any_alloc_fn *fn);
 
 /** @brief allocates a new slot from the buffer at the end of the contiguous
 array. A slot is equivalent to one of the element type specified when the

--- a/ccc/doubly_linked_list.h
+++ b/ccc/doubly_linked_list.h
@@ -82,7 +82,7 @@ destructors.
 @param [in] list_name the name of the list being initialized.
 @param [in] struct_name the type containing the intrusive dll element.
 @param [in] list_elem_field name of the dll element in the containing type.
-@param [in] cmp_fn the ccc_any_cmp_fn used to compare list elements.
+@param [in] cmp_fn the ccc_any_type_cmp_fn used to compare list elements.
 @param [in] aux_data any auxilliary data that will be needed for comparison,
 printing, or destruction of elements.
 @param [in] alloc_fn the optional allocation function or NULL.
@@ -266,7 +266,8 @@ the list elements with the destructor if they wish to do so. The implementation
 ensures the function is called after the element is removed. Otherwise, the user
 must manage their elements at their discretion after the list is emptied in
 this function. */
-ccc_result ccc_dll_clear(ccc_doubly_linked_list *l, ccc_any_destructor_fn *fn);
+ccc_result ccc_dll_clear(ccc_doubly_linked_list *l,
+                         ccc_any_type_destructor_fn *fn);
 
 /**@}*/
 

--- a/ccc/doubly_linked_list.h
+++ b/ccc/doubly_linked_list.h
@@ -82,7 +82,7 @@ destructors.
 @param [in] list_name the name of the list being initialized.
 @param [in] struct_name the type containing the intrusive dll element.
 @param [in] list_elem_field name of the dll element in the containing type.
-@param [in] cmp_fn the ccc_cmp_fn used to compare list elements.
+@param [in] cmp_fn the ccc_any_cmp_fn used to compare list elements.
 @param [in] aux_data any auxilliary data that will be needed for comparison,
 printing, or destruction of elements.
 @param [in] alloc_fn the optional allocation function or NULL.
@@ -266,7 +266,7 @@ the list elements with the destructor if they wish to do so. The implementation
 ensures the function is called after the element is removed. Otherwise, the user
 must manage their elements at their discretion after the list is emptied in
 this function. */
-ccc_result ccc_dll_clear(ccc_doubly_linked_list *l, ccc_destructor_fn *fn);
+ccc_result ccc_dll_clear(ccc_doubly_linked_list *l, ccc_any_destructor_fn *fn);
 
 /**@}*/
 

--- a/ccc/flat_double_ended_queue.h
+++ b/ccc/flat_double_ended_queue.h
@@ -138,7 +138,7 @@ These options allow users to stay consistent across containers with their
 memory management strategies. */
 ccc_result ccc_fdeq_copy(ccc_flat_double_ended_queue *dst,
                          ccc_flat_double_ended_queue const *src,
-                         ccc_alloc_fn *fn);
+                         ccc_any_alloc_fn *fn);
 
 /** @brief Reserves space for at least to_add more elements.
 @param [in] fdeq a pointer to the flat double ended queue.
@@ -159,7 +159,7 @@ as ring buffer when space runs out. This is helpful when a fixed size is needed
 but that size is only known dynamically at runtime. To free the fdeq in such a
 case see the ccc_fdeq_clear_and_free_reserve function. */
 ccc_result ccc_fdeq_reserve(ccc_flat_double_ended_queue *fdeq, size_t to_add,
-                            ccc_alloc_fn *fn);
+                            ccc_any_alloc_fn *fn);
 
 /**@}*/
 
@@ -303,7 +303,7 @@ Note that if destructor is non-NULL it will be called on each element in the
 fdeq. However, the underlying buffer for the fdeq is not freed. If the
 destructor is NULL, setting the size to 0 is O(1). */
 ccc_result ccc_fdeq_clear(ccc_flat_double_ended_queue *fdeq,
-                          ccc_destructor_fn *destructor);
+                          ccc_any_destructor_fn *destructor);
 
 /** @brief Set size of fdeq to 0 and call destructor on each element if needed.
 Free the underlying buffer setting the capacity to 0. O(1) if no destructor is
@@ -315,7 +315,7 @@ Note that if destructor is non-NULL it will be called on each element in the
 fdeq. After all elements are processed the buffer is freed and capacity is 0.
 If destructor is NULL the buffer is freed directly and capacity is 0. */
 ccc_result ccc_fdeq_clear_and_free(ccc_flat_double_ended_queue *fdeq,
-                                   ccc_destructor_fn *destructor);
+                                   ccc_any_destructor_fn *destructor);
 
 /** @brief Frees all slots in the fdeq and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -329,7 +329,7 @@ the allocation function when called.
 @return the result of free operation. OK if success, or an error status to
 indicate the error.
 @warning It is an error to call this function on a fdeq that was not reserved
-with the provided ccc_alloc_fn. The fdeq must have existing memory to free.
+with the provided ccc_any_alloc_fn. The fdeq must have existing memory to free.
 
 This function covers the edge case of reserving a dynamic capacity for a fdeq
 at runtime but denying the fdeq allocation permission to resize. This can help
@@ -344,8 +344,8 @@ to reserve memory so to is it required to free memory.
 This function will work normally if called on a fdeq with allocation permission
 however the normal ccc_fdeq_clear_and_free is sufficient for that use case. */
 ccc_result ccc_fdeq_clear_and_free_reserve(ccc_flat_double_ended_queue *fdeq,
-                                           ccc_destructor_fn *destructor,
-                                           ccc_alloc_fn *alloc);
+                                           ccc_any_destructor_fn *destructor,
+                                           ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/flat_double_ended_queue.h
+++ b/ccc/flat_double_ended_queue.h
@@ -303,7 +303,7 @@ Note that if destructor is non-NULL it will be called on each element in the
 fdeq. However, the underlying buffer for the fdeq is not freed. If the
 destructor is NULL, setting the size to 0 is O(1). */
 ccc_result ccc_fdeq_clear(ccc_flat_double_ended_queue *fdeq,
-                          ccc_any_destructor_fn *destructor);
+                          ccc_any_type_destructor_fn *destructor);
 
 /** @brief Set size of fdeq to 0 and call destructor on each element if needed.
 Free the underlying buffer setting the capacity to 0. O(1) if no destructor is
@@ -315,7 +315,7 @@ Note that if destructor is non-NULL it will be called on each element in the
 fdeq. After all elements are processed the buffer is freed and capacity is 0.
 If destructor is NULL the buffer is freed directly and capacity is 0. */
 ccc_result ccc_fdeq_clear_and_free(ccc_flat_double_ended_queue *fdeq,
-                                   ccc_any_destructor_fn *destructor);
+                                   ccc_any_type_destructor_fn *destructor);
 
 /** @brief Frees all slots in the fdeq and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -343,9 +343,10 @@ to reserve memory so to is it required to free memory.
 
 This function will work normally if called on a fdeq with allocation permission
 however the normal ccc_fdeq_clear_and_free is sufficient for that use case. */
-ccc_result ccc_fdeq_clear_and_free_reserve(ccc_flat_double_ended_queue *fdeq,
-                                           ccc_any_destructor_fn *destructor,
-                                           ccc_any_alloc_fn *alloc);
+ccc_result
+ccc_fdeq_clear_and_free_reserve(ccc_flat_double_ended_queue *fdeq,
+                                ccc_any_type_destructor_fn *destructor,
+                                ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -143,8 +143,8 @@ restrictions. */
 or (T *)NULL.
 @param [in] tag_ptr a pointer to the .tag field of a fixed map or NULL.
 @param [in] key_field the field of the struct used for key storage.
-@param [in] hash_fn the ccc_hash_fn function the user desires for the table.
-@param [in] key_eq_fn the ccc_key_eq_fn the user intends to use.
+@param [in] hash_fn the ccc_any_hash_fn function the user desires for the table.
+@param [in] key_eq_fn the ccc_any_key_eq_fn the user intends to use.
 @param [in] alloc_fn the allocation function for resizing or NULL if no
 resizing is allowed.
 @param [in] aux_data auxiliary data that is needed for hashing or comparison.
@@ -283,7 +283,7 @@ size dynamic maps are required.
 These options allow users to stay consistent across containers with their
 memory management strategies. */
 ccc_result ccc_fhm_copy(ccc_flat_hash_map *dst, ccc_flat_hash_map const *src,
-                        ccc_alloc_fn *fn);
+                        ccc_any_alloc_fn *fn);
 
 /** @brief Reserve space required to add a specified number of elements to the
 map. If the current capacity is sufficient, do nothing.
@@ -301,7 +301,7 @@ code to indicate the specific failure.
 If the map has already been initialized with allocation permission simply
 provide the same function that was passed upon initialization. */
 ccc_result ccc_fhm_reserve(ccc_flat_hash_map *h, size_t to_add,
-                           ccc_alloc_fn *fn);
+                           ccc_any_alloc_fn *fn);
 
 /**@}*/
 
@@ -377,9 +377,9 @@ Entry Interface.*/
 
 This function is intended to make the function chaining in the Entry Interface
 more succinct if the entry will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 [[nodiscard]] ccc_fhmap_entry *ccc_fhm_and_modify(ccc_fhmap_entry *e,
-                                                  ccc_update_fn *fn);
+                                                  ccc_any_update_fn *fn);
 
 /** @brief Modifies the provided entry if it is Occupied.
 @param [in] e the entry obtained from an entry function or macro.
@@ -387,10 +387,10 @@ without the need of the auxiliary argument a ccc_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated entry if it was Occupied or the unmodified vacant entry.
 
-This function makes full use of a ccc_update_fn capability, meaning a complete
-ccc_update object will be passed to the update function callback. */
+This function makes full use of a ccc_any_update_fn capability, meaning a
+complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_fhmap_entry *
-ccc_fhm_and_modify_aux(ccc_fhmap_entry *e, ccc_update_fn *fn, void *aux);
+ccc_fhm_and_modify_aux(ccc_fhmap_entry *e, ccc_any_update_fn *fn, void *aux);
 
 /** @brief Modify an Occupied entry with a closure over user type T.
 @param [in] map_entry_ptr a pointer to the obtained entry.
@@ -696,7 +696,7 @@ maintenance is required on the elements in the table before their slots are
 forfeit.
 
 If NULL is passed as the destructor function time is O(1), else O(capacity). */
-ccc_result ccc_fhm_clear(ccc_flat_hash_map *h, ccc_destructor_fn *fn);
+ccc_result ccc_fhm_clear(ccc_flat_hash_map *h, ccc_any_destructor_fn *fn);
 
 /** @brief Frees all slots in the table and frees the underlying buffer.
 @param [in] h the table to be cleared.
@@ -706,7 +706,8 @@ forfeit.
 @return the result of free operation. If no alloc function is provided it is
 an error to attempt to free the buffer and a memory error is returned.
 Otherwise, an OK result is returned. */
-ccc_result ccc_fhm_clear_and_free(ccc_flat_hash_map *h, ccc_destructor_fn *fn);
+ccc_result ccc_fhm_clear_and_free(ccc_flat_hash_map *h,
+                                  ccc_any_destructor_fn *fn);
 
 /** @brief Frees all slots in the table and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -720,7 +721,7 @@ the allocation function when called.
 @return the result of free operation. CCC_RESULT_OK if success, or an error
 status to indicate the error.
 @warning It is an error to call this function on a map that was not reserved
-with the provided ccc_alloc_fn. The map must have existing memory to free.
+with the provided ccc_any_alloc_fn. The map must have existing memory to free.
 
 This function covers the edge case of reserving a dynamic capacity for a map
 at runtime but denying the map allocation permission to resize. This can help
@@ -735,8 +736,8 @@ to reserve memory so to is it required to free memory.
 This function will work normally if called on a map with allocation permission
 however the normal ccc_fhm_clear_and_free is sufficient for that use case. */
 ccc_result ccc_fhm_clear_and_free_reserve(ccc_flat_hash_map *h,
-                                          ccc_destructor_fn *destructor,
-                                          ccc_alloc_fn *alloc);
+                                          ccc_any_destructor_fn *destructor,
+                                          ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -143,7 +143,8 @@ restrictions. */
 or (T *)NULL.
 @param [in] tag_ptr a pointer to the .tag field of a fixed map or NULL.
 @param [in] key_field the field of the struct used for key storage.
-@param [in] hash_fn the ccc_any_hash_fn function the user desires for the table.
+@param [in] hash_fn the ccc_any_key_hash_fn function the user desires for the
+table.
 @param [in] key_eq_fn the ccc_any_key_eq_fn the user intends to use.
 @param [in] alloc_fn the allocation function for resizing or NULL if no
 resizing is allowed.
@@ -377,9 +378,10 @@ Entry Interface.*/
 
 This function is intended to make the function chaining in the Entry Interface
 more succinct if the entry will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_any_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_type_update_fn can provide.
+*/
 [[nodiscard]] ccc_fhmap_entry *ccc_fhm_and_modify(ccc_fhmap_entry *e,
-                                                  ccc_any_update_fn *fn);
+                                                  ccc_any_type_update_fn *fn);
 
 /** @brief Modifies the provided entry if it is Occupied.
 @param [in] e the entry obtained from an entry function or macro.
@@ -387,10 +389,11 @@ without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated entry if it was Occupied or the unmodified vacant entry.
 
-This function makes full use of a ccc_any_update_fn capability, meaning a
+This function makes full use of a ccc_any_type_update_fn capability, meaning a
 complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_fhmap_entry *
-ccc_fhm_and_modify_aux(ccc_fhmap_entry *e, ccc_any_update_fn *fn, void *aux);
+ccc_fhm_and_modify_aux(ccc_fhmap_entry *e, ccc_any_type_update_fn *fn,
+                       void *aux);
 
 /** @brief Modify an Occupied entry with a closure over user type T.
 @param [in] map_entry_ptr a pointer to the obtained entry.
@@ -696,7 +699,7 @@ maintenance is required on the elements in the table before their slots are
 forfeit.
 
 If NULL is passed as the destructor function time is O(1), else O(capacity). */
-ccc_result ccc_fhm_clear(ccc_flat_hash_map *h, ccc_any_destructor_fn *fn);
+ccc_result ccc_fhm_clear(ccc_flat_hash_map *h, ccc_any_type_destructor_fn *fn);
 
 /** @brief Frees all slots in the table and frees the underlying buffer.
 @param [in] h the table to be cleared.
@@ -707,7 +710,7 @@ forfeit.
 an error to attempt to free the buffer and a memory error is returned.
 Otherwise, an OK result is returned. */
 ccc_result ccc_fhm_clear_and_free(ccc_flat_hash_map *h,
-                                  ccc_any_destructor_fn *fn);
+                                  ccc_any_type_destructor_fn *fn);
 
 /** @brief Frees all slots in the table and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -735,9 +738,10 @@ to reserve memory so to is it required to free memory.
 
 This function will work normally if called on a map with allocation permission
 however the normal ccc_fhm_clear_and_free is sufficient for that use case. */
-ccc_result ccc_fhm_clear_and_free_reserve(ccc_flat_hash_map *h,
-                                          ccc_any_destructor_fn *destructor,
-                                          ccc_any_alloc_fn *alloc);
+ccc_result
+ccc_fhm_clear_and_free_reserve(ccc_flat_hash_map *h,
+                               ccc_any_type_destructor_fn *destructor,
+                               ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -156,7 +156,8 @@ copying between ring buffers.
 These options allow users to stay consistent across containers with their
 memory management strategies. */
 ccc_result ccc_fpq_copy(ccc_flat_priority_queue *dst,
-                        ccc_flat_priority_queue const *src, ccc_alloc_fn *fn);
+                        ccc_flat_priority_queue const *src,
+                        ccc_any_alloc_fn *fn);
 
 /** @brief Reserves space for at least to_add more elements.
 @param [in] fpq a pointer to the flat priority queue.
@@ -176,7 +177,7 @@ this function can serve as a one-time reservation. This is helpful when a fixed
 size is needed but that size is only known dynamically at runtime. To free the
 fpq in such a case see the ccc_fpq_clear_and_free_reserve function. */
 ccc_result ccc_fpq_reserve(ccc_flat_priority_queue *fpq, size_t to_add,
-                           ccc_alloc_fn *fn);
+                           ccc_any_alloc_fn *fn);
 
 /**@}*/
 
@@ -225,7 +226,7 @@ ccc_result ccc_fpq_heapify_inplace(ccc_flat_priority_queue *fpq, size_t n);
 @param [in] fn the allocation function. May be the same as used on init.
 @return OK if allocation was successful or a memory error on failure. */
 ccc_result ccc_fpq_alloc(ccc_flat_priority_queue *fpq, size_t new_capacity,
-                         ccc_alloc_fn *fn);
+                         ccc_any_alloc_fn *fn);
 
 /** @brief Pushes element pointed to at e into fpq. O(lgN).
 @param [in] fpq a pointer to the priority queue.
@@ -258,8 +259,8 @@ ccc_result ccc_fpq_erase(ccc_flat_priority_queue *fpq, void *e);
 @return a reference to the element at its new position in the fpq on success,
 NULL if parameters are invalid or fpq is empty.
 @warning the user must ensure e is in the fpq. */
-void *ccc_fpq_update(ccc_flat_priority_queue *fpq, void *e, ccc_update_fn *fn,
-                     void *aux);
+void *ccc_fpq_update(ccc_flat_priority_queue *fpq, void *e,
+                     ccc_any_update_fn *fn, void *aux);
 
 /** @brief Update the user type stored in the priority queue directly. O(lgN).
 @param [in] fpq_ptr a pointer to the flat priority queue.
@@ -291,8 +292,8 @@ Note that whether the key increases or decreases does not affect runtime. */
 @return a reference to the element at its new position in the fpq on success,
 NULL if parameters are invalid or fpq is empty.
 @warning the user must ensure e is in the fpq. */
-void *ccc_fpq_increase(ccc_flat_priority_queue *fpq, void *e, ccc_update_fn *fn,
-                       void *aux);
+void *ccc_fpq_increase(ccc_flat_priority_queue *fpq, void *e,
+                       ccc_any_update_fn *fn, void *aux);
 
 /** @brief Increase the user type stored in the priority queue directly. O(lgN).
 @param [in] fpq_ptr a pointer to the flat priority queue.
@@ -324,8 +325,8 @@ Note that if this priority queue is min or max, the runtime is the same. */
 @return a reference to the element at its new position in the fpq on success,
 NULL if parameters are invalid or fpq is empty.
 @warning the user must ensure e is in the fpq. */
-void *ccc_fpq_decrease(ccc_flat_priority_queue *fpq, void *e, ccc_update_fn *fn,
-                       void *aux);
+void *ccc_fpq_decrease(ccc_flat_priority_queue *fpq, void *e,
+                       ccc_any_update_fn *fn, void *aux);
 
 /** @brief Increase the user type stored in the priority queue directly. O(lgN).
 @param [in] fpq_ptr a pointer to the flat priority queue.
@@ -366,7 +367,8 @@ parts of user code as needed upon destruction of each element.
 
 If the destructor is NULL, the function is O(1) and no attempt is made to
 free capacity of the fpq. */
-ccc_result ccc_fpq_clear(ccc_flat_priority_queue *fpq, ccc_destructor_fn *fn);
+ccc_result ccc_fpq_clear(ccc_flat_priority_queue *fpq,
+                         ccc_any_destructor_fn *fn);
 
 /** @brief Clears the fpq calling fn on every element if provided and frees the
 underlying buffer. O(1)-O(N).
@@ -382,7 +384,7 @@ parts of user code as needed upon destruction of each element.
 If the destructor is NULL, the function is O(1) and only relies on the runtime
 of the provided allocation function free operation. */
 ccc_result ccc_fpq_clear_and_free(ccc_flat_priority_queue *fpq,
-                                  ccc_destructor_fn *fn);
+                                  ccc_any_destructor_fn *fn);
 
 /** @brief Frees all slots in the fpq and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -396,7 +398,7 @@ the allocation function when called.
 @return the result of free operation. OK if success, or an error status to
 indicate the error.
 @warning It is an error to call this function on a fpq that was not reserved
-with the provided ccc_alloc_fn. The fpq must have existing memory to free.
+with the provided ccc_any_alloc_fn. The fpq must have existing memory to free.
 
 This function covers the edge case of reserving a dynamic capacity for a fpq
 at runtime but denying the fpq allocation permission to resize. This can help
@@ -411,8 +413,8 @@ to reserve memory so to is it required to free memory.
 This function will work normally if called on a fpq with allocation permission
 however the normal ccc_fpq_clear_and_free is sufficient for that use case. */
 ccc_result ccc_fpq_clear_and_free_reserve(ccc_flat_priority_queue *fpq,
-                                          ccc_destructor_fn *destructor,
-                                          ccc_alloc_fn *alloc);
+                                          ccc_any_destructor_fn *destructor,
+                                          ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -260,7 +260,7 @@ ccc_result ccc_fpq_erase(ccc_flat_priority_queue *fpq, void *e);
 NULL if parameters are invalid or fpq is empty.
 @warning the user must ensure e is in the fpq. */
 void *ccc_fpq_update(ccc_flat_priority_queue *fpq, void *e,
-                     ccc_any_update_fn *fn, void *aux);
+                     ccc_any_type_update_fn *fn, void *aux);
 
 /** @brief Update the user type stored in the priority queue directly. O(lgN).
 @param [in] fpq_ptr a pointer to the flat priority queue.
@@ -293,7 +293,7 @@ Note that whether the key increases or decreases does not affect runtime. */
 NULL if parameters are invalid or fpq is empty.
 @warning the user must ensure e is in the fpq. */
 void *ccc_fpq_increase(ccc_flat_priority_queue *fpq, void *e,
-                       ccc_any_update_fn *fn, void *aux);
+                       ccc_any_type_update_fn *fn, void *aux);
 
 /** @brief Increase the user type stored in the priority queue directly. O(lgN).
 @param [in] fpq_ptr a pointer to the flat priority queue.
@@ -326,7 +326,7 @@ Note that if this priority queue is min or max, the runtime is the same. */
 NULL if parameters are invalid or fpq is empty.
 @warning the user must ensure e is in the fpq. */
 void *ccc_fpq_decrease(ccc_flat_priority_queue *fpq, void *e,
-                       ccc_any_update_fn *fn, void *aux);
+                       ccc_any_type_update_fn *fn, void *aux);
 
 /** @brief Increase the user type stored in the priority queue directly. O(lgN).
 @param [in] fpq_ptr a pointer to the flat priority queue.
@@ -368,7 +368,7 @@ parts of user code as needed upon destruction of each element.
 If the destructor is NULL, the function is O(1) and no attempt is made to
 free capacity of the fpq. */
 ccc_result ccc_fpq_clear(ccc_flat_priority_queue *fpq,
-                         ccc_any_destructor_fn *fn);
+                         ccc_any_type_destructor_fn *fn);
 
 /** @brief Clears the fpq calling fn on every element if provided and frees the
 underlying buffer. O(1)-O(N).
@@ -384,7 +384,7 @@ parts of user code as needed upon destruction of each element.
 If the destructor is NULL, the function is O(1) and only relies on the runtime
 of the provided allocation function free operation. */
 ccc_result ccc_fpq_clear_and_free(ccc_flat_priority_queue *fpq,
-                                  ccc_any_destructor_fn *fn);
+                                  ccc_any_type_destructor_fn *fn);
 
 /** @brief Frees all slots in the fpq and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -412,9 +412,10 @@ to reserve memory so to is it required to free memory.
 
 This function will work normally if called on a fpq with allocation permission
 however the normal ccc_fpq_clear_and_free is sufficient for that use case. */
-ccc_result ccc_fpq_clear_and_free_reserve(ccc_flat_priority_queue *fpq,
-                                          ccc_any_destructor_fn *destructor,
-                                          ccc_any_alloc_fn *alloc);
+ccc_result
+ccc_fpq_clear_and_free_reserve(ccc_flat_priority_queue *fpq,
+                               ccc_any_type_destructor_fn *destructor,
+                               ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/handle_ordered_map.h
+++ b/ccc/handle_ordered_map.h
@@ -185,7 +185,8 @@ copying between maps without allocation permission.
 These options allow users to stay consistent across containers with their
 memory management strategies. */
 ccc_result ccc_hom_copy(ccc_handle_ordered_map *dst,
-                        ccc_handle_ordered_map const *src, ccc_alloc_fn *fn);
+                        ccc_handle_ordered_map const *src,
+                        ccc_any_alloc_fn *fn);
 
 /** @brief Reserves space for at least to_add more elements.
 @param [in] hom a pointer to the handle ordered map.
@@ -205,7 +206,7 @@ this function can serve as a one-time reservation. This is helpful when a fixed
 size is needed but that size is only known dynamically at runtime. To free the
 hom in such a case see the ccc_hom_clear_and_free_reserve function. */
 ccc_result ccc_hom_reserve(ccc_handle_ordered_map *hom, size_t to_add,
-                           ccc_alloc_fn *fn);
+                           ccc_any_alloc_fn *fn);
 
 /**@}*/
 
@@ -435,9 +436,9 @@ to subsequent calls in the Handle Interface. */
 
 This function is intended to make the function chaining in the Handle Interface
 more succinct if the handle will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 [[nodiscard]] ccc_homap_handle *ccc_hom_and_modify(ccc_homap_handle *h,
-                                                   ccc_update_fn *fn);
+                                                   ccc_any_update_fn *fn);
 
 /** @brief Modifies the provided handle if it is Occupied.
 @param [in] h the handle obtained from a handle function or macro.
@@ -445,10 +446,10 @@ without the need of the auxiliary argument a ccc_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated handle if it was Occupied or the unmodified vacant handle.
 
-This function makes full use of a ccc_update_fn capability, meaning a complete
-ccc_update object will be passed to the update function callback. */
+This function makes full use of a ccc_any_update_fn capability, meaning a
+complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_homap_handle *
-ccc_hom_and_modify_aux(ccc_homap_handle *h, ccc_update_fn *fn, void *aux);
+ccc_hom_and_modify_aux(ccc_homap_handle *h, ccc_any_update_fn *fn, void *aux);
 
 /** @brief Modify an Occupied handle with a closure over user type T.
 @param [in] handle_ordered_map_handle_ptr a pointer to the obtained handle.
@@ -713,7 +714,8 @@ maintenance is required on the elements in the map before their slots are
 forfeit.
 
 If NULL is passed as the destructor function time is O(1), else O(size). */
-ccc_result ccc_hom_clear(ccc_handle_ordered_map *hom, ccc_destructor_fn *fn);
+ccc_result ccc_hom_clear(ccc_handle_ordered_map *hom,
+                         ccc_any_destructor_fn *fn);
 
 /** @brief Frees all slots in the map and frees the underlying buffer.
 @param [in] hom the map to be cleared.
@@ -726,7 +728,7 @@ Otherwise, an OK result is returned.
 
 If NULL is passed as the destructor function time is O(1), else O(size). */
 ccc_result ccc_hom_clear_and_free(ccc_handle_ordered_map *hom,
-                                  ccc_destructor_fn *fn);
+                                  ccc_any_destructor_fn *fn);
 
 /** @brief Frees all slots in the hom and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -740,7 +742,7 @@ the allocation function when called.
 @return the result of free operation. OK if success, or an error status to
 indicate the error.
 @warning It is an error to call this function on a hom that was not reserved
-with the provided ccc_alloc_fn. The hom must have existing memory to free.
+with the provided ccc_any_alloc_fn. The hom must have existing memory to free.
 
 This function covers the edge case of reserving a dynamic capacity for a hom
 at runtime but denying the hom allocation permission to resize. This can help
@@ -755,8 +757,8 @@ to reserve memory so to is it required to free memory.
 This function will work normally if called on a hom with allocation permission
 however the normal ccc_hom_clear_and_free is sufficient for that use case. */
 ccc_result ccc_hom_clear_and_free_reserve(ccc_handle_ordered_map *hom,
-                                          ccc_destructor_fn *destructor,
-                                          ccc_alloc_fn *alloc);
+                                          ccc_any_destructor_fn *destructor,
+                                          ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/handle_ordered_map.h
+++ b/ccc/handle_ordered_map.h
@@ -436,9 +436,10 @@ to subsequent calls in the Handle Interface. */
 
 This function is intended to make the function chaining in the Handle Interface
 more succinct if the handle will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_any_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_type_update_fn can provide.
+*/
 [[nodiscard]] ccc_homap_handle *ccc_hom_and_modify(ccc_homap_handle *h,
-                                                   ccc_any_update_fn *fn);
+                                                   ccc_any_type_update_fn *fn);
 
 /** @brief Modifies the provided handle if it is Occupied.
 @param [in] h the handle obtained from a handle function or macro.
@@ -446,10 +447,11 @@ without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated handle if it was Occupied or the unmodified vacant handle.
 
-This function makes full use of a ccc_any_update_fn capability, meaning a
+This function makes full use of a ccc_any_type_update_fn capability, meaning a
 complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_homap_handle *
-ccc_hom_and_modify_aux(ccc_homap_handle *h, ccc_any_update_fn *fn, void *aux);
+ccc_hom_and_modify_aux(ccc_homap_handle *h, ccc_any_type_update_fn *fn,
+                       void *aux);
 
 /** @brief Modify an Occupied handle with a closure over user type T.
 @param [in] handle_ordered_map_handle_ptr a pointer to the obtained handle.
@@ -715,7 +717,7 @@ forfeit.
 
 If NULL is passed as the destructor function time is O(1), else O(size). */
 ccc_result ccc_hom_clear(ccc_handle_ordered_map *hom,
-                         ccc_any_destructor_fn *fn);
+                         ccc_any_type_destructor_fn *fn);
 
 /** @brief Frees all slots in the map and frees the underlying buffer.
 @param [in] hom the map to be cleared.
@@ -728,7 +730,7 @@ Otherwise, an OK result is returned.
 
 If NULL is passed as the destructor function time is O(1), else O(size). */
 ccc_result ccc_hom_clear_and_free(ccc_handle_ordered_map *hom,
-                                  ccc_any_destructor_fn *fn);
+                                  ccc_any_type_destructor_fn *fn);
 
 /** @brief Frees all slots in the hom and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -756,9 +758,10 @@ to reserve memory so to is it required to free memory.
 
 This function will work normally if called on a hom with allocation permission
 however the normal ccc_hom_clear_and_free is sufficient for that use case. */
-ccc_result ccc_hom_clear_and_free_reserve(ccc_handle_ordered_map *hom,
-                                          ccc_any_destructor_fn *destructor,
-                                          ccc_any_alloc_fn *alloc);
+ccc_result
+ccc_hom_clear_and_free_reserve(ccc_handle_ordered_map *hom,
+                               ccc_any_type_destructor_fn *destructor,
+                               ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/handle_realtime_ordered_map.h
+++ b/ccc/handle_realtime_ordered_map.h
@@ -187,7 +187,7 @@ These options allow users to stay consistent across containers with their
 memory management strategies. */
 ccc_result ccc_hrm_copy(ccc_handle_realtime_ordered_map *dst,
                         ccc_handle_realtime_ordered_map const *src,
-                        ccc_alloc_fn *fn);
+                        ccc_any_alloc_fn *fn);
 
 /** @brief Reserves space for at least to_add more elements.
 @param [in] hrm a pointer to the handle realtime ordered map.
@@ -207,7 +207,7 @@ this function can serve as a one-time reservation. This is helpful when a fixed
 size is needed but that size is only known dynamically at runtime. To free the
 hrm in such a case see the ccc_hrm_clear_and_free_reserve function. */
 ccc_result ccc_hrm_reserve(ccc_handle_realtime_ordered_map *hrm, size_t to_add,
-                           ccc_alloc_fn *fn);
+                           ccc_any_alloc_fn *fn);
 
 /**@}*/
 
@@ -448,9 +448,9 @@ to subsequent calls in the Handle Interface. */
 
 This function is intended to make the function chaining in the Handle Interface
 more succinct if the handle will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 [[nodiscard]] ccc_hromap_handle *ccc_hrm_and_modify(ccc_hromap_handle *h,
-                                                    ccc_update_fn *fn);
+                                                    ccc_any_update_fn *fn);
 
 /** @brief Modifies the provided handle if it is Occupied.
 @param [in] h the handle obtained from a handle function or macro.
@@ -458,10 +458,10 @@ without the need of the auxiliary argument a ccc_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated handle if it was Occupied or the unmodified vacant handle.
 
-This function makes full use of a ccc_update_fn capability, meaning a complete
-ccc_update object will be passed to the update function callback. */
+This function makes full use of a ccc_any_update_fn capability, meaning a
+complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_hromap_handle *
-ccc_hrm_and_modify_aux(ccc_hromap_handle *h, ccc_update_fn *fn, void *aux);
+ccc_hrm_and_modify_aux(ccc_hromap_handle *h, ccc_any_update_fn *fn, void *aux);
 
 /** @brief Modify an Occupied handle with a closure over user type T.
 @param [in] handle_realtime_ordered_map_handle_ptr a pointer to the obtained
@@ -616,7 +616,7 @@ forfeit.
 
 If NULL is passed as the destructor function time is O(1), else O(size). */
 ccc_result ccc_hrm_clear(ccc_handle_realtime_ordered_map *hrm,
-                         ccc_destructor_fn *fn);
+                         ccc_any_destructor_fn *fn);
 
 /** @brief Frees all slots in the map and frees the underlying buffer.
 @param [in] hrm the map to be cleared.
@@ -629,7 +629,7 @@ Otherwise, an OK result is returned.
 
 If NULL is passed as the destructor function time is O(1), else O(size). */
 ccc_result ccc_hrm_clear_and_free(ccc_handle_realtime_ordered_map *hrm,
-                                  ccc_destructor_fn *fn);
+                                  ccc_any_destructor_fn *fn);
 
 /** @brief Frees all slots in the hrm and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -643,7 +643,7 @@ the allocation function when called.
 @return the result of free operation. OK if success, or an error status to
 indicate the error.
 @warning It is an error to call this function on a hrm that was not reserved
-with the provided ccc_alloc_fn. The hrm must have existing memory to free.
+with the provided ccc_any_alloc_fn. The hrm must have existing memory to free.
 
 This function covers the edge case of reserving a dynamic capacity for a hrm
 at runtime but denying the hrm allocation permission to resize. This can help
@@ -658,8 +658,8 @@ to reserve memory so to is it required to free memory.
 This function will work normally if called on a hrm with allocation permission
 however the normal ccc_hrm_clear_and_free is sufficient for that use case. */
 ccc_result ccc_hrm_clear_and_free_reserve(ccc_handle_realtime_ordered_map *hrm,
-                                          ccc_destructor_fn *destructor,
-                                          ccc_alloc_fn *alloc);
+                                          ccc_any_destructor_fn *destructor,
+                                          ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/handle_realtime_ordered_map.h
+++ b/ccc/handle_realtime_ordered_map.h
@@ -448,9 +448,10 @@ to subsequent calls in the Handle Interface. */
 
 This function is intended to make the function chaining in the Handle Interface
 more succinct if the handle will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_any_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_type_update_fn can provide.
+*/
 [[nodiscard]] ccc_hromap_handle *ccc_hrm_and_modify(ccc_hromap_handle *h,
-                                                    ccc_any_update_fn *fn);
+                                                    ccc_any_type_update_fn *fn);
 
 /** @brief Modifies the provided handle if it is Occupied.
 @param [in] h the handle obtained from a handle function or macro.
@@ -458,10 +459,11 @@ without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated handle if it was Occupied or the unmodified vacant handle.
 
-This function makes full use of a ccc_any_update_fn capability, meaning a
+This function makes full use of a ccc_any_type_update_fn capability, meaning a
 complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_hromap_handle *
-ccc_hrm_and_modify_aux(ccc_hromap_handle *h, ccc_any_update_fn *fn, void *aux);
+ccc_hrm_and_modify_aux(ccc_hromap_handle *h, ccc_any_type_update_fn *fn,
+                       void *aux);
 
 /** @brief Modify an Occupied handle with a closure over user type T.
 @param [in] handle_realtime_ordered_map_handle_ptr a pointer to the obtained
@@ -616,7 +618,7 @@ forfeit.
 
 If NULL is passed as the destructor function time is O(1), else O(size). */
 ccc_result ccc_hrm_clear(ccc_handle_realtime_ordered_map *hrm,
-                         ccc_any_destructor_fn *fn);
+                         ccc_any_type_destructor_fn *fn);
 
 /** @brief Frees all slots in the map and frees the underlying buffer.
 @param [in] hrm the map to be cleared.
@@ -629,7 +631,7 @@ Otherwise, an OK result is returned.
 
 If NULL is passed as the destructor function time is O(1), else O(size). */
 ccc_result ccc_hrm_clear_and_free(ccc_handle_realtime_ordered_map *hrm,
-                                  ccc_any_destructor_fn *fn);
+                                  ccc_any_type_destructor_fn *fn);
 
 /** @brief Frees all slots in the hrm and frees the underlying buffer that was
 previously dynamically reserved with the reserve function.
@@ -657,9 +659,10 @@ to reserve memory so to is it required to free memory.
 
 This function will work normally if called on a hrm with allocation permission
 however the normal ccc_hrm_clear_and_free is sufficient for that use case. */
-ccc_result ccc_hrm_clear_and_free_reserve(ccc_handle_realtime_ordered_map *hrm,
-                                          ccc_any_destructor_fn *destructor,
-                                          ccc_any_alloc_fn *alloc);
+ccc_result
+ccc_hrm_clear_and_free_reserve(ccc_handle_realtime_ordered_map *hrm,
+                               ccc_any_type_destructor_fn *destructor,
+                               ccc_any_alloc_fn *alloc);
 
 /**@}*/
 

--- a/ccc/impl/impl_bitset.h
+++ b/ccc/impl/impl_bitset.h
@@ -32,7 +32,7 @@ struct ccc_bitset_
     ccc_bitblock_ *mem_;
     size_t sz_;
     size_t cap_;
-    ccc_alloc_fn *alloc_;
+    ccc_any_alloc_fn *alloc_;
     void *aux_;
 };
 

--- a/ccc/impl/impl_buffer.h
+++ b/ccc/impl/impl_buffer.h
@@ -32,7 +32,7 @@ struct ccc_buf_
     size_t elem_sz_;
     size_t sz_;
     size_t capacity_;
-    ccc_alloc_fn *alloc_;
+    ccc_any_alloc_fn *alloc_;
     void *aux_;
 };
 

--- a/ccc/impl/impl_doubly_linked_list.h
+++ b/ccc/impl/impl_doubly_linked_list.h
@@ -40,7 +40,7 @@ struct ccc_dll_
     size_t dll_elem_offset_;
     size_t sz_;
     ccc_any_alloc_fn *alloc_;
-    ccc_any_cmp_fn *cmp_;
+    ccc_any_type_cmp_fn *cmp_;
     void *aux_;
 };
 

--- a/ccc/impl/impl_doubly_linked_list.h
+++ b/ccc/impl/impl_doubly_linked_list.h
@@ -39,8 +39,8 @@ struct ccc_dll_
     size_t elem_sz_;
     size_t dll_elem_offset_;
     size_t sz_;
-    ccc_alloc_fn *alloc_;
-    ccc_cmp_fn *cmp_;
+    ccc_any_alloc_fn *alloc_;
+    ccc_any_cmp_fn *cmp_;
     void *aux_;
 };
 

--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -114,11 +114,11 @@ struct ccc_fhmap_
     /** The location of the key field in user type. */
     size_t key_offset_;
     /** The user callback for equality comparison. */
-    ccc_key_eq_fn *eq_fn_;
+    ccc_any_key_eq_fn *eq_fn_;
     /** The hash function provided by user. */
-    ccc_hash_fn *hash_fn_;
+    ccc_any_hash_fn *hash_fn_;
     /** The allocation function, if any. */
-    ccc_alloc_fn *alloc_fn_;
+    ccc_any_alloc_fn *alloc_fn_;
     /** Auxiliary data, if any. */
     void *aux_;
 };

--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -116,7 +116,7 @@ struct ccc_fhmap_
     /** The user callback for equality comparison. */
     ccc_any_key_eq_fn *eq_fn_;
     /** The hash function provided by user. */
-    ccc_any_hash_fn *hash_fn_;
+    ccc_any_key_hash_fn *hash_fn_;
     /** The allocation function, if any. */
     ccc_any_alloc_fn *alloc_fn_;
     /** Auxiliary data, if any. */

--- a/ccc/impl/impl_flat_priority_queue.h
+++ b/ccc/impl/impl_flat_priority_queue.h
@@ -30,7 +30,7 @@ limitations under the License.
 struct ccc_fpq_
 {
     ccc_buffer buf_;
-    ccc_any_cmp_fn *cmp_;
+    ccc_any_type_cmp_fn *cmp_;
     ccc_threeway_cmp order_;
 };
 

--- a/ccc/impl/impl_flat_priority_queue.h
+++ b/ccc/impl/impl_flat_priority_queue.h
@@ -30,7 +30,7 @@ limitations under the License.
 struct ccc_fpq_
 {
     ccc_buffer buf_;
-    ccc_cmp_fn *cmp_;
+    ccc_any_cmp_fn *cmp_;
     ccc_threeway_cmp order_;
 };
 

--- a/ccc/impl/impl_handle_ordered_map.h
+++ b/ccc/impl/impl_handle_ordered_map.h
@@ -53,7 +53,7 @@ struct ccc_homap_
     size_t free_list_;        /** The start of the free singly linked list. */
     size_t key_offset_;       /** Where user key can be found in type. */
     size_t node_elem_offset_; /** Where intrusive elem is found in type. */
-    ccc_key_cmp_fn *cmp_;     /** The provided key comparison function. */
+    ccc_any_key_cmp_fn *cmp_; /** The provided key comparison function. */
 };
 
 /** @private */

--- a/ccc/impl/impl_handle_realtime_ordered_map.h
+++ b/ccc/impl/impl_handle_realtime_ordered_map.h
@@ -55,7 +55,7 @@ struct ccc_hromap_
     size_t free_list_;        /** The start of the free singly linked list. */
     size_t key_offset_;       /** Where user key can be found in type. */
     size_t node_elem_offset_; /** Where intrusive elem is found in type. */
-    ccc_key_cmp_fn *cmp_;     /** The provided key comparison function. */
+    ccc_any_key_cmp_fn *cmp_; /** The provided key comparison function. */
 };
 
 /** @private */

--- a/ccc/impl/impl_ordered_map.h
+++ b/ccc/impl/impl_ordered_map.h
@@ -37,8 +37,8 @@ struct ccc_omap_
 {
     struct ccc_omap_elem_ *root_;
     struct ccc_omap_elem_ end_;
-    ccc_alloc_fn *alloc_;
-    ccc_key_cmp_fn *cmp_;
+    ccc_any_alloc_fn *alloc_;
+    ccc_any_key_cmp_fn *cmp_;
     void *aux_;
     size_t size_;
     size_t elem_sz_;

--- a/ccc/impl/impl_ordered_multimap.h
+++ b/ccc/impl/impl_ordered_multimap.h
@@ -59,8 +59,8 @@ struct ccc_ommap_
 {
     struct ccc_ommap_elem_ *root_;
     struct ccc_ommap_elem_ end_;
-    ccc_alloc_fn *alloc_;
-    ccc_key_cmp_fn *cmp_;
+    ccc_any_alloc_fn *alloc_;
+    ccc_any_key_cmp_fn *cmp_;
     void *aux_;
     size_t size_;
     size_t elem_sz_;

--- a/ccc/impl/impl_priority_queue.h
+++ b/ccc/impl/impl_priority_queue.h
@@ -41,7 +41,7 @@ struct ccc_pq_
     size_t pq_elem_offset_;
     size_t elem_sz_;
     ccc_any_alloc_fn *alloc_;
-    ccc_any_cmp_fn *cmp_;
+    ccc_any_type_cmp_fn *cmp_;
     ccc_threeway_cmp order_;
     void *aux_;
 };

--- a/ccc/impl/impl_priority_queue.h
+++ b/ccc/impl/impl_priority_queue.h
@@ -40,8 +40,8 @@ struct ccc_pq_
     size_t sz_;
     size_t pq_elem_offset_;
     size_t elem_sz_;
-    ccc_alloc_fn *alloc_;
-    ccc_cmp_fn *cmp_;
+    ccc_any_alloc_fn *alloc_;
+    ccc_any_cmp_fn *cmp_;
     ccc_threeway_cmp order_;
     void *aux_;
 };

--- a/ccc/impl/impl_realtime_ordered_map.h
+++ b/ccc/impl/impl_realtime_ordered_map.h
@@ -43,8 +43,8 @@ struct ccc_romap_
     size_t key_offset_;
     size_t node_elem_offset_;
     size_t elem_sz_;
-    ccc_alloc_fn *alloc_;
-    ccc_key_cmp_fn *cmp_;
+    ccc_any_alloc_fn *alloc_;
+    ccc_any_key_cmp_fn *cmp_;
     void *aux_;
 };
 

--- a/ccc/impl/impl_singly_linked_list.h
+++ b/ccc/impl/impl_singly_linked_list.h
@@ -39,7 +39,7 @@ struct ccc_sll_
     size_t elem_sz_;
     size_t sll_elem_offset_;
     ccc_any_alloc_fn *alloc_;
-    ccc_any_cmp_fn *cmp_;
+    ccc_any_type_cmp_fn *cmp_;
     void *aux_;
 };
 

--- a/ccc/impl/impl_singly_linked_list.h
+++ b/ccc/impl/impl_singly_linked_list.h
@@ -38,8 +38,8 @@ struct ccc_sll_
     size_t sz_;
     size_t elem_sz_;
     size_t sll_elem_offset_;
-    ccc_alloc_fn *alloc_;
-    ccc_cmp_fn *cmp_;
+    ccc_any_alloc_fn *alloc_;
+    ccc_any_cmp_fn *cmp_;
     void *aux_;
 };
 

--- a/ccc/ordered_map.h
+++ b/ccc/ordered_map.h
@@ -307,9 +307,9 @@ to subsequent calls in the Entry Interface. */
 
 This function is intended to make the function chaining in the Entry Interface
 more succinct if the entry will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 [[nodiscard]] ccc_omap_entry *ccc_om_and_modify(ccc_omap_entry *e,
-                                                ccc_update_fn *fn);
+                                                ccc_any_update_fn *fn);
 
 /** @brief Modifies the provided entry if it is Occupied.
 @param [in] e the entry obtained from an entry function or macro.
@@ -317,10 +317,10 @@ without the need of the auxiliary argument a ccc_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated entry if it was Occupied or the unmodified vacant entry.
 
-This function makes full use of a ccc_update_fn capability, meaning a complete
-ccc_update object will be passed to the update function callback. */
+This function makes full use of a ccc_any_update_fn capability, meaning a
+complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_omap_entry *
-ccc_om_and_modify_aux(ccc_omap_entry *e, ccc_update_fn *fn, void *aux);
+ccc_om_and_modify_aux(ccc_omap_entry *e, ccc_any_update_fn *fn, void *aux);
 
 /** @brief Modify an Occupied entry with a closure over user type T.
 @param [in] ordered_map_entry_ptr a pointer to the obtained entry.
@@ -597,7 +597,7 @@ will occur.
 If the container has not been given allocation permission, then the destructor
 may free elements or not depending on how and when the user wishes to free
 elements of the map according to their own memory management schemes. */
-ccc_result ccc_om_clear(ccc_ordered_map *om, ccc_destructor_fn *destructor);
+ccc_result ccc_om_clear(ccc_ordered_map *om, ccc_any_destructor_fn *destructor);
 
 /**@}*/
 

--- a/ccc/ordered_map.h
+++ b/ccc/ordered_map.h
@@ -307,9 +307,10 @@ to subsequent calls in the Entry Interface. */
 
 This function is intended to make the function chaining in the Entry Interface
 more succinct if the entry will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_any_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_type_update_fn can provide.
+*/
 [[nodiscard]] ccc_omap_entry *ccc_om_and_modify(ccc_omap_entry *e,
-                                                ccc_any_update_fn *fn);
+                                                ccc_any_type_update_fn *fn);
 
 /** @brief Modifies the provided entry if it is Occupied.
 @param [in] e the entry obtained from an entry function or macro.
@@ -317,10 +318,10 @@ without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated entry if it was Occupied or the unmodified vacant entry.
 
-This function makes full use of a ccc_any_update_fn capability, meaning a
+This function makes full use of a ccc_any_type_update_fn capability, meaning a
 complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_omap_entry *
-ccc_om_and_modify_aux(ccc_omap_entry *e, ccc_any_update_fn *fn, void *aux);
+ccc_om_and_modify_aux(ccc_omap_entry *e, ccc_any_type_update_fn *fn, void *aux);
 
 /** @brief Modify an Occupied entry with a closure over user type T.
 @param [in] ordered_map_entry_ptr a pointer to the obtained entry.
@@ -597,7 +598,8 @@ will occur.
 If the container has not been given allocation permission, then the destructor
 may free elements or not depending on how and when the user wishes to free
 elements of the map according to their own memory management schemes. */
-ccc_result ccc_om_clear(ccc_ordered_map *om, ccc_any_destructor_fn *destructor);
+ccc_result ccc_om_clear(ccc_ordered_map *om,
+                        ccc_any_type_destructor_fn *destructor);
 
 /**@}*/
 

--- a/ccc/ordered_multimap.h
+++ b/ccc/ordered_multimap.h
@@ -95,9 +95,10 @@ Initialize the container with memory, callbacks, and permissions. */
 @param [in] any_struct_name the struct the user intends to store.
 @param [in] ommap_elem_field the name of the field with the intrusive element.
 @param [in] key_field the name of the field used as the multimap key.
-@param [in] key_cmp_fn the ccc_key_cmp_fn (types.h) used to compare the key to
-the current stored element under considertion during a map operation.
-@param [in] alloc_fn the ccc_alloc_fn (types.h) used to allocate nodes or NULL.
+@param [in] key_cmp_fn the ccc_any_key_cmp_fn (types.h) used to compare the key
+to the current stored element under considertion during a map operation.
+@param [in] alloc_fn the ccc_any_alloc_fn (types.h) used to allocate nodes or
+NULL.
 @param [in] aux any aux data needed for compare, print, or destruction.
 @return the initialized ordered multimap. Use this initializer on the right
 hand side of the variable at compile or run time
@@ -275,7 +276,7 @@ called on the entry with NULL as the auxiliary argument if the entry is
 Occupied, otherwise the function is not called. If either arguments to the
 function are NULL, NULL is returned. */
 [[nodiscard]] ccc_ommap_entry *ccc_omm_and_modify(ccc_ommap_entry *e,
-                                                  ccc_update_fn *fn);
+                                                  ccc_any_update_fn *fn);
 
 /** @brief Return a reference to the provided entry modified with fn and
 auxiliary data aux if Occupied.
@@ -287,7 +288,7 @@ called on the entry with aux as the auxiliary argument if the entry is
 Occupied, otherwise the function is not called. If any arguments to the
 function are NULL, NULL is returned. */
 [[nodiscard]] ccc_ommap_entry *
-ccc_omm_and_modify_aux(ccc_ommap_entry *e, ccc_update_fn *fn, void *aux);
+ccc_omm_and_modify_aux(ccc_ommap_entry *e, ccc_any_update_fn *fn, void *aux);
 
 /** @brief Modify an Occupied entry with a closure over user type T.
 @param [in] ordered_multimap_entry_ptr the address of the multimap entry.
@@ -523,7 +524,7 @@ arguments are provided or it can be deduced that key_val_handle is not a member
 of the container. */
 [[nodiscard]] ccc_tribool ccc_omm_update(ccc_ordered_multimap *mm,
                                          ccc_ommap_elem *key_val_handle,
-                                         ccc_update_fn *fn, void *aux);
+                                         ccc_any_update_fn *fn, void *aux);
 
 /** @brief Increases an element key that is currently tracked directly as a
 member of the map. Amortized O(lg N).
@@ -538,7 +539,7 @@ arguments are provided or it can be deduced that key_val_handle is not a member
 of the container. */
 [[nodiscard]] ccc_tribool ccc_omm_increase(ccc_ordered_multimap *mm,
                                            ccc_ommap_elem *key_val_handle,
-                                           ccc_update_fn *fn, void *aux);
+                                           ccc_any_update_fn *fn, void *aux);
 
 /** @brief Decreases an element key that is currently tracked directly as a
 member of the map. Amortized O(lg N).
@@ -553,7 +554,7 @@ arguments are provided or it can be deduced that key_val_handle is not a member
 of the container. */
 [[nodiscard]] ccc_tribool ccc_omm_decrease(ccc_ordered_multimap *mm,
                                            ccc_ommap_elem *key_val_handle,
-                                           ccc_update_fn *fn, void *aux);
+                                           ccc_any_update_fn *fn, void *aux);
 
 /**@}*/
 
@@ -576,7 +577,7 @@ If the container has not been given allocation permission, then the destructor
 may free elements or not depending on how and when the user wishes to free
 elements of the map according to their own memory management schemes. */
 ccc_result ccc_omm_clear(ccc_ordered_multimap *mm,
-                         ccc_destructor_fn *destructor);
+                         ccc_any_destructor_fn *destructor);
 
 /**@}*/
 

--- a/ccc/ordered_multimap.h
+++ b/ccc/ordered_multimap.h
@@ -276,7 +276,7 @@ called on the entry with NULL as the auxiliary argument if the entry is
 Occupied, otherwise the function is not called. If either arguments to the
 function are NULL, NULL is returned. */
 [[nodiscard]] ccc_ommap_entry *ccc_omm_and_modify(ccc_ommap_entry *e,
-                                                  ccc_any_update_fn *fn);
+                                                  ccc_any_type_update_fn *fn);
 
 /** @brief Return a reference to the provided entry modified with fn and
 auxiliary data aux if Occupied.
@@ -288,7 +288,8 @@ called on the entry with aux as the auxiliary argument if the entry is
 Occupied, otherwise the function is not called. If any arguments to the
 function are NULL, NULL is returned. */
 [[nodiscard]] ccc_ommap_entry *
-ccc_omm_and_modify_aux(ccc_ommap_entry *e, ccc_any_update_fn *fn, void *aux);
+ccc_omm_and_modify_aux(ccc_ommap_entry *e, ccc_any_type_update_fn *fn,
+                       void *aux);
 
 /** @brief Modify an Occupied entry with a closure over user type T.
 @param [in] ordered_multimap_entry_ptr the address of the multimap entry.
@@ -524,7 +525,7 @@ arguments are provided or it can be deduced that key_val_handle is not a member
 of the container. */
 [[nodiscard]] ccc_tribool ccc_omm_update(ccc_ordered_multimap *mm,
                                          ccc_ommap_elem *key_val_handle,
-                                         ccc_any_update_fn *fn, void *aux);
+                                         ccc_any_type_update_fn *fn, void *aux);
 
 /** @brief Increases an element key that is currently tracked directly as a
 member of the map. Amortized O(lg N).
@@ -539,7 +540,8 @@ arguments are provided or it can be deduced that key_val_handle is not a member
 of the container. */
 [[nodiscard]] ccc_tribool ccc_omm_increase(ccc_ordered_multimap *mm,
                                            ccc_ommap_elem *key_val_handle,
-                                           ccc_any_update_fn *fn, void *aux);
+                                           ccc_any_type_update_fn *fn,
+                                           void *aux);
 
 /** @brief Decreases an element key that is currently tracked directly as a
 member of the map. Amortized O(lg N).
@@ -554,7 +556,8 @@ arguments are provided or it can be deduced that key_val_handle is not a member
 of the container. */
 [[nodiscard]] ccc_tribool ccc_omm_decrease(ccc_ordered_multimap *mm,
                                            ccc_ommap_elem *key_val_handle,
-                                           ccc_any_update_fn *fn, void *aux);
+                                           ccc_any_type_update_fn *fn,
+                                           void *aux);
 
 /**@}*/
 
@@ -577,7 +580,7 @@ If the container has not been given allocation permission, then the destructor
 may free elements or not depending on how and when the user wishes to free
 elements of the map according to their own memory management schemes. */
 ccc_result ccc_omm_clear(ccc_ordered_multimap *mm,
-                         ccc_any_destructor_fn *destructor);
+                         ccc_any_type_destructor_fn *destructor);
 
 /**@}*/
 

--- a/ccc/priority_queue.h
+++ b/ccc/priority_queue.h
@@ -148,7 +148,7 @@ Note that this operation may incur unnecessary overhead if the user can't
 deduce if an increase or decrease is occurring. See the increase and decrease
 operations. O(1) best case, O(lgN) worst case. */
 ccc_tribool ccc_pq_update(ccc_priority_queue *pq, ccc_pq_elem *elem,
-                          ccc_update_fn *fn, void *aux);
+                          ccc_any_update_fn *fn, void *aux);
 
 /** @brief Update the priority in the user type stored in the container.
 @param [in] pq_ptr a pointer to the priority queue.
@@ -197,7 +197,7 @@ value. If this is a max heap O(1), otherwise O(lgN).
 While the best case operation is O(1) the impact of restructuring on future pops
 from the pq creates an amortized o(lgN) runtime for this function. */
 ccc_tribool ccc_pq_increase(ccc_priority_queue *pq, ccc_pq_elem *elem,
-                            ccc_update_fn *fn, void *aux);
+                            ccc_any_update_fn *fn, void *aux);
 
 /** @brief Increases the priority of the user type stored in the container.
 @param [in] pq_ptr a pointer to the priority queue.
@@ -249,7 +249,7 @@ value. If this is a min heap O(1), otherwise O(lgN).
 While the best case operation is O(1) the impact of restructuring on future pops
 from the pq creates an amortized o(lgN) runtime for this function. */
 ccc_tribool ccc_pq_decrease(ccc_priority_queue *pq, ccc_pq_elem *elem,
-                            ccc_update_fn *fn, void *aux);
+                            ccc_any_update_fn *fn, void *aux);
 
 /** @brief Decreases the priority of the user type stored in the container.
 @param [in] pq_ptr a pointer to the priority queue.
@@ -304,7 +304,7 @@ If allocation is not allowed, the user may free their stored types in the
 destructor function if they wish to do so. The container simply removes all
 the elements from the pq, calling fn on each user type if provided, and sets the
 size to zero. */
-ccc_result ccc_pq_clear(ccc_priority_queue *pq, ccc_destructor_fn *fn);
+ccc_result ccc_pq_clear(ccc_priority_queue *pq, ccc_any_destructor_fn *fn);
 
 /**@}*/
 

--- a/ccc/priority_queue.h
+++ b/ccc/priority_queue.h
@@ -148,7 +148,7 @@ Note that this operation may incur unnecessary overhead if the user can't
 deduce if an increase or decrease is occurring. See the increase and decrease
 operations. O(1) best case, O(lgN) worst case. */
 ccc_tribool ccc_pq_update(ccc_priority_queue *pq, ccc_pq_elem *elem,
-                          ccc_any_update_fn *fn, void *aux);
+                          ccc_any_type_update_fn *fn, void *aux);
 
 /** @brief Update the priority in the user type stored in the container.
 @param [in] pq_ptr a pointer to the priority queue.
@@ -197,7 +197,7 @@ value. If this is a max heap O(1), otherwise O(lgN).
 While the best case operation is O(1) the impact of restructuring on future pops
 from the pq creates an amortized o(lgN) runtime for this function. */
 ccc_tribool ccc_pq_increase(ccc_priority_queue *pq, ccc_pq_elem *elem,
-                            ccc_any_update_fn *fn, void *aux);
+                            ccc_any_type_update_fn *fn, void *aux);
 
 /** @brief Increases the priority of the user type stored in the container.
 @param [in] pq_ptr a pointer to the priority queue.
@@ -249,7 +249,7 @@ value. If this is a min heap O(1), otherwise O(lgN).
 While the best case operation is O(1) the impact of restructuring on future pops
 from the pq creates an amortized o(lgN) runtime for this function. */
 ccc_tribool ccc_pq_decrease(ccc_priority_queue *pq, ccc_pq_elem *elem,
-                            ccc_any_update_fn *fn, void *aux);
+                            ccc_any_type_update_fn *fn, void *aux);
 
 /** @brief Decreases the priority of the user type stored in the container.
 @param [in] pq_ptr a pointer to the priority queue.
@@ -304,7 +304,7 @@ If allocation is not allowed, the user may free their stored types in the
 destructor function if they wish to do so. The container simply removes all
 the elements from the pq, calling fn on each user type if provided, and sets the
 size to zero. */
-ccc_result ccc_pq_clear(ccc_priority_queue *pq, ccc_any_destructor_fn *fn);
+ccc_result ccc_pq_clear(ccc_priority_queue *pq, ccc_any_type_destructor_fn *fn);
 
 /**@}*/
 

--- a/ccc/realtime_ordered_map.h
+++ b/ccc/realtime_ordered_map.h
@@ -315,9 +315,10 @@ to subsequent calls in the Entry Interface. */
 
 This function is intended to make the function chaining in the Entry Interface
 more succinct if the entry will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_any_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_type_update_fn can provide.
+*/
 [[nodiscard]] ccc_romap_entry *ccc_rom_and_modify(ccc_romap_entry *e,
-                                                  ccc_any_update_fn *fn);
+                                                  ccc_any_type_update_fn *fn);
 
 /** @brief Modifies the provided entry if it is Occupied.
 @param [in] e the entry obtained from an entry function or macro.
@@ -325,10 +326,11 @@ without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated entry if it was Occupied or the unmodified vacant entry.
 
-This function makes full use of a ccc_any_update_fn capability, meaning a
+This function makes full use of a ccc_any_type_update_fn capability, meaning a
 complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_romap_entry *
-ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_any_update_fn *fn, void *aux);
+ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_any_type_update_fn *fn,
+                       void *aux);
 
 /** @brief Modify an Occupied entry with a closure over user type T.
 @param [in] realtime_ordered_map_entry_ptr a pointer to the obtained entry.
@@ -488,7 +490,7 @@ If the container has not been given allocation permission, then the destructor
 may free elements or not depending on how and when the user wishes to free
 elements of the map according to their own memory management schemes. */
 ccc_result ccc_rom_clear(ccc_realtime_ordered_map *rom,
-                         ccc_any_destructor_fn *destructor);
+                         ccc_any_type_destructor_fn *destructor);
 
 /**@}*/
 

--- a/ccc/realtime_ordered_map.h
+++ b/ccc/realtime_ordered_map.h
@@ -315,9 +315,9 @@ to subsequent calls in the Entry Interface. */
 
 This function is intended to make the function chaining in the Entry Interface
 more succinct if the entry will be modified in place based on its own value
-without the need of the auxiliary argument a ccc_update_fn can provide. */
+without the need of the auxiliary argument a ccc_any_update_fn can provide. */
 [[nodiscard]] ccc_romap_entry *ccc_rom_and_modify(ccc_romap_entry *e,
-                                                  ccc_update_fn *fn);
+                                                  ccc_any_update_fn *fn);
 
 /** @brief Modifies the provided entry if it is Occupied.
 @param [in] e the entry obtained from an entry function or macro.
@@ -325,10 +325,10 @@ without the need of the auxiliary argument a ccc_update_fn can provide. */
 @param [in] aux auxiliary data required for the update.
 @return the updated entry if it was Occupied or the unmodified vacant entry.
 
-This function makes full use of a ccc_update_fn capability, meaning a complete
-ccc_update object will be passed to the update function callback. */
+This function makes full use of a ccc_any_update_fn capability, meaning a
+complete ccc_update object will be passed to the update function callback. */
 [[nodiscard]] ccc_romap_entry *
-ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_update_fn *fn, void *aux);
+ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_any_update_fn *fn, void *aux);
 
 /** @brief Modify an Occupied entry with a closure over user type T.
 @param [in] realtime_ordered_map_entry_ptr a pointer to the obtained entry.
@@ -488,7 +488,7 @@ If the container has not been given allocation permission, then the destructor
 may free elements or not depending on how and when the user wishes to free
 elements of the map according to their own memory management schemes. */
 ccc_result ccc_rom_clear(ccc_realtime_ordered_map *rom,
-                         ccc_destructor_fn *destructor);
+                         ccc_any_destructor_fn *destructor);
 
 /**@}*/
 

--- a/ccc/singly_linked_list.h
+++ b/ccc/singly_linked_list.h
@@ -229,7 +229,7 @@ If allocation is not allowed fn may free memory or not as the user sees fit.
 The user is responsible for managing the memory that wraps each intrusive
 handle as the elements are simply removed from the list. */
 ccc_result ccc_sll_clear(ccc_singly_linked_list *sll,
-                         ccc_any_destructor_fn *fn);
+                         ccc_any_type_destructor_fn *fn);
 
 /**@}*/
 

--- a/ccc/singly_linked_list.h
+++ b/ccc/singly_linked_list.h
@@ -228,7 +228,8 @@ It should only perform other necessary cleanup or state management.
 If allocation is not allowed fn may free memory or not as the user sees fit.
 The user is responsible for managing the memory that wraps each intrusive
 handle as the elements are simply removed from the list. */
-ccc_result ccc_sll_clear(ccc_singly_linked_list *sll, ccc_destructor_fn *fn);
+ccc_result ccc_sll_clear(ccc_singly_linked_list *sll,
+                         ccc_any_destructor_fn *fn);
 
 /**@}*/
 

--- a/ccc/types.h
+++ b/ccc/types.h
@@ -207,7 +207,7 @@ typedef struct
     void const *const any_type_rhs;
     /** A reference to aux data provided to container on initialization. */
     void *aux;
-} ccc_any_cmp;
+} ccc_any_type_cmp;
 
 /** @brief A key comparison helper to avoid argument swapping.
 
@@ -317,7 +317,7 @@ A three-way comparison return value is expected and the two containers being
 compared are guaranteed to be non-NULL and pointing to the base of the user type
 stored in the container. Aux may be NULL if no aux is provided on
 initialization. */
-typedef ccc_threeway_cmp ccc_any_cmp_fn(ccc_any_cmp);
+typedef ccc_threeway_cmp ccc_any_type_cmp_fn(ccc_any_type_cmp);
 
 /** @brief A callback function for modifying an element in the container.
 
@@ -326,7 +326,7 @@ is available. The container pointer points to the base of the user type and is
 not NULL. Aux may be NULL if no aux is provided on initialization. An update
 function is used when a container Interface exposes functions to modify the key
 or value used to determine sorted order of elements in the container. */
-typedef void ccc_any_update_fn(ccc_any_type);
+typedef void ccc_any_type_update_fn(ccc_any_type);
 
 /** @brief A callback function for destroying an element in the container.
 
@@ -344,7 +344,7 @@ container frees. If the user has not given permission to the container to
 allocate memory, this a good function in which to free each element, if
 desired; any program state can be maintained then the element can be freed by
 the user in this function as the final step. */
-typedef void ccc_any_destructor_fn(ccc_any_type);
+typedef void ccc_any_type_destructor_fn(ccc_any_type);
 
 /** @brief A callback function to determining equality between two stored keys.
 
@@ -365,7 +365,7 @@ typedef ccc_threeway_cmp ccc_any_key_cmp_fn(ccc_any_key_cmp);
 
 A reference to any aux data provided on initialization is also available.
 Return the complete hash value as determined by the user hashing algorithm. */
-typedef uint64_t ccc_any_hash_fn(ccc_any_key to_hash);
+typedef uint64_t ccc_any_key_hash_fn(ccc_any_key to_hash);
 
 /**@}*/
 
@@ -552,17 +552,17 @@ typedef ccc_handle handle;
 typedef ccc_handle_i handle_i;
 typedef ccc_result result;
 typedef ccc_threeway_cmp threeway_cmp;
-typedef ccc_any_alloc_fn any_alloc_fn;
-typedef ccc_any_cmp any_cmp;
-typedef ccc_any_key_cmp any_key_cmp;
 typedef ccc_any_type any_type;
+typedef ccc_any_type_cmp any_type_cmp;
 typedef ccc_any_key any_key;
-typedef ccc_any_cmp_fn any_cmp_fn;
-typedef ccc_any_update_fn any_update_fn;
-typedef ccc_any_destructor_fn any_destructor_fn;
+typedef ccc_any_key_cmp any_key_cmp;
+typedef ccc_any_alloc_fn any_alloc_fn;
+typedef ccc_any_type_cmp_fn any_type_cmp_fn;
+typedef ccc_any_type_update_fn any_type_update_fn;
+typedef ccc_any_type_destructor_fn any_type_destructor_fn;
 typedef ccc_any_key_eq_fn any_key_eq_fn;
 typedef ccc_any_key_cmp_fn any_key_cmp_fn;
-typedef ccc_any_hash_fn any_hash_fn;
+typedef ccc_any_key_hash_fn any_key_hash_fn;
 #    define entry_occupied(entry_ptr) ccc_entry_occupied(entry_ptr)
 #    define entry_insert_error(entry_ptr) ccc_entry_insert_error(entry_ptr)
 #    define entry_unwrap(entry_ptr) ccc_entry_unwrap(entry_ptr)

--- a/samples/graph.c
+++ b/samples/graph.c
@@ -282,8 +282,8 @@ static struct int_conversion parse_digits(str_view, int lower_bound,
 static struct path_request parse_path_request(struct graph *, str_view);
 static void help(void);
 
-static threeway_cmp cmp_pq_costs(cmp);
-static ccc_tribool eq_parent_cells(key_cmp);
+static threeway_cmp cmp_pq_costs(any_cmp);
+static ccc_tribool eq_parent_cells(any_key_cmp);
 static uint64_t hash_parent_cells(any_key point_struct);
 static uint64_t hash_64_bits(uint64_t);
 
@@ -1038,10 +1038,10 @@ build_path_outline(struct graph *graph)
 /*====================    Data Structure Helpers    =========================*/
 
 static ccc_tribool
-eq_parent_cells(key_cmp const c)
+eq_parent_cells(any_key_cmp const c)
 {
     struct path_backtrack_cell const *const pc = c.any_type_rhs;
-    struct point const *const p = c.key_lhs;
+    struct point const *const p = c.any_key_lhs;
     return pc->current.r == p->r && pc->current.c == p->c;
 }
 
@@ -1054,7 +1054,7 @@ hash_parent_cells(any_key const point_struct)
 }
 
 static threeway_cmp
-cmp_pq_costs(cmp const cost_cmp)
+cmp_pq_costs(any_cmp const cost_cmp)
 {
     struct dijkstra_vertex const *const a = cost_cmp.any_type_lhs;
     struct dijkstra_vertex const *const b = cost_cmp.any_type_rhs;

--- a/samples/graph.c
+++ b/samples/graph.c
@@ -1040,8 +1040,8 @@ build_path_outline(struct graph *graph)
 static ccc_tribool
 eq_parent_cells(any_key_cmp const c)
 {
-    struct path_backtrack_cell const *const pc = c.any_type_rhs;
     struct point const *const p = c.any_key_lhs;
+    struct path_backtrack_cell const *const pc = c.any_type_rhs;
     return pc->current.r == p->r && pc->current.c == p->c;
 }
 

--- a/samples/graph.c
+++ b/samples/graph.c
@@ -282,7 +282,7 @@ static struct int_conversion parse_digits(str_view, int lower_bound,
 static struct path_request parse_path_request(struct graph *, str_view);
 static void help(void);
 
-static threeway_cmp cmp_pq_costs(any_cmp);
+static threeway_cmp cmp_pq_costs(any_type_cmp);
 static ccc_tribool eq_parent_cells(any_key_cmp);
 static uint64_t hash_parent_cells(any_key point_struct);
 static uint64_t hash_64_bits(uint64_t);
@@ -1054,7 +1054,7 @@ hash_parent_cells(any_key const point_struct)
 }
 
 static threeway_cmp
-cmp_pq_costs(any_cmp const cost_cmp)
+cmp_pq_costs(any_type_cmp const cost_cmp)
 {
     struct dijkstra_vertex const *const a = cost_cmp.any_type_lhs;
     struct dijkstra_vertex const *const b = cost_cmp.any_type_rhs;

--- a/samples/maze.c
+++ b/samples/maze.c
@@ -142,7 +142,7 @@ static void flush_cursor_maze_coordinate(struct maze const *, int r, int c);
 static bool can_build_new_square(struct maze const *, int r, int c);
 static void help(void);
 static struct point rand_point(struct maze const *);
-static threeway_cmp cmp_prim_cells(any_cmp);
+static threeway_cmp cmp_prim_cells(any_type_cmp);
 static struct int_conversion parse_digits(str_view);
 static ccc_tribool prim_cell_eq(any_key_cmp);
 static uint64_t prim_cell_hash_fn(any_key);
@@ -325,7 +325,7 @@ hash_64_bits(uint64_t x)
 }
 
 static threeway_cmp
-cmp_prim_cells(any_cmp const cmp_cells)
+cmp_prim_cells(any_type_cmp const cmp_cells)
 {
     struct prim_cell const *const lhs = cmp_cells.any_type_lhs;
     struct prim_cell const *const rhs = cmp_cells.any_type_rhs;

--- a/samples/maze.c
+++ b/samples/maze.c
@@ -142,9 +142,9 @@ static void flush_cursor_maze_coordinate(struct maze const *, int r, int c);
 static bool can_build_new_square(struct maze const *, int r, int c);
 static void help(void);
 static struct point rand_point(struct maze const *);
-static threeway_cmp cmp_prim_cells(cmp);
+static threeway_cmp cmp_prim_cells(any_cmp);
 static struct int_conversion parse_digits(str_view);
-static ccc_tribool prim_cell_eq(key_cmp);
+static ccc_tribool prim_cell_eq(any_key_cmp);
 static uint64_t prim_cell_hash_fn(any_key);
 static uint64_t hash_64_bits(uint64_t);
 
@@ -297,9 +297,9 @@ animate_maze(struct maze *maze)
 /*===================     Container Support Code     ========================*/
 
 static ccc_tribool
-prim_cell_eq(key_cmp const c)
+prim_cell_eq(any_key_cmp const c)
 {
-    struct point const *const lhs = c.key_lhs;
+    struct point const *const lhs = c.any_key_lhs;
     struct prim_cell const *const rhs = c.any_type_rhs;
     return lhs->r == rhs->cell.r && lhs->c == rhs->cell.c;
 }
@@ -325,7 +325,7 @@ hash_64_bits(uint64_t x)
 }
 
 static threeway_cmp
-cmp_prim_cells(cmp const cmp_cells)
+cmp_prim_cells(any_cmp const cmp_cells)
 {
     struct prim_cell const *const lhs = cmp_cells.any_type_lhs;
     struct prim_cell const *const rhs = cmp_cells.any_type_rhs;

--- a/samples/words.c
+++ b/samples/words.c
@@ -173,8 +173,8 @@ static char *str_arena_at(struct str_arena const *, str_ofs);
 
 /* Container Functions */
 static handle_ordered_map create_frequency_map(struct str_arena *, FILE *);
-static threeway_cmp cmp_string_keys(key_cmp);
-static threeway_cmp cmp_freqs(cmp);
+static threeway_cmp cmp_string_keys(any_key_cmp);
+static threeway_cmp cmp_freqs(any_cmp);
 
 /* Misc. Functions */
 static FILE *open_file(str_view file);
@@ -668,11 +668,11 @@ str_arena_at(struct str_arena const *const a, str_ofs const i)
 /*=======================   Container Helpers    ============================*/
 
 static threeway_cmp
-cmp_string_keys(key_cmp const c)
+cmp_string_keys(any_key_cmp const c)
 {
     word const *const w = c.any_type_rhs;
     struct str_arena const *const a = c.aux;
-    str_ofs const *const id = c.key_lhs;
+    str_ofs const *const id = c.any_key_lhs;
     char const *const key_word = str_arena_at(a, *id);
     char const *const struct_word = str_arena_at(a, w->ofs);
     PROG_ASSERT(key_word && struct_word);
@@ -690,7 +690,7 @@ cmp_string_keys(key_cmp const c)
 
 /* Sorts by frequency then alphabetic order if frequencies are tied. */
 static threeway_cmp
-cmp_freqs(cmp const c)
+cmp_freqs(any_cmp const c)
 {
     struct frequency const *const lhs = c.any_type_lhs;
     struct frequency const *const rhs = c.any_type_rhs;

--- a/samples/words.c
+++ b/samples/words.c
@@ -174,7 +174,7 @@ static char *str_arena_at(struct str_arena const *, str_ofs);
 /* Container Functions */
 static handle_ordered_map create_frequency_map(struct str_arena *, FILE *);
 static threeway_cmp cmp_string_keys(any_key_cmp);
-static threeway_cmp cmp_freqs(any_cmp);
+static threeway_cmp cmp_freqs(any_type_cmp);
 
 /* Misc. Functions */
 static FILE *open_file(str_view file);
@@ -690,7 +690,7 @@ cmp_string_keys(any_key_cmp const c)
 
 /* Sorts by frequency then alphabetic order if frequencies are tied. */
 static threeway_cmp
-cmp_freqs(any_cmp const c)
+cmp_freqs(any_type_cmp const c)
 {
     struct frequency const *const lhs = c.any_type_lhs;
     struct frequency const *const rhs = c.any_type_rhs;

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -84,7 +84,7 @@ static struct group max_trailing_ones(ccc_bitblock_ b, size_t i_in_block,
 static struct group max_leading_ones(ccc_bitblock_ b, ptrdiff_t i_in_block,
                                      ptrdiff_t num_ones_remaining);
 static ccc_result maybe_resize(struct ccc_bitset_ *bs, size_t to_add,
-                               ccc_alloc_fn *);
+                               ccc_any_alloc_fn *);
 static size_t min(size_t, size_t);
 static void set_all(struct ccc_bitset_ *bs, ccc_tribool b);
 static blockwidth_t blockwidth_i(size_t bit_i);
@@ -866,7 +866,7 @@ ccc_bs_clear_and_free(ccc_bitset *const bs)
 }
 
 ccc_result
-ccc_bs_clear_and_free_reserve(ccc_bitset *bs, ccc_alloc_fn *fn)
+ccc_bs_clear_and_free_reserve(ccc_bitset *bs, ccc_any_alloc_fn *fn)
 {
     if (!bs || !fn)
     {
@@ -883,7 +883,7 @@ ccc_bs_clear_and_free_reserve(ccc_bitset *bs, ccc_alloc_fn *fn)
 
 ccc_result
 ccc_bs_reserve(ccc_bitset *const bs, size_t const to_add,
-               ccc_alloc_fn *const fn)
+               ccc_any_alloc_fn *const fn)
 {
     if (!bs || !fn)
     {
@@ -894,7 +894,7 @@ ccc_bs_reserve(ccc_bitset *const bs, size_t const to_add,
 
 ccc_result
 ccc_bs_copy(ccc_bitset *const dst, ccc_bitset const *const src,
-            ccc_alloc_fn *const fn)
+            ccc_any_alloc_fn *const fn)
 {
     if (!dst || !src || (dst->cap_ < src->cap_ && !fn))
     {
@@ -905,7 +905,7 @@ ccc_bs_copy(ccc_bitset *const dst, ccc_bitset const *const src,
        over everything else as a catch all. */
     ccc_bitblock_ *const dst_mem = dst->mem_;
     size_t const dst_cap = dst->cap_;
-    ccc_alloc_fn *const dst_alloc = dst->alloc_;
+    ccc_any_alloc_fn *const dst_alloc = dst->alloc_;
     *dst = *src;
     dst->mem_ = dst_mem;
     dst->cap_ = dst_cap;
@@ -981,7 +981,7 @@ is_subset_of(struct ccc_bitset_ const *const set,
 
 static ccc_result
 maybe_resize(struct ccc_bitset_ *const bs, size_t const to_add,
-             ccc_alloc_fn *const fn)
+             ccc_any_alloc_fn *const fn)
 {
     size_t required = bs->sz_ + to_add;
     if (required < bs->sz_)

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -27,7 +27,7 @@ static void *at(ccc_buffer const *, size_t);
 
 ccc_result
 ccc_buf_alloc(ccc_buffer *const buf, size_t const capacity,
-              ccc_alloc_fn *const fn)
+              ccc_any_alloc_fn *const fn)
 {
     if (!buf)
     {

--- a/src/doubly_linked_list.c
+++ b/src/doubly_linked_list.c
@@ -398,7 +398,7 @@ ccc_dll_is_empty(ccc_doubly_linked_list const *const l)
 }
 
 ccc_result
-ccc_dll_clear(ccc_doubly_linked_list *const l, ccc_destructor_fn *fn)
+ccc_dll_clear(ccc_doubly_linked_list *const l, ccc_any_destructor_fn *fn)
 {
     if (!l)
     {

--- a/src/doubly_linked_list.c
+++ b/src/doubly_linked_list.c
@@ -398,7 +398,7 @@ ccc_dll_is_empty(ccc_doubly_linked_list const *const l)
 }
 
 ccc_result
-ccc_dll_clear(ccc_doubly_linked_list *const l, ccc_any_destructor_fn *fn)
+ccc_dll_clear(ccc_doubly_linked_list *const l, ccc_any_type_destructor_fn *fn)
 {
     if (!l)
     {

--- a/src/flat_double_ended_queue.c
+++ b/src/flat_double_ended_queue.c
@@ -357,7 +357,7 @@ ccc_fdeq_reserve(ccc_flat_double_ended_queue *const fdeq, size_t const to_add,
 
 ccc_result
 ccc_fdeq_clear(ccc_flat_double_ended_queue *const fdeq,
-               ccc_any_destructor_fn *const destructor)
+               ccc_any_type_destructor_fn *const destructor)
 {
     if (!fdeq)
     {
@@ -379,7 +379,7 @@ ccc_fdeq_clear(ccc_flat_double_ended_queue *const fdeq,
 
 ccc_result
 ccc_fdeq_clear_and_free(ccc_flat_double_ended_queue *const fdeq,
-                        ccc_any_destructor_fn *const destructor)
+                        ccc_any_type_destructor_fn *const destructor)
 {
     if (!fdeq)
     {
@@ -406,7 +406,7 @@ ccc_fdeq_clear_and_free(ccc_flat_double_ended_queue *const fdeq,
 
 ccc_result
 ccc_fdeq_clear_and_free_reserve(ccc_flat_double_ended_queue *const fdeq,
-                                ccc_any_destructor_fn *const destructor,
+                                ccc_any_type_destructor_fn *const destructor,
                                 ccc_any_alloc_fn *const alloc)
 {
     if (!fdeq)

--- a/src/flat_double_ended_queue.c
+++ b/src/flat_double_ended_queue.c
@@ -29,7 +29,7 @@ enum : size_t
 
 /*==========================    Prototypes    ===============================*/
 
-static ccc_result maybe_resize(struct ccc_fdeq_ *, size_t, ccc_alloc_fn *);
+static ccc_result maybe_resize(struct ccc_fdeq_ *, size_t, ccc_any_alloc_fn *);
 static size_t index_of(struct ccc_fdeq_ const *, void const *);
 static void *at(struct ccc_fdeq_ const *, size_t i);
 static size_t increment(struct ccc_fdeq_ const *, size_t i);
@@ -285,7 +285,7 @@ ccc_fdeq_data(ccc_flat_double_ended_queue const *const fdeq)
 ccc_result
 ccc_fdeq_copy(ccc_flat_double_ended_queue *const dst,
               ccc_flat_double_ended_queue const *const src,
-              ccc_alloc_fn *const fn)
+              ccc_any_alloc_fn *const fn)
 {
     if (!dst || !src || src == dst
         || (dst->buf_.capacity_ < src->buf_.capacity_ && !fn))
@@ -299,7 +299,7 @@ ccc_fdeq_copy(ccc_flat_double_ended_queue *const dst,
        is a ring buffer or dynamic fdeq. */
     void *const dst_mem = dst->buf_.mem_;
     size_t const dst_cap = dst->buf_.capacity_;
-    ccc_alloc_fn *const dst_alloc = dst->buf_.alloc_;
+    ccc_any_alloc_fn *const dst_alloc = dst->buf_.alloc_;
     *dst = *src;
     dst->buf_.mem_ = dst_mem;
     dst->buf_.capacity_ = dst_cap;
@@ -346,7 +346,7 @@ ccc_fdeq_copy(ccc_flat_double_ended_queue *const dst,
 
 ccc_result
 ccc_fdeq_reserve(ccc_flat_double_ended_queue *const fdeq, size_t const to_add,
-                 ccc_alloc_fn *const fn)
+                 ccc_any_alloc_fn *const fn)
 {
     if (!fdeq || !fn)
     {
@@ -357,7 +357,7 @@ ccc_fdeq_reserve(ccc_flat_double_ended_queue *const fdeq, size_t const to_add,
 
 ccc_result
 ccc_fdeq_clear(ccc_flat_double_ended_queue *const fdeq,
-               ccc_destructor_fn *const destructor)
+               ccc_any_destructor_fn *const destructor)
 {
     if (!fdeq)
     {
@@ -379,7 +379,7 @@ ccc_fdeq_clear(ccc_flat_double_ended_queue *const fdeq,
 
 ccc_result
 ccc_fdeq_clear_and_free(ccc_flat_double_ended_queue *const fdeq,
-                        ccc_destructor_fn *const destructor)
+                        ccc_any_destructor_fn *const destructor)
 {
     if (!fdeq)
     {
@@ -406,8 +406,8 @@ ccc_fdeq_clear_and_free(ccc_flat_double_ended_queue *const fdeq,
 
 ccc_result
 ccc_fdeq_clear_and_free_reserve(ccc_flat_double_ended_queue *const fdeq,
-                                ccc_destructor_fn *const destructor,
-                                ccc_alloc_fn *const alloc)
+                                ccc_any_destructor_fn *const destructor,
+                                ccc_any_alloc_fn *const alloc)
 {
     if (!fdeq)
     {
@@ -688,7 +688,7 @@ push_range(struct ccc_fdeq_ *const fdeq, char const *const pos, size_t n,
 
 static ccc_result
 maybe_resize(struct ccc_fdeq_ *const q, size_t const additional_elems_to_add,
-             ccc_alloc_fn *const fn)
+             ccc_any_alloc_fn *const fn)
 {
     size_t required = q->buf_.sz_ + additional_elems_to_add;
     if (required < q->buf_.sz_)

--- a/src/flat_double_ended_queue.c
+++ b/src/flat_double_ended_queue.c
@@ -497,7 +497,7 @@ static void *
 alloc_front(struct ccc_fdeq_ *const fdeq)
 {
     ccc_tribool const full
-        = maybe_resize(fdeq, 0, fdeq->buf_.alloc_) != CCC_RESULT_OK;
+        = maybe_resize(fdeq, 1, fdeq->buf_.alloc_) != CCC_RESULT_OK;
     /* Should have been able to resize. Bad error. */
     if (fdeq->buf_.alloc_ && full)
     {
@@ -516,7 +516,7 @@ static void *
 alloc_back(struct ccc_fdeq_ *const fdeq)
 {
     ccc_tribool const full
-        = maybe_resize(fdeq, 0, fdeq->buf_.alloc_) != CCC_RESULT_OK;
+        = maybe_resize(fdeq, 1, fdeq->buf_.alloc_) != CCC_RESULT_OK;
     /* Should have been able to resize. Bad error. */
     if (fdeq->buf_.alloc_ && full)
     {
@@ -695,7 +695,7 @@ maybe_resize(struct ccc_fdeq_ *const q, size_t const additional_elems_to_add,
     {
         return CCC_RESULT_ARG_ERROR;
     }
-    if (required < q->buf_.capacity_)
+    if (required <= q->buf_.capacity_)
     {
         return CCC_RESULT_OK;
     }

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -441,7 +441,7 @@ ccc_fhm_remove_entry(ccc_fhmap_entry const *const e)
 }
 
 ccc_fhmap_entry *
-ccc_fhm_and_modify(ccc_fhmap_entry *const e, ccc_any_update_fn *const fn)
+ccc_fhm_and_modify(ccc_fhmap_entry *const e, ccc_any_type_update_fn *const fn)
 {
     if (e && fn && (e->impl_.handle_.stats_ & CCC_ENTRY_OCCUPIED) != 0)
     {
@@ -451,8 +451,8 @@ ccc_fhm_and_modify(ccc_fhmap_entry *const e, ccc_any_update_fn *const fn)
 }
 
 ccc_fhmap_entry *
-ccc_fhm_and_modify_aux(ccc_fhmap_entry *const e, ccc_any_update_fn *const fn,
-                       void *const aux)
+ccc_fhm_and_modify_aux(ccc_fhmap_entry *const e,
+                       ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (e && fn && (e->impl_.handle_.stats_ & CCC_ENTRY_OCCUPIED) != 0)
     {
@@ -614,7 +614,7 @@ ccc_fhm_unwrap(ccc_fhmap_entry const *const e)
 }
 
 ccc_result
-ccc_fhm_clear(ccc_flat_hash_map *const h, ccc_any_destructor_fn *const fn)
+ccc_fhm_clear(ccc_flat_hash_map *const h, ccc_any_type_destructor_fn *const fn)
 {
     if (unlikely(!h))
     {
@@ -646,7 +646,7 @@ ccc_fhm_clear(ccc_flat_hash_map *const h, ccc_any_destructor_fn *const fn)
 
 ccc_result
 ccc_fhm_clear_and_free(ccc_flat_hash_map *const h,
-                       ccc_any_destructor_fn *const fn)
+                       ccc_any_type_destructor_fn *const fn)
 {
     if (unlikely(!h || !h->data_ || !h->mask_ || !h->init_))
     {
@@ -678,7 +678,7 @@ ccc_fhm_clear_and_free(ccc_flat_hash_map *const h,
 
 ccc_result
 ccc_fhm_clear_and_free_reserve(ccc_flat_hash_map *const h,
-                               ccc_any_destructor_fn *const destructor,
+                               ccc_any_type_destructor_fn *const destructor,
                                ccc_any_alloc_fn *const alloc)
 {
     if (unlikely(!h || !h->data_ || !h->init_ || !h->mask_

--- a/src/flat_priority_queue.c
+++ b/src/flat_priority_queue.c
@@ -43,7 +43,7 @@ static void inplace_heapify(struct ccc_fpq_ *fpq, size_t n);
 
 ccc_result
 ccc_fpq_alloc(ccc_flat_priority_queue *const fpq, size_t const new_capacity,
-              ccc_alloc_fn *const fn)
+              ccc_any_alloc_fn *const fn)
 {
     if (!fpq || !fn)
     {
@@ -168,8 +168,8 @@ ccc_fpq_erase(ccc_flat_priority_queue *const fpq, void *const e)
     swap(fpq, tmp, swap_location, fpq->buf_.sz_ - 1);
     void *const erased = at(fpq, fpq->buf_.sz_ - 1);
     (void)ccc_buf_pop_back(&fpq->buf_);
-    ccc_threeway_cmp const erased_cmp
-        = fpq->cmp_((ccc_cmp){at(fpq, swap_location), erased, fpq->buf_.aux_});
+    ccc_threeway_cmp const erased_cmp = fpq->cmp_(
+        (ccc_any_cmp){at(fpq, swap_location), erased, fpq->buf_.aux_});
     if (erased_cmp == fpq->order_)
     {
         (void)bubble_up(fpq, tmp, swap_location);
@@ -184,7 +184,7 @@ ccc_fpq_erase(ccc_flat_priority_queue *const fpq, void *const e)
 
 void *
 ccc_fpq_update(ccc_flat_priority_queue *const fpq, void *const e,
-               ccc_update_fn *const fn, void *const aux)
+               ccc_any_update_fn *const fn, void *const aux)
 {
     if (!fpq || !e || !fn || ccc_buf_is_empty(&fpq->buf_))
     {
@@ -197,7 +197,7 @@ ccc_fpq_update(ccc_flat_priority_queue *const fpq, void *const e,
 /* There are no efficiency benefits in knowing an increase will occur. */
 void *
 ccc_fpq_increase(ccc_flat_priority_queue *const fpq, void *const e,
-                 ccc_update_fn *const fn, void *const aux)
+                 ccc_any_update_fn *const fn, void *const aux)
 {
     return ccc_fpq_update(fpq, e, fn, aux);
 }
@@ -205,7 +205,7 @@ ccc_fpq_increase(ccc_flat_priority_queue *const fpq, void *const e,
 /* There are no efficiency benefits in knowing an decrease will occur. */
 void *
 ccc_fpq_decrease(ccc_flat_priority_queue *const fpq, void *const e,
-                 ccc_update_fn *const fn, void *const aux)
+                 ccc_any_update_fn *const fn, void *const aux)
 {
     return ccc_fpq_update(fpq, e, fn, aux);
 }
@@ -264,7 +264,7 @@ ccc_fpq_order(ccc_flat_priority_queue const *const fpq)
 
 ccc_result
 ccc_fpq_reserve(ccc_flat_priority_queue *const fpq, size_t const to_add,
-                ccc_alloc_fn *const fn)
+                ccc_any_alloc_fn *const fn)
 {
     if (!fpq || !fn)
     {
@@ -280,7 +280,8 @@ ccc_fpq_reserve(ccc_flat_priority_queue *const fpq, size_t const to_add,
 
 ccc_result
 ccc_fpq_copy(ccc_flat_priority_queue *const dst,
-             ccc_flat_priority_queue const *const src, ccc_alloc_fn *const fn)
+             ccc_flat_priority_queue const *const src,
+             ccc_any_alloc_fn *const fn)
 {
     if (!dst || !src || src == dst
         || (dst->buf_.capacity_ < src->buf_.capacity_ && !fn))
@@ -293,7 +294,7 @@ ccc_fpq_copy(ccc_flat_priority_queue *const dst,
        same as in dst initialization because that controls permission. */
     void *const dst_mem = dst->buf_.mem_;
     size_t const dst_cap = dst->buf_.capacity_;
-    ccc_alloc_fn *const dst_alloc = dst->buf_.alloc_;
+    ccc_any_alloc_fn *const dst_alloc = dst->buf_.alloc_;
     *dst = *src;
     dst->buf_.mem_ = dst_mem;
     dst->buf_.capacity_ = dst_cap;
@@ -322,7 +323,8 @@ ccc_fpq_copy(ccc_flat_priority_queue *const dst,
 }
 
 ccc_result
-ccc_fpq_clear(ccc_flat_priority_queue *const fpq, ccc_destructor_fn *const fn)
+ccc_fpq_clear(ccc_flat_priority_queue *const fpq,
+              ccc_any_destructor_fn *const fn)
 {
     if (!fpq)
     {
@@ -341,7 +343,7 @@ ccc_fpq_clear(ccc_flat_priority_queue *const fpq, ccc_destructor_fn *const fn)
 
 ccc_result
 ccc_fpq_clear_and_free(ccc_flat_priority_queue *const fpq,
-                       ccc_destructor_fn *const fn)
+                       ccc_any_destructor_fn *const fn)
 {
     if (!fpq)
     {
@@ -360,8 +362,8 @@ ccc_fpq_clear_and_free(ccc_flat_priority_queue *const fpq,
 
 ccc_result
 ccc_fpq_clear_and_free_reserve(ccc_flat_priority_queue *const fpq,
-                               ccc_destructor_fn *const destructor,
-                               ccc_alloc_fn *const alloc)
+                               ccc_any_destructor_fn *const destructor,
+                               ccc_any_alloc_fn *const alloc)
 {
     if (!fpq)
     {
@@ -459,7 +461,7 @@ update_fixup(struct ccc_fpq_ *const fpq, void *const e)
         return bubble_down(fpq, tmp, 0);
     }
     ccc_threeway_cmp const parent_cmp = fpq->cmp_(
-        (ccc_cmp){at(fpq, i), at(fpq, (i - 1) / 2), fpq->buf_.aux_});
+        (ccc_any_cmp){at(fpq, i), at(fpq, (i - 1) / 2), fpq->buf_.aux_});
     if (parent_cmp == fpq->order_)
     {
         return bubble_up(fpq, tmp, i);
@@ -552,5 +554,6 @@ static inline ccc_tribool
 wins(struct ccc_fpq_ const *const fpq, void const *const winner,
      void const *const loser)
 {
-    return fpq->cmp_((ccc_cmp){winner, loser, fpq->buf_.aux_}) == fpq->order_;
+    return fpq->cmp_((ccc_any_cmp){winner, loser, fpq->buf_.aux_})
+           == fpq->order_;
 }

--- a/src/flat_priority_queue.c
+++ b/src/flat_priority_queue.c
@@ -169,7 +169,7 @@ ccc_fpq_erase(ccc_flat_priority_queue *const fpq, void *const e)
     void *const erased = at(fpq, fpq->buf_.sz_ - 1);
     (void)ccc_buf_pop_back(&fpq->buf_);
     ccc_threeway_cmp const erased_cmp = fpq->cmp_(
-        (ccc_any_cmp){at(fpq, swap_location), erased, fpq->buf_.aux_});
+        (ccc_any_type_cmp){at(fpq, swap_location), erased, fpq->buf_.aux_});
     if (erased_cmp == fpq->order_)
     {
         (void)bubble_up(fpq, tmp, swap_location);
@@ -184,7 +184,7 @@ ccc_fpq_erase(ccc_flat_priority_queue *const fpq, void *const e)
 
 void *
 ccc_fpq_update(ccc_flat_priority_queue *const fpq, void *const e,
-               ccc_any_update_fn *const fn, void *const aux)
+               ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!fpq || !e || !fn || ccc_buf_is_empty(&fpq->buf_))
     {
@@ -197,7 +197,7 @@ ccc_fpq_update(ccc_flat_priority_queue *const fpq, void *const e,
 /* There are no efficiency benefits in knowing an increase will occur. */
 void *
 ccc_fpq_increase(ccc_flat_priority_queue *const fpq, void *const e,
-                 ccc_any_update_fn *const fn, void *const aux)
+                 ccc_any_type_update_fn *const fn, void *const aux)
 {
     return ccc_fpq_update(fpq, e, fn, aux);
 }
@@ -205,7 +205,7 @@ ccc_fpq_increase(ccc_flat_priority_queue *const fpq, void *const e,
 /* There are no efficiency benefits in knowing an decrease will occur. */
 void *
 ccc_fpq_decrease(ccc_flat_priority_queue *const fpq, void *const e,
-                 ccc_any_update_fn *const fn, void *const aux)
+                 ccc_any_type_update_fn *const fn, void *const aux)
 {
     return ccc_fpq_update(fpq, e, fn, aux);
 }
@@ -324,7 +324,7 @@ ccc_fpq_copy(ccc_flat_priority_queue *const dst,
 
 ccc_result
 ccc_fpq_clear(ccc_flat_priority_queue *const fpq,
-              ccc_any_destructor_fn *const fn)
+              ccc_any_type_destructor_fn *const fn)
 {
     if (!fpq)
     {
@@ -343,7 +343,7 @@ ccc_fpq_clear(ccc_flat_priority_queue *const fpq,
 
 ccc_result
 ccc_fpq_clear_and_free(ccc_flat_priority_queue *const fpq,
-                       ccc_any_destructor_fn *const fn)
+                       ccc_any_type_destructor_fn *const fn)
 {
     if (!fpq)
     {
@@ -362,7 +362,7 @@ ccc_fpq_clear_and_free(ccc_flat_priority_queue *const fpq,
 
 ccc_result
 ccc_fpq_clear_and_free_reserve(ccc_flat_priority_queue *const fpq,
-                               ccc_any_destructor_fn *const destructor,
+                               ccc_any_type_destructor_fn *const destructor,
                                ccc_any_alloc_fn *const alloc)
 {
     if (!fpq)
@@ -461,7 +461,7 @@ update_fixup(struct ccc_fpq_ *const fpq, void *const e)
         return bubble_down(fpq, tmp, 0);
     }
     ccc_threeway_cmp const parent_cmp = fpq->cmp_(
-        (ccc_any_cmp){at(fpq, i), at(fpq, (i - 1) / 2), fpq->buf_.aux_});
+        (ccc_any_type_cmp){at(fpq, i), at(fpq, (i - 1) / 2), fpq->buf_.aux_});
     if (parent_cmp == fpq->order_)
     {
         return bubble_up(fpq, tmp, i);
@@ -554,6 +554,6 @@ static inline ccc_tribool
 wins(struct ccc_fpq_ const *const fpq, void const *const winner,
      void const *const loser)
 {
-    return fpq->cmp_((ccc_any_cmp){winner, loser, fpq->buf_.aux_})
+    return fpq->cmp_((ccc_any_type_cmp){winner, loser, fpq->buf_.aux_})
            == fpq->order_;
 }

--- a/src/handle_ordered_map.c
+++ b/src/handle_ordered_map.c
@@ -182,7 +182,7 @@ ccc_hom_insert_handle(ccc_homap_handle const *const h,
 }
 
 ccc_homap_handle *
-ccc_hom_and_modify(ccc_homap_handle *const h, ccc_any_update_fn *const fn)
+ccc_hom_and_modify(ccc_homap_handle *const h, ccc_any_type_update_fn *const fn)
 {
     if (!h)
     {
@@ -199,8 +199,8 @@ ccc_hom_and_modify(ccc_homap_handle *const h, ccc_any_update_fn *const fn)
 }
 
 ccc_homap_handle *
-ccc_hom_and_modify_aux(ccc_homap_handle *const h, ccc_any_update_fn *const fn,
-                       void *const aux)
+ccc_hom_and_modify_aux(ccc_homap_handle *const h,
+                       ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!h)
     {
@@ -597,7 +597,7 @@ ccc_hom_copy(ccc_handle_ordered_map *const dst,
 
 ccc_result
 ccc_hom_clear(ccc_handle_ordered_map *const hom,
-              ccc_any_destructor_fn *const fn)
+              ccc_any_type_destructor_fn *const fn)
 {
     if (!hom)
     {
@@ -623,7 +623,7 @@ ccc_hom_clear(ccc_handle_ordered_map *const hom,
 
 ccc_result
 ccc_hom_clear_and_free(ccc_handle_ordered_map *const hom,
-                       ccc_any_destructor_fn *const fn)
+                       ccc_any_type_destructor_fn *const fn)
 {
     if (!hom)
     {
@@ -647,7 +647,7 @@ ccc_hom_clear_and_free(ccc_handle_ordered_map *const hom,
 
 ccc_result
 ccc_hom_clear_and_free_reserve(ccc_handle_ordered_map *const hom,
-                               ccc_any_destructor_fn *const destructor,
+                               ccc_any_type_destructor_fn *const destructor,
                                ccc_any_alloc_fn *const alloc)
 {
     if (!hom)

--- a/src/handle_ordered_map.c
+++ b/src/handle_ordered_map.c
@@ -63,7 +63,7 @@ enum
 
 /* Returning the internal elem type with stored offsets. */
 static size_t splay(struct ccc_homap_ *t, size_t root, void const *key,
-                    ccc_key_cmp_fn *cmp_fn);
+                    ccc_any_key_cmp_fn *cmp_fn);
 static struct ccc_homap_elem_ *at(struct ccc_homap_ const *, size_t);
 static struct ccc_homap_elem_ *elem_in_slot(struct ccc_homap_ const *t,
                                             void const *slot);
@@ -90,7 +90,7 @@ static void *key_from_node(struct ccc_homap_ const *t,
 static void *key_at(struct ccc_homap_ const *t, size_t i);
 /* Returning threeway comparison with user callback. */
 static ccc_threeway_cmp cmp_elems(struct ccc_homap_ const *hom, void const *key,
-                                  size_t node, ccc_key_cmp_fn *fn);
+                                  size_t node, ccc_any_key_cmp_fn *fn);
 /* Returning read only indices for tree nodes. */
 static size_t remove_from_tree(struct ccc_homap_ *t, size_t ret);
 static size_t min_max_from(struct ccc_homap_ const *t, size_t start,
@@ -182,7 +182,7 @@ ccc_hom_insert_handle(ccc_homap_handle const *const h,
 }
 
 ccc_homap_handle *
-ccc_hom_and_modify(ccc_homap_handle *const h, ccc_update_fn *const fn)
+ccc_hom_and_modify(ccc_homap_handle *const h, ccc_any_update_fn *const fn)
 {
     if (!h)
     {
@@ -199,7 +199,7 @@ ccc_hom_and_modify(ccc_homap_handle *const h, ccc_update_fn *const fn)
 }
 
 ccc_homap_handle *
-ccc_hom_and_modify_aux(ccc_homap_handle *const h, ccc_update_fn *const fn,
+ccc_hom_and_modify_aux(ccc_homap_handle *const h, ccc_any_update_fn *const fn,
                        void *const aux)
 {
     if (!h)
@@ -513,7 +513,7 @@ ccc_hom_equal_rrange(ccc_handle_ordered_map *const hom,
 
 ccc_result
 ccc_hom_reserve(ccc_handle_ordered_map *const hom, size_t const to_add,
-                ccc_alloc_fn *const fn)
+                ccc_any_alloc_fn *const fn)
 {
     if (!hom || !fn)
     {
@@ -553,7 +553,8 @@ ccc_hom_reserve(ccc_handle_ordered_map *const hom, size_t const to_add,
 
 ccc_result
 ccc_hom_copy(ccc_handle_ordered_map *const dst,
-             ccc_handle_ordered_map const *const src, ccc_alloc_fn *const fn)
+             ccc_handle_ordered_map const *const src,
+             ccc_any_alloc_fn *const fn)
 {
     if (!dst || !src || src == dst
         || (dst->buf_.capacity_ < src->buf_.capacity_ && !fn))
@@ -566,7 +567,7 @@ ccc_hom_copy(ccc_handle_ordered_map *const dst,
        same as in dst initialization because that controls permission. */
     void *const dst_mem = dst->buf_.mem_;
     size_t const dst_cap = dst->buf_.capacity_;
-    ccc_alloc_fn *const dst_alloc = dst->buf_.alloc_;
+    ccc_any_alloc_fn *const dst_alloc = dst->buf_.alloc_;
     *dst = *src;
     dst->buf_.mem_ = dst_mem;
     dst->buf_.capacity_ = dst_cap;
@@ -595,7 +596,8 @@ ccc_hom_copy(ccc_handle_ordered_map *const dst,
 }
 
 ccc_result
-ccc_hom_clear(ccc_handle_ordered_map *const hom, ccc_destructor_fn *const fn)
+ccc_hom_clear(ccc_handle_ordered_map *const hom,
+              ccc_any_destructor_fn *const fn)
 {
     if (!hom)
     {
@@ -621,7 +623,7 @@ ccc_hom_clear(ccc_handle_ordered_map *const hom, ccc_destructor_fn *const fn)
 
 ccc_result
 ccc_hom_clear_and_free(ccc_handle_ordered_map *const hom,
-                       ccc_destructor_fn *const fn)
+                       ccc_any_destructor_fn *const fn)
 {
     if (!hom)
     {
@@ -645,8 +647,8 @@ ccc_hom_clear_and_free(ccc_handle_ordered_map *const hom,
 
 ccc_result
 ccc_hom_clear_and_free_reserve(ccc_handle_ordered_map *const hom,
-                               ccc_destructor_fn *const destructor,
-                               ccc_alloc_fn *const alloc)
+                               ccc_any_destructor_fn *const destructor,
+                               ccc_any_alloc_fn *const alloc)
 {
     if (!hom)
     {
@@ -860,7 +862,7 @@ find(struct ccc_homap_ *const t, void const *const key)
 
 static size_t
 splay(struct ccc_homap_ *const t, size_t root, void const *const key,
-      ccc_key_cmp_fn *const cmp_fn)
+      ccc_any_key_cmp_fn *const cmp_fn)
 {
     /* Pointers in an array and we can use the symmetric enum and flip it to
        choose the Left or Right subtree. Another benefit of our nil node: use it
@@ -953,11 +955,11 @@ next(struct ccc_homap_ const *const t, size_t n,
 
 static inline ccc_threeway_cmp
 cmp_elems(struct ccc_homap_ const *const hom, void const *const key,
-          size_t const node, ccc_key_cmp_fn *const fn)
+          size_t const node, ccc_any_key_cmp_fn *const fn)
 {
-    return fn((ccc_key_cmp){.key_lhs = key,
-                            .any_type_rhs = base_at(hom, node),
-                            .aux = hom->buf_.aux_});
+    return fn((ccc_any_key_cmp){.any_key_lhs = key,
+                                .any_type_rhs = base_at(hom, node),
+                                .aux = hom->buf_.aux_});
 }
 
 static size_t

--- a/src/handle_realtime_ordered_map.c
+++ b/src/handle_realtime_ordered_map.c
@@ -280,7 +280,7 @@ ccc_hrm_insert_or_assign(ccc_handle_realtime_ordered_map *const hrm,
 }
 
 ccc_hromap_handle *
-ccc_hrm_and_modify(ccc_hromap_handle *const h, ccc_any_update_fn *const fn)
+ccc_hrm_and_modify(ccc_hromap_handle *const h, ccc_any_type_update_fn *const fn)
 {
     if (h && fn && h->impl_.handle_.stats_ & CCC_ENTRY_OCCUPIED
         && h->impl_.handle_.i_ > 0)
@@ -292,8 +292,8 @@ ccc_hrm_and_modify(ccc_hromap_handle *const h, ccc_any_update_fn *const fn)
 }
 
 ccc_hromap_handle *
-ccc_hrm_and_modify_aux(ccc_hromap_handle *const h, ccc_any_update_fn *const fn,
-                       void *const aux)
+ccc_hrm_and_modify_aux(ccc_hromap_handle *const h,
+                       ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (h && fn && h->impl_.handle_.stats_ & CCC_ENTRY_OCCUPIED
         && h->impl_.handle_.stats_ > 0)
@@ -650,7 +650,7 @@ ccc_hrm_copy(ccc_handle_realtime_ordered_map *const dst,
 
 ccc_result
 ccc_hrm_clear(ccc_handle_realtime_ordered_map *const hrm,
-              ccc_any_destructor_fn *const fn)
+              ccc_any_type_destructor_fn *const fn)
 {
     if (!hrm)
     {
@@ -675,7 +675,7 @@ ccc_hrm_clear(ccc_handle_realtime_ordered_map *const hrm,
 
 ccc_result
 ccc_hrm_clear_and_free(ccc_handle_realtime_ordered_map *const hrm,
-                       ccc_any_destructor_fn *const fn)
+                       ccc_any_type_destructor_fn *const fn)
 {
     if (!hrm)
     {
@@ -699,7 +699,7 @@ ccc_hrm_clear_and_free(ccc_handle_realtime_ordered_map *const hrm,
 
 ccc_result
 ccc_hrm_clear_and_free_reserve(ccc_handle_realtime_ordered_map *const hrm,
-                               ccc_any_destructor_fn *const destructor,
+                               ccc_any_type_destructor_fn *const destructor,
                                ccc_any_alloc_fn *const alloc)
 {
     if (!hrm)

--- a/src/handle_realtime_ordered_map.c
+++ b/src/handle_realtime_ordered_map.c
@@ -117,7 +117,7 @@ static struct ccc_range_u_ equal_range(struct ccc_hromap_ const *, void const *,
 /* Returning threeway comparison with user callback. */
 static ccc_threeway_cmp cmp_elems(struct ccc_hromap_ const *hrm,
                                   void const *key, size_t node,
-                                  ccc_key_cmp_fn *fn);
+                                  ccc_any_key_cmp_fn *fn);
 /* Returning read only indices for tree nodes. */
 static size_t sibling_of(struct ccc_hromap_ const *t, size_t x);
 static size_t next(struct ccc_hromap_ const *t, size_t n,
@@ -280,7 +280,7 @@ ccc_hrm_insert_or_assign(ccc_handle_realtime_ordered_map *const hrm,
 }
 
 ccc_hromap_handle *
-ccc_hrm_and_modify(ccc_hromap_handle *const h, ccc_update_fn *const fn)
+ccc_hrm_and_modify(ccc_hromap_handle *const h, ccc_any_update_fn *const fn)
 {
     if (h && fn && h->impl_.handle_.stats_ & CCC_ENTRY_OCCUPIED
         && h->impl_.handle_.i_ > 0)
@@ -292,7 +292,7 @@ ccc_hrm_and_modify(ccc_hromap_handle *const h, ccc_update_fn *const fn)
 }
 
 ccc_hromap_handle *
-ccc_hrm_and_modify_aux(ccc_hromap_handle *const h, ccc_update_fn *const fn,
+ccc_hrm_and_modify_aux(ccc_hromap_handle *const h, ccc_any_update_fn *const fn,
                        void *const aux)
 {
     if (h && fn && h->impl_.handle_.stats_ & CCC_ENTRY_OCCUPIED
@@ -564,7 +564,7 @@ ccc_hrm_rend(ccc_handle_realtime_ordered_map const *const hrm)
 
 ccc_result
 ccc_hrm_reserve(ccc_handle_realtime_ordered_map *const hrm, size_t const to_add,
-                ccc_alloc_fn *const fn)
+                ccc_any_alloc_fn *const fn)
 {
     if (!hrm || !fn)
     {
@@ -607,7 +607,7 @@ ccc_hrm_reserve(ccc_handle_realtime_ordered_map *const hrm, size_t const to_add,
 ccc_result
 ccc_hrm_copy(ccc_handle_realtime_ordered_map *const dst,
              ccc_handle_realtime_ordered_map const *const src,
-             ccc_alloc_fn *const fn)
+             ccc_any_alloc_fn *const fn)
 {
     if (!dst || !src || src == dst
         || (dst->buf_.capacity_ < src->buf_.capacity_ && !fn))
@@ -620,7 +620,7 @@ ccc_hrm_copy(ccc_handle_realtime_ordered_map *const dst,
        same as in dst initialization because that controls permission. */
     void *const dst_mem = dst->buf_.mem_;
     size_t const dst_cap = dst->buf_.capacity_;
-    ccc_alloc_fn *const dst_alloc = dst->buf_.alloc_;
+    ccc_any_alloc_fn *const dst_alloc = dst->buf_.alloc_;
     *dst = *src;
     dst->buf_.mem_ = dst_mem;
     dst->buf_.capacity_ = dst_cap;
@@ -650,7 +650,7 @@ ccc_hrm_copy(ccc_handle_realtime_ordered_map *const dst,
 
 ccc_result
 ccc_hrm_clear(ccc_handle_realtime_ordered_map *const hrm,
-              ccc_destructor_fn *const fn)
+              ccc_any_destructor_fn *const fn)
 {
     if (!hrm)
     {
@@ -675,7 +675,7 @@ ccc_hrm_clear(ccc_handle_realtime_ordered_map *const hrm,
 
 ccc_result
 ccc_hrm_clear_and_free(ccc_handle_realtime_ordered_map *const hrm,
-                       ccc_destructor_fn *const fn)
+                       ccc_any_destructor_fn *const fn)
 {
     if (!hrm)
     {
@@ -699,8 +699,8 @@ ccc_hrm_clear_and_free(ccc_handle_realtime_ordered_map *const hrm,
 
 ccc_result
 ccc_hrm_clear_and_free_reserve(ccc_handle_realtime_ordered_map *const hrm,
-                               ccc_destructor_fn *const destructor,
-                               ccc_alloc_fn *const alloc)
+                               ccc_any_destructor_fn *const destructor,
+                               ccc_any_alloc_fn *const alloc)
 {
     if (!hrm)
     {
@@ -911,11 +911,11 @@ min_max_from(struct ccc_hromap_ const *const t, size_t start,
 
 static inline ccc_threeway_cmp
 cmp_elems(struct ccc_hromap_ const *const hrm, void const *const key,
-          size_t const node, ccc_key_cmp_fn *const fn)
+          size_t const node, ccc_any_key_cmp_fn *const fn)
 {
-    return fn((ccc_key_cmp){.key_lhs = key,
-                            .any_type_rhs = base_at(hrm, node),
-                            .aux = hrm->buf_.aux_});
+    return fn((ccc_any_key_cmp){.any_key_lhs = key,
+                                .any_type_rhs = base_at(hrm, node),
+                                .aux = hrm->buf_.aux_});
 }
 
 static size_t

--- a/src/ordered_map.c
+++ b/src/ordered_map.c
@@ -179,7 +179,7 @@ ccc_om_or_insert(ccc_omap_entry const *const e, ccc_omap_elem *const elem)
 }
 
 ccc_omap_entry *
-ccc_om_and_modify(ccc_omap_entry *const e, ccc_any_update_fn *const fn)
+ccc_om_and_modify(ccc_omap_entry *const e, ccc_any_type_update_fn *const fn)
 {
     if (!e)
     {
@@ -193,7 +193,7 @@ ccc_om_and_modify(ccc_omap_entry *const e, ccc_any_update_fn *const fn)
 }
 
 ccc_omap_entry *
-ccc_om_and_modify_aux(ccc_omap_entry *const e, ccc_any_update_fn *const fn,
+ccc_om_and_modify_aux(ccc_omap_entry *const e, ccc_any_type_update_fn *const fn,
                       void *const aux)
 {
     if (e && fn && e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED
@@ -443,7 +443,8 @@ ccc_om_equal_rrange(ccc_ordered_map *const om, void const *const rbegin_key,
 }
 
 ccc_result
-ccc_om_clear(ccc_ordered_map *const om, ccc_any_destructor_fn *const destructor)
+ccc_om_clear(ccc_ordered_map *const om,
+             ccc_any_type_destructor_fn *const destructor)
 {
     if (!om)
     {

--- a/src/ordered_map.c
+++ b/src/ordered_map.c
@@ -93,13 +93,14 @@ static struct ccc_omap_elem_ *remove_from_tree(struct ccc_omap_ *,
 static struct ccc_omap_elem_ const *
 next(struct ccc_omap_ const *, struct ccc_omap_elem_ const *, om_branch_);
 static struct ccc_omap_elem_ *splay(struct ccc_omap_ *, struct ccc_omap_elem_ *,
-                                    void const *key, ccc_key_cmp_fn *);
+                                    void const *key, ccc_any_key_cmp_fn *);
 static struct ccc_omap_elem_ *elem_in_slot(struct ccc_omap_ const *t,
                                            void const *slot);
 
 /* The key comes first. It is the "left hand side" of the comparison. */
 static ccc_threeway_cmp cmp(struct ccc_omap_ const *, void const *key,
-                            struct ccc_omap_elem_ const *, ccc_key_cmp_fn *);
+                            struct ccc_omap_elem_ const *,
+                            ccc_any_key_cmp_fn *);
 
 /* ======================        Map Interface      ====================== */
 
@@ -178,7 +179,7 @@ ccc_om_or_insert(ccc_omap_entry const *const e, ccc_omap_elem *const elem)
 }
 
 ccc_omap_entry *
-ccc_om_and_modify(ccc_omap_entry *const e, ccc_update_fn *const fn)
+ccc_om_and_modify(ccc_omap_entry *const e, ccc_any_update_fn *const fn)
 {
     if (!e)
     {
@@ -192,7 +193,7 @@ ccc_om_and_modify(ccc_omap_entry *const e, ccc_update_fn *const fn)
 }
 
 ccc_omap_entry *
-ccc_om_and_modify_aux(ccc_omap_entry *const e, ccc_update_fn *const fn,
+ccc_om_and_modify_aux(ccc_omap_entry *const e, ccc_any_update_fn *const fn,
                       void *const aux)
 {
     if (e && fn && e->impl_.entry_.stats_ & CCC_ENTRY_OCCUPIED
@@ -442,7 +443,7 @@ ccc_om_equal_rrange(ccc_ordered_map *const om, void const *const rbegin_key,
 }
 
 ccc_result
-ccc_om_clear(ccc_ordered_map *const om, ccc_destructor_fn *const destructor)
+ccc_om_clear(ccc_ordered_map *const om, ccc_any_destructor_fn *const destructor)
 {
     if (!om)
     {
@@ -757,7 +758,7 @@ remove_from_tree(struct ccc_omap_ *const t, struct ccc_omap_elem_ *const ret)
 
 static struct ccc_omap_elem_ *
 splay(struct ccc_omap_ *const t, struct ccc_omap_elem_ *root,
-      void const *const key, ccc_key_cmp_fn *const cmp_fn)
+      void const *const key, ccc_any_key_cmp_fn *const cmp_fn)
 {
     /* Pointers in an array and we can use the symmetric enum and flip it to
        choose the Left or Right subtree. Another benefit of our nil node: use it
@@ -813,10 +814,10 @@ struct_base(struct ccc_omap_ const *const t,
 
 static inline ccc_threeway_cmp
 cmp(struct ccc_omap_ const *const t, void const *const key,
-    struct ccc_omap_elem_ const *const node, ccc_key_cmp_fn *const fn)
+    struct ccc_omap_elem_ const *const node, ccc_any_key_cmp_fn *const fn)
 {
-    return fn((ccc_key_cmp){
-        .key_lhs = key,
+    return fn((ccc_any_key_cmp){
+        .any_key_lhs = key,
         .any_type_rhs = struct_base(t, node),
         .aux = t->aux_,
     });

--- a/src/ordered_multimap.c
+++ b/src/ordered_multimap.c
@@ -203,7 +203,7 @@ ccc_omm_or_insert(ccc_ommap_entry const *const e,
 }
 
 ccc_ommap_entry *
-ccc_omm_and_modify(ccc_ommap_entry *const e, ccc_any_update_fn *const fn)
+ccc_omm_and_modify(ccc_ommap_entry *const e, ccc_any_type_update_fn *const fn)
 {
     if (!e || !fn)
     {
@@ -217,8 +217,8 @@ ccc_omm_and_modify(ccc_ommap_entry *const e, ccc_any_update_fn *const fn)
 }
 
 ccc_ommap_entry *
-ccc_omm_and_modify_aux(ccc_ommap_entry *const e, ccc_any_update_fn *const fn,
-                       void *const aux)
+ccc_omm_and_modify_aux(ccc_ommap_entry *const e,
+                       ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!e || !fn)
     {
@@ -462,7 +462,7 @@ ccc_omm_extract(ccc_ordered_multimap *const mm,
 ccc_tribool
 ccc_omm_update(ccc_ordered_multimap *const mm,
                ccc_ommap_elem *const key_val_handle,
-               ccc_any_update_fn *const fn, void *const aux)
+               ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!mm || !key_val_handle || !fn || !key_val_handle->branch_[L]
         || !key_val_handle->branch_[R])
@@ -482,7 +482,7 @@ ccc_omm_update(ccc_ordered_multimap *const mm,
 ccc_tribool
 ccc_omm_increase(ccc_ordered_multimap *const mm,
                  ccc_ommap_elem *const key_val_handle,
-                 ccc_any_update_fn *const fn, void *const aux)
+                 ccc_any_type_update_fn *const fn, void *const aux)
 {
     return ccc_omm_update(mm, key_val_handle, fn, aux);
 }
@@ -490,7 +490,7 @@ ccc_omm_increase(ccc_ordered_multimap *const mm,
 ccc_tribool
 ccc_omm_decrease(ccc_ordered_multimap *const mm,
                  ccc_ommap_elem *const key_val_handle,
-                 ccc_any_update_fn *const fn, void *const aux)
+                 ccc_any_type_update_fn *const fn, void *const aux)
 {
     return ccc_omm_update(mm, key_val_handle, fn, aux);
 }
@@ -607,7 +607,7 @@ ccc_omm_validate(ccc_ordered_multimap const *const mm)
 
 ccc_result
 ccc_omm_clear(ccc_ordered_multimap *const mm,
-              ccc_any_destructor_fn *const destructor)
+              ccc_any_type_destructor_fn *const destructor)
 {
     if (!mm)
     {

--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -127,7 +127,7 @@ ccc_pq_erase(ccc_priority_queue *const pq, ccc_pq_elem *const e)
 }
 
 ccc_result
-ccc_pq_clear(ccc_priority_queue *const pq, ccc_destructor_fn *const fn)
+ccc_pq_clear(ccc_priority_queue *const pq, ccc_any_destructor_fn *const fn)
 {
     if (!pq)
     {
@@ -172,7 +172,7 @@ ccc_pq_size(ccc_priority_queue const *const pq)
    left child value. */
 ccc_tribool
 ccc_pq_update(ccc_priority_queue *const pq, ccc_pq_elem *const e,
-              ccc_update_fn *const fn, void *const aux)
+              ccc_any_update_fn *const fn, void *const aux)
 {
     if (!pq || !e || !fn || !e->next_sibling_ || !e->prev_sibling_)
     {
@@ -187,7 +187,7 @@ ccc_pq_update(ccc_priority_queue *const pq, ccc_pq_elem *const e,
    Much more efficient. */
 ccc_tribool
 ccc_pq_increase(ccc_priority_queue *const pq, ccc_pq_elem *const e,
-                ccc_update_fn *const fn, void *const aux)
+                ccc_any_update_fn *const fn, void *const aux)
 {
     if (!pq || !e || !fn || !e->next_sibling_ || !e->prev_sibling_)
     {
@@ -202,7 +202,7 @@ ccc_pq_increase(ccc_priority_queue *const pq, ccc_pq_elem *const e,
    Much more efficient. */
 ccc_tribool
 ccc_pq_decrease(ccc_priority_queue *const pq, ccc_pq_elem *const e,
-                ccc_update_fn *const fn, void *const aux)
+                ccc_any_update_fn *const fn, void *const aux)
 {
     if (!pq || !e || !fn || !e->next_sibling_ || !e->prev_sibling_)
     {
@@ -464,9 +464,9 @@ static inline ccc_threeway_cmp
 cmp(struct ccc_pq_ const *const pq, struct ccc_pq_elem_ const *const a,
     struct ccc_pq_elem_ const *const b)
 {
-    return pq->cmp_((ccc_cmp){.any_type_lhs = struct_base(pq, a),
-                              .any_type_rhs = struct_base(pq, b),
-                              .aux = pq->aux_});
+    return pq->cmp_((ccc_any_cmp){.any_type_lhs = struct_base(pq, a),
+                                  .any_type_rhs = struct_base(pq, b),
+                                  .aux = pq->aux_});
 }
 
 static inline void *

--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -127,7 +127,7 @@ ccc_pq_erase(ccc_priority_queue *const pq, ccc_pq_elem *const e)
 }
 
 ccc_result
-ccc_pq_clear(ccc_priority_queue *const pq, ccc_any_destructor_fn *const fn)
+ccc_pq_clear(ccc_priority_queue *const pq, ccc_any_type_destructor_fn *const fn)
 {
     if (!pq)
     {
@@ -172,7 +172,7 @@ ccc_pq_size(ccc_priority_queue const *const pq)
    left child value. */
 ccc_tribool
 ccc_pq_update(ccc_priority_queue *const pq, ccc_pq_elem *const e,
-              ccc_any_update_fn *const fn, void *const aux)
+              ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!pq || !e || !fn || !e->next_sibling_ || !e->prev_sibling_)
     {
@@ -187,7 +187,7 @@ ccc_pq_update(ccc_priority_queue *const pq, ccc_pq_elem *const e,
    Much more efficient. */
 ccc_tribool
 ccc_pq_increase(ccc_priority_queue *const pq, ccc_pq_elem *const e,
-                ccc_any_update_fn *const fn, void *const aux)
+                ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!pq || !e || !fn || !e->next_sibling_ || !e->prev_sibling_)
     {
@@ -202,7 +202,7 @@ ccc_pq_increase(ccc_priority_queue *const pq, ccc_pq_elem *const e,
    Much more efficient. */
 ccc_tribool
 ccc_pq_decrease(ccc_priority_queue *const pq, ccc_pq_elem *const e,
-                ccc_any_update_fn *const fn, void *const aux)
+                ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!pq || !e || !fn || !e->next_sibling_ || !e->prev_sibling_)
     {
@@ -464,9 +464,9 @@ static inline ccc_threeway_cmp
 cmp(struct ccc_pq_ const *const pq, struct ccc_pq_elem_ const *const a,
     struct ccc_pq_elem_ const *const b)
 {
-    return pq->cmp_((ccc_any_cmp){.any_type_lhs = struct_base(pq, a),
-                                  .any_type_rhs = struct_base(pq, b),
-                                  .aux = pq->aux_});
+    return pq->cmp_((ccc_any_type_cmp){.any_type_lhs = struct_base(pq, a),
+                                       .any_type_rhs = struct_base(pq, b),
+                                       .aux = pq->aux_});
 }
 
 static inline void *

--- a/src/realtime_ordered_map.c
+++ b/src/realtime_ordered_map.c
@@ -352,7 +352,7 @@ ccc_rom_remove(ccc_realtime_ordered_map *const rom,
 }
 
 ccc_romap_entry *
-ccc_rom_and_modify(ccc_romap_entry *e, ccc_any_update_fn *fn)
+ccc_rom_and_modify(ccc_romap_entry *e, ccc_any_type_update_fn *fn)
 {
     if (!e)
     {
@@ -366,7 +366,8 @@ ccc_rom_and_modify(ccc_romap_entry *e, ccc_any_update_fn *fn)
 }
 
 ccc_romap_entry *
-ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_any_update_fn *fn, void *aux)
+ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_any_type_update_fn *fn,
+                       void *aux)
 {
     if (!e)
     {
@@ -533,7 +534,7 @@ ccc_rom_validate(ccc_realtime_ordered_map const *rom)
 
 ccc_result
 ccc_rom_clear(ccc_realtime_ordered_map *const rom,
-              ccc_any_destructor_fn *const destructor)
+              ccc_any_type_destructor_fn *const destructor)
 {
     if (!rom)
     {

--- a/src/realtime_ordered_map.c
+++ b/src/realtime_ordered_map.c
@@ -77,7 +77,7 @@ struct romap_query_
 static void init_node(struct ccc_romap_ *, struct ccc_romap_elem_ *);
 static ccc_threeway_cmp cmp(struct ccc_romap_ const *, void const *key,
                             struct ccc_romap_elem_ const *node,
-                            ccc_key_cmp_fn *);
+                            ccc_any_key_cmp_fn *);
 static void *struct_base(struct ccc_romap_ const *,
                          struct ccc_romap_elem_ const *);
 static struct romap_query_ find(struct ccc_romap_ const *, void const *key);
@@ -352,7 +352,7 @@ ccc_rom_remove(ccc_realtime_ordered_map *const rom,
 }
 
 ccc_romap_entry *
-ccc_rom_and_modify(ccc_romap_entry *e, ccc_update_fn *fn)
+ccc_rom_and_modify(ccc_romap_entry *e, ccc_any_update_fn *fn)
 {
     if (!e)
     {
@@ -366,7 +366,7 @@ ccc_rom_and_modify(ccc_romap_entry *e, ccc_update_fn *fn)
 }
 
 ccc_romap_entry *
-ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_update_fn *fn, void *aux)
+ccc_rom_and_modify_aux(ccc_romap_entry *e, ccc_any_update_fn *fn, void *aux)
 {
     if (!e)
     {
@@ -533,7 +533,7 @@ ccc_rom_validate(ccc_realtime_ordered_map const *rom)
 
 ccc_result
 ccc_rom_clear(ccc_realtime_ordered_map *const rom,
-              ccc_destructor_fn *const destructor)
+              ccc_any_destructor_fn *const destructor)
 {
     if (!rom)
     {
@@ -765,10 +765,10 @@ swap(char tmp[const], void *const a, void *const b, size_t const elem_sz)
 
 static inline ccc_threeway_cmp
 cmp(struct ccc_romap_ const *const rom, void const *const key,
-    struct ccc_romap_elem_ const *const node, ccc_key_cmp_fn *const fn)
+    struct ccc_romap_elem_ const *const node, ccc_any_key_cmp_fn *const fn)
 {
-    return fn((ccc_key_cmp){
-        .key_lhs = key,
+    return fn((ccc_any_key_cmp){
+        .any_key_lhs = key,
         .any_type_rhs = struct_base(rom, node),
         .aux = rom->aux_,
     });

--- a/src/singly_linked_list.c
+++ b/src/singly_linked_list.c
@@ -255,7 +255,7 @@ ccc_sll_next(ccc_singly_linked_list const *const sll,
 
 ccc_result
 ccc_sll_clear(ccc_singly_linked_list *const sll,
-              ccc_any_destructor_fn *const fn)
+              ccc_any_type_destructor_fn *const fn)
 {
     if (!sll)
     {

--- a/src/singly_linked_list.c
+++ b/src/singly_linked_list.c
@@ -254,7 +254,8 @@ ccc_sll_next(ccc_singly_linked_list const *const sll,
 }
 
 ccc_result
-ccc_sll_clear(ccc_singly_linked_list *const sll, ccc_destructor_fn *const fn)
+ccc_sll_clear(ccc_singly_linked_list *const sll,
+              ccc_any_destructor_fn *const fn)
 {
     if (!sll)
     {

--- a/tests/dll/dll_util.c
+++ b/tests/dll/dll_util.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 
 ccc_threeway_cmp
-val_cmp(ccc_any_cmp const c)
+val_cmp(ccc_any_type_cmp const c)
 {
     struct val const *const a = c.any_type_lhs;
     struct val const *const b = c.any_type_rhs;

--- a/tests/dll/dll_util.c
+++ b/tests/dll/dll_util.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 
 ccc_threeway_cmp
-val_cmp(ccc_cmp const c)
+val_cmp(ccc_any_cmp const c)
 {
     struct val const *const a = c.any_type_lhs;
     struct val const *const b = c.any_type_rhs;

--- a/tests/dll/dll_util.h
+++ b/tests/dll/dll_util.h
@@ -20,7 +20,7 @@ enum push_end
     UTIL_PUSH_BACK,
 };
 
-ccc_threeway_cmp val_cmp(ccc_cmp);
+ccc_threeway_cmp val_cmp(ccc_any_cmp);
 
 enum check_result check_order(ccc_doubly_linked_list const *, size_t n,
                               int const order[]);

--- a/tests/dll/dll_util.h
+++ b/tests/dll/dll_util.h
@@ -20,7 +20,7 @@ enum push_end
     UTIL_PUSH_BACK,
 };
 
-ccc_threeway_cmp val_cmp(ccc_any_cmp);
+ccc_threeway_cmp val_cmp(ccc_any_type_cmp);
 
 enum check_result check_order(ccc_doubly_linked_list const *, size_t n,
                               int const order[]);

--- a/tests/fhmap/fhmap_util.c
+++ b/tests/fhmap/fhmap_util.c
@@ -17,10 +17,10 @@ fhmap_int_last_digit(ccc_any_key const n)
 }
 
 ccc_tribool
-fhmap_id_eq(ccc_key_cmp const cmp)
+fhmap_id_eq(ccc_any_key_cmp const cmp)
 {
     struct val const *const va = cmp.any_type_rhs;
-    return va->key == *((int *)cmp.key_lhs);
+    return va->key == *((int *)cmp.any_key_lhs);
 }
 
 uint64_t

--- a/tests/fhmap/fhmap_util.h
+++ b/tests/fhmap/fhmap_util.h
@@ -32,7 +32,7 @@ enum : size_t
 uint64_t fhmap_int_zero(ccc_any_key);
 uint64_t fhmap_int_last_digit(ccc_any_key);
 uint64_t fhmap_int_to_u64(ccc_any_key);
-ccc_tribool fhmap_id_eq(ccc_key_cmp);
+ccc_tribool fhmap_id_eq(ccc_any_key_cmp);
 
 void fhmap_modplus(ccc_any_type);
 struct val fhmap_create(int id, int val);

--- a/tests/fhmap/test_fhmap_lru.c
+++ b/tests/fhmap/test_fhmap_lru.c
@@ -71,14 +71,14 @@ static bool const quiet = true;
     } while (0)
 
 static ccc_tribool
-lru_lookup_cmp(ccc_key_cmp const cmp)
+lru_lookup_cmp(ccc_any_key_cmp const cmp)
 {
     struct lru_lookup const *const lookup = cmp.any_type_rhs;
-    return lookup->key == *((int *)cmp.key_lhs);
+    return lookup->key == *((int *)cmp.any_key_lhs);
 }
 
 static ccc_threeway_cmp
-cmp_by_key(ccc_cmp const cmp)
+cmp_by_key(ccc_any_cmp const cmp)
 {
     struct key_val const *const kv_a = cmp.any_type_lhs;
     struct key_val const *const kv_b = cmp.any_type_rhs;

--- a/tests/fhmap/test_fhmap_lru.c
+++ b/tests/fhmap/test_fhmap_lru.c
@@ -78,7 +78,7 @@ lru_lookup_cmp(ccc_any_key_cmp const cmp)
 }
 
 static ccc_threeway_cmp
-cmp_by_key(ccc_any_cmp const cmp)
+cmp_by_key(ccc_any_type_cmp const cmp)
 {
     struct key_val const *const kv_a = cmp.any_type_lhs;
     struct key_val const *const kv_b = cmp.any_type_rhs;

--- a/tests/fpq/fpq_util.c
+++ b/tests/fpq/fpq_util.c
@@ -10,7 +10,7 @@
 #include "types.h"
 
 ccc_threeway_cmp
-val_cmp(ccc_any_cmp const cmp)
+val_cmp(ccc_any_type_cmp const cmp)
 {
     struct val const *const lhs = cmp.any_type_lhs;
     struct val const *const rhs = cmp.any_type_rhs;

--- a/tests/fpq/fpq_util.c
+++ b/tests/fpq/fpq_util.c
@@ -10,7 +10,7 @@
 #include "types.h"
 
 ccc_threeway_cmp
-val_cmp(ccc_cmp const cmp)
+val_cmp(ccc_any_cmp const cmp)
 {
     struct val const *const lhs = cmp.any_type_lhs;
     struct val const *const rhs = cmp.any_type_rhs;

--- a/tests/fpq/fpq_util.h
+++ b/tests/fpq/fpq_util.h
@@ -13,7 +13,7 @@ struct val
     int val;
 };
 
-ccc_threeway_cmp val_cmp(ccc_any_cmp);
+ccc_threeway_cmp val_cmp(ccc_any_type_cmp);
 void val_update(ccc_any_type);
 size_t rand_range(size_t min, size_t max);
 enum check_result inorder_fill(int[], size_t, ccc_flat_priority_queue *);

--- a/tests/fpq/fpq_util.h
+++ b/tests/fpq/fpq_util.h
@@ -13,7 +13,7 @@ struct val
     int val;
 };
 
-ccc_threeway_cmp val_cmp(ccc_cmp);
+ccc_threeway_cmp val_cmp(ccc_any_cmp);
 void val_update(ccc_any_type);
 size_t rand_range(size_t min, size_t max);
 enum check_result inorder_fill(int[], size_t, ccc_flat_priority_queue *);

--- a/tests/fpq/test_fpq_construct.c
+++ b/tests/fpq/test_fpq_construct.c
@@ -13,7 +13,7 @@
 #include "types.h"
 
 static ccc_threeway_cmp
-int_cmp(ccc_any_cmp const cmp)
+int_cmp(ccc_any_type_cmp const cmp)
 {
     int a = *((int const *const)cmp.any_type_lhs);
     int b = *((int const *const)cmp.any_type_rhs);

--- a/tests/fpq/test_fpq_construct.c
+++ b/tests/fpq/test_fpq_construct.c
@@ -13,7 +13,7 @@
 #include "types.h"
 
 static ccc_threeway_cmp
-int_cmp(ccc_cmp const cmp)
+int_cmp(ccc_any_cmp const cmp)
 {
     int a = *((int const *const)cmp.any_type_lhs);
     int b = *((int const *const)cmp.any_type_rhs);

--- a/tests/homap/homap_util.c
+++ b/tests/homap/homap_util.c
@@ -8,10 +8,10 @@
 #include "types.h"
 
 ccc_threeway_cmp
-id_cmp(ccc_key_cmp const cmp)
+id_cmp(ccc_any_key_cmp const cmp)
 {
     struct val const *const c = cmp.any_type_rhs;
-    int const key = *((int *)cmp.key_lhs);
+    int const key = *((int *)cmp.any_key_lhs);
     return (key > c->id) - (key < c->id);
 }
 

--- a/tests/homap/homap_util.h
+++ b/tests/homap/homap_util.h
@@ -14,7 +14,7 @@ struct val
     ccc_homap_elem elem;
 };
 
-ccc_threeway_cmp id_cmp(ccc_key_cmp);
+ccc_threeway_cmp id_cmp(ccc_any_key_cmp);
 
 enum check_result insert_shuffled(ccc_handle_ordered_map *m, size_t size,
                                   int larger_prime);

--- a/tests/hromap/hromap_util.c
+++ b/tests/hromap/hromap_util.c
@@ -8,10 +8,10 @@
 #include "types.h"
 
 ccc_threeway_cmp
-id_cmp(ccc_key_cmp const cmp)
+id_cmp(ccc_any_key_cmp const cmp)
 {
     struct val const *const c = cmp.any_type_rhs;
-    int const key = *((int *)cmp.key_lhs);
+    int const key = *((int *)cmp.any_key_lhs);
     return (key > c->id) - (key < c->id);
 }
 

--- a/tests/hromap/hromap_util.h
+++ b/tests/hromap/hromap_util.h
@@ -14,7 +14,7 @@ struct val
     ccc_hromap_elem elem;
 };
 
-ccc_threeway_cmp id_cmp(ccc_key_cmp);
+ccc_threeway_cmp id_cmp(ccc_any_key_cmp);
 
 enum check_result insert_shuffled(ccc_handle_realtime_ordered_map *m,
                                   size_t size, int larger_prime);

--- a/tests/omap/omap_util.c
+++ b/tests/omap/omap_util.c
@@ -10,10 +10,10 @@
 #include "types.h"
 
 ccc_threeway_cmp
-id_cmp(ccc_key_cmp const cmp)
+id_cmp(ccc_any_key_cmp const cmp)
 {
     struct val const *const c = cmp.any_type_rhs;
-    int const key = *((int *)cmp.key_lhs);
+    int const key = *((int *)cmp.any_key_lhs);
     return (key > c->key) - (key < c->key);
 }
 

--- a/tests/omap/omap_util.h
+++ b/tests/omap/omap_util.h
@@ -30,7 +30,7 @@ struct val_pool
 can only allocate. Freeing is a No Op. Reallocation will kill the program. */
 void *val_bump_alloc(void *ptr, size_t size, void *aux);
 
-ccc_threeway_cmp id_cmp(ccc_key_cmp);
+ccc_threeway_cmp id_cmp(ccc_any_key_cmp);
 
 enum check_result insert_shuffled(ccc_ordered_map *m, struct val vals[],
                                   size_t size, int larger_prime);

--- a/tests/omap/test_omap_lru.c
+++ b/tests/omap/test_omap_lru.c
@@ -66,15 +66,15 @@ static bool const quiet = true;
     } while (0)
 
 static ccc_threeway_cmp
-cmp_by_key(ccc_key_cmp const cmp)
+cmp_by_key(ccc_any_key_cmp const cmp)
 {
-    int const key_lhs = *(int *)cmp.key_lhs;
+    int const key_lhs = *(int *)cmp.any_key_lhs;
     struct lru_elem const *const kv = cmp.any_type_rhs;
     return (key_lhs > kv->key) - (key_lhs < kv->key);
 }
 
 static ccc_threeway_cmp
-cmp_list_elems(ccc_cmp const cmp)
+cmp_list_elems(ccc_any_cmp const cmp)
 {
     struct lru_elem const *const kv_a = cmp.any_type_lhs;
     struct lru_elem const *const kv_b = cmp.any_type_rhs;

--- a/tests/omap/test_omap_lru.c
+++ b/tests/omap/test_omap_lru.c
@@ -74,7 +74,7 @@ cmp_by_key(ccc_any_key_cmp const cmp)
 }
 
 static ccc_threeway_cmp
-cmp_list_elems(ccc_any_cmp const cmp)
+cmp_list_elems(ccc_any_type_cmp const cmp)
 {
     struct lru_elem const *const kv_a = cmp.any_type_lhs;
     struct lru_elem const *const kv_b = cmp.any_type_rhs;

--- a/tests/ommap/ommap_util.c
+++ b/tests/ommap/ommap_util.c
@@ -10,10 +10,10 @@
 #include "types.h"
 
 ccc_threeway_cmp
-id_cmp(ccc_key_cmp const cmp)
+id_cmp(ccc_any_key_cmp const cmp)
 {
     struct val const *const c = cmp.any_type_rhs;
-    int key = *((int *)cmp.key_lhs);
+    int key = *((int *)cmp.any_key_lhs);
     return (key > c->key) - (key < c->key);
 }
 

--- a/tests/ommap/ommap_util.h
+++ b/tests/ommap/ommap_util.h
@@ -29,7 +29,7 @@ struct val_pool
 can only allocate. Freeing is a No Op. Reallocation will kill the program. */
 void *val_bump_alloc(void *ptr, size_t size, void *aux);
 
-ccc_threeway_cmp id_cmp(ccc_key_cmp);
+ccc_threeway_cmp id_cmp(ccc_any_key_cmp);
 void val_update(ccc_any_type);
 
 enum check_result insert_shuffled(ccc_ordered_multimap *, struct val[], size_t,

--- a/tests/perf/pq_perf.c
+++ b/tests/perf/pq_perf.c
@@ -36,8 +36,8 @@ static void test_update(void);
 
 static void *valid_malloc(size_t bytes);
 static struct val *create_rand_vals(size_t);
-static ccc_threeway_cmp val_key_cmp(ccc_key_cmp);
-static ccc_threeway_cmp val_cmp(ccc_cmp);
+static ccc_threeway_cmp val_key_cmp(ccc_any_key_cmp);
+static ccc_threeway_cmp val_cmp(ccc_any_cmp);
 static void val_update(ccc_any_type);
 
 #define NUM_TESTS (size_t)6
@@ -442,15 +442,15 @@ valid_malloc(size_t bytes)
 }
 
 static ccc_threeway_cmp
-val_key_cmp(ccc_key_cmp const cmp)
+val_key_cmp(ccc_any_key_cmp const cmp)
 {
     struct val const *const x = cmp.any_type_rhs;
-    int const key = *((int *)cmp.key_lhs);
+    int const key = *((int *)cmp.any_key_lhs);
     return (key > x->val) - (key < x->val);
 }
 
 static ccc_threeway_cmp
-val_cmp(ccc_cmp const cmp)
+val_cmp(ccc_any_cmp const cmp)
 {
     struct val const *const a = cmp.any_type_lhs;
     struct val const *const b = cmp.any_type_rhs;

--- a/tests/perf/pq_perf.c
+++ b/tests/perf/pq_perf.c
@@ -37,7 +37,7 @@ static void test_update(void);
 static void *valid_malloc(size_t bytes);
 static struct val *create_rand_vals(size_t);
 static ccc_threeway_cmp val_key_cmp(ccc_any_key_cmp);
-static ccc_threeway_cmp val_cmp(ccc_any_cmp);
+static ccc_threeway_cmp val_cmp(ccc_any_type_cmp);
 static void val_update(ccc_any_type);
 
 #define NUM_TESTS (size_t)6
@@ -450,7 +450,7 @@ val_key_cmp(ccc_any_key_cmp const cmp)
 }
 
 static ccc_threeway_cmp
-val_cmp(ccc_any_cmp const cmp)
+val_cmp(ccc_any_type_cmp const cmp)
 {
     struct val const *const a = cmp.any_type_lhs;
     struct val const *const b = cmp.any_type_rhs;

--- a/tests/pq/pq_util.c
+++ b/tests/pq/pq_util.c
@@ -9,7 +9,7 @@
 #include <stddef.h>
 
 ccc_threeway_cmp
-val_cmp(ccc_cmp const cmp)
+val_cmp(ccc_any_cmp const cmp)
 {
     struct val const *const lhs = cmp.any_type_lhs;
     struct val const *const rhs = cmp.any_type_rhs;

--- a/tests/pq/pq_util.c
+++ b/tests/pq/pq_util.c
@@ -9,7 +9,7 @@
 #include <stddef.h>
 
 ccc_threeway_cmp
-val_cmp(ccc_any_cmp const cmp)
+val_cmp(ccc_any_type_cmp const cmp)
 {
     struct val const *const lhs = cmp.any_type_lhs;
     struct val const *const rhs = cmp.any_type_rhs;

--- a/tests/pq/pq_util.h
+++ b/tests/pq/pq_util.h
@@ -15,7 +15,7 @@ struct val
 };
 
 void val_update(ccc_any_type);
-ccc_threeway_cmp val_cmp(ccc_cmp);
+ccc_threeway_cmp val_cmp(ccc_any_cmp);
 enum check_result insert_shuffled(ccc_priority_queue *, struct val[], size_t,
                                   int);
 enum check_result inorder_fill(int[], size_t, ccc_priority_queue *);

--- a/tests/pq/pq_util.h
+++ b/tests/pq/pq_util.h
@@ -15,7 +15,7 @@ struct val
 };
 
 void val_update(ccc_any_type);
-ccc_threeway_cmp val_cmp(ccc_any_cmp);
+ccc_threeway_cmp val_cmp(ccc_any_type_cmp);
 enum check_result insert_shuffled(ccc_priority_queue *, struct val[], size_t,
                                   int);
 enum check_result inorder_fill(int[], size_t, ccc_priority_queue *);

--- a/tests/romap/romap_util.c
+++ b/tests/romap/romap_util.c
@@ -10,10 +10,10 @@
 #include "types.h"
 
 ccc_threeway_cmp
-id_cmp(ccc_key_cmp const cmp)
+id_cmp(ccc_any_key_cmp const cmp)
 {
     struct val const *const c = cmp.any_type_rhs;
-    int const key = *((int *)cmp.key_lhs);
+    int const key = *((int *)cmp.any_key_lhs);
     return (key > c->key) - (key < c->key);
 }
 

--- a/tests/romap/romap_util.h
+++ b/tests/romap/romap_util.h
@@ -30,7 +30,7 @@ struct val_pool
 can only allocate. Freeing is a No Op. Reallocation will kill the program. */
 void *val_bump_alloc(void *ptr, size_t size, void *aux);
 
-ccc_threeway_cmp id_cmp(ccc_key_cmp);
+ccc_threeway_cmp id_cmp(ccc_any_key_cmp);
 
 enum check_result insert_shuffled(ccc_realtime_ordered_map *m,
                                   struct val vals[], size_t size,

--- a/tests/romap/test_romap_lru.c
+++ b/tests/romap/test_romap_lru.c
@@ -66,15 +66,15 @@ static bool const quiet = true;
     } while (0)
 
 static ccc_threeway_cmp
-cmp_by_key(ccc_key_cmp const cmp)
+cmp_by_key(ccc_any_key_cmp const cmp)
 {
-    int const key_lhs = *(int *)cmp.key_lhs;
+    int const key_lhs = *(int *)cmp.any_key_lhs;
     struct lru_elem const *const kv = cmp.any_type_rhs;
     return (key_lhs > kv->key) - (key_lhs < kv->key);
 }
 
 static ccc_threeway_cmp
-cmp_list_elems(ccc_cmp const cmp)
+cmp_list_elems(ccc_any_cmp const cmp)
 {
     struct lru_elem const *const kv_a = cmp.any_type_lhs;
     struct lru_elem const *const kv_b = cmp.any_type_rhs;

--- a/tests/romap/test_romap_lru.c
+++ b/tests/romap/test_romap_lru.c
@@ -74,7 +74,7 @@ cmp_by_key(ccc_any_key_cmp const cmp)
 }
 
 static ccc_threeway_cmp
-cmp_list_elems(ccc_any_cmp const cmp)
+cmp_list_elems(ccc_any_type_cmp const cmp)
 {
     struct lru_elem const *const kv_a = cmp.any_type_lhs;
     struct lru_elem const *const kv_b = cmp.any_type_rhs;

--- a/tests/sll/sll_util.c
+++ b/tests/sll/sll_util.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 
 ccc_threeway_cmp
-val_cmp(ccc_any_cmp const c)
+val_cmp(ccc_any_type_cmp const c)
 {
     struct val const *const a = c.any_type_lhs;
     struct val const *const b = c.any_type_rhs;

--- a/tests/sll/sll_util.c
+++ b/tests/sll/sll_util.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 
 ccc_threeway_cmp
-val_cmp(ccc_cmp const c)
+val_cmp(ccc_any_cmp const c)
 {
     struct val const *const a = c.any_type_lhs;
     struct val const *const b = c.any_type_rhs;

--- a/tests/sll/sll_util.h
+++ b/tests/sll/sll_util.h
@@ -14,7 +14,7 @@ struct val
     ccc_sll_elem e;
 };
 
-ccc_threeway_cmp val_cmp(ccc_any_cmp);
+ccc_threeway_cmp val_cmp(ccc_any_type_cmp);
 enum check_result check_order(ccc_singly_linked_list const *, size_t n,
                               int const order[]);
 enum check_result create_list(ccc_singly_linked_list *, size_t n,

--- a/tests/sll/sll_util.h
+++ b/tests/sll/sll_util.h
@@ -14,7 +14,7 @@ struct val
     ccc_sll_elem e;
 };
 
-ccc_threeway_cmp val_cmp(ccc_cmp);
+ccc_threeway_cmp val_cmp(ccc_any_cmp);
 enum check_result check_order(ccc_singly_linked_list const *, size_t n,
                               int const order[]);
 enum check_result create_list(ccc_singly_linked_list *, size_t n,


### PR DESCRIPTION
The fields with `any_` fields prefix to communicate same concept in wrapping types. Then functions should follow for consistency.