### PR TITLE
editing deleted double underscores by mistake forcing portable

### DIFF
--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -59,16 +59,16 @@ that means uint64_t is widest default integer widely supported. That width
 is still valid on 32-bit but probably very slow due to emulation. */
 enum : uint8_t
 {
-#if defined(__x86_64) && defined(__SSE2_) && !defined(CCC_FHM_PORTABLE)
+#if defined(__x86_64) && defined(__SSE2__) && !defined(CCC_FHM_PORTABLE)
     /** A group of tags that can be loaded into a 128 bit vector. */
     CCC_FHM_GROUP_SIZE = 16,
-#elif defined(__ARM_NEON_) && !defined(CCC_FHM_PORTABLE)
+#elif defined(__ARM_NEON__) && !defined(CCC_FHM_PORTABLE)
     /** A group of tags that can be loded into a 64 bit integer. */
     CCC_FHM_GROUP_SIZE = 8,
 #else  /* PORTABLE FALLBACK */
     /** A group of tags that can be loded into a 64 bit integer. */
     CCC_FHM_GROUP_SIZE = 8,
-#endif /* defined(__x86_64) && defined(__SSE2_) && !CCC_FHM_PORTABLE */
+#endif /* defined(__x86_64) && defined(__SSE2__) && !CCC_FHM_PORTABLE */
 };
 
 /** @private The layout of the map uses only pointers to account for the
@@ -77,7 +77,7 @@ map is allowed to allocate it will take care of aligning pointers appropriately.
 In the fixed size case we rely on the user defining a fixed size type. In either
 case the arrays are in one contiguous allocation but split as follows:
 
-(N == capacity - 1) Where capacity is a required power of 2. (G == group size).
+(N == capacity - 1) Where capacity is a power of 2. (G == group size - 1).
 
 ┌────┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
 │Swap│D_N│...│D_1│D_0│T_0│T_1│...│T_N│R_0│R_1│...│R_G│

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -29,7 +29,8 @@ candidate keys for a match in the map simultaneously. This is achieved in the
 best case by having 16 one-byte hash fingerprints analyzed simultaneously for
 a match against a candidate fingerprint. The details of how this is done and
 trade-offs involved can be found in the comments around the implementations
-and data structures. */
+and data structures. The ARM NEON implementation may be updated if they add
+better capabilities for 128 bit group operations. */
 #include <assert.h>
 #include <limits.h>
 #include <stdalign.h>

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -1709,8 +1709,8 @@ match_empty_or_deleted(group const g)
     return (index_mask){_mm_movemask_epi8(g.v)};
 }
 
-/** Converts the empty and deleted constants all CCC_FHM_EMPTY and the full
-tags representing hashed user data CCC_FHM_DELETED. Making the hashed data
+/** Converts the empty and deleted constants all TAG_EMPTY and the full
+tags representing hashed user data TAG_DELETED. Making the hashed data
 deleted is OK because it will only turn on the previously unused most
 significant bit. This does not affect user hashed data. */
 static inline group
@@ -1779,7 +1779,7 @@ based index in the context of the probe sequence. */
 static inline index_mask
 match_empty(group const g)
 {
-    return match_tag(g, (ccc_fhm_tag){CCC_FHM_EMPTY});
+    return match_tag(g, (ccc_fhm_tag){TAG_EMPTY});
 }
 
 /** Returns a 0 based index mask with every bit on representing those tags
@@ -1800,8 +1800,8 @@ match_empty_or_deleted(group const g)
     return res;
 }
 
-/** Converts the empty and deleted constants all CCC_FHM_EMPTY and the full
-tags representing hashed user data CCC_FHM_DELETED. Making the hashed data
+/** Converts the empty and deleted constants all TAG_EMPTY and the full
+tags representing hashed user data TAG_DELETED. Making the hashed data
 deleted is OK because it will only turn on the previously unused most
 significant bit. This does not affect user hashed data. */
 static inline group
@@ -1916,8 +1916,8 @@ match_empty_or_deleted(group const g)
     return to_little_endian((index_mask){g.v & INDEX_MASK_MSBS});
 }
 
-/** Converts the empty and deleted constants all CCC_FHM_EMPTY and the full
-tags representing hashed user data CCC_FHM_DELETED. Making the hashed data
+/** Converts the empty and deleted constants all TAG_EMPTY and the full
+tags representing hashed user data TAG_DELETED. Making the hashed data
 deleted is OK because it will only turn on the previously unused most
 significant bit. This does not affect user hashed data. */
 static inline group

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -167,7 +167,7 @@ typedef struct
     uint16_t v;
 } index_mask;
 
-#elif defined(__ARM_NEON_) && !defined(CCC_FHM_PORTABLE)
+#elif defined(__ARM_NEON__) && !defined(CCC_FHM_PORTABLE)
 
 /** @private The 64 bit vector is used on NEON due to a lack of ability to
 compress a 128 bit vector to a smaller int efficiently. */

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -38,11 +38,11 @@ and data structures. */
 #include <string.h>
 
 /** Two platforms offer some form of vector instructions we can try. */
-#if defined(__x86_64) && defined(__SSE2_) && !defined(CCC_FHM_PORTABLE)
+#if defined(__x86_64) && defined(__SSE2__) && !defined(CCC_FHM_PORTABLE)
 #    include <immintrin.h>
-#elif defined(__ARM_NEON_) && !defined(CCC_FHM_PORTABLE)
+#elif defined(__ARM_NEON__) && !defined(CCC_FHM_PORTABLE)
 #    include <arm_neon.h>
-#endif /* defined(__x86_64) && defined(__SSE2_) && !CCC_FHM_PORTABLE */
+#endif /* defined(__x86_64) && defined(__SSE2__) && !CCC_FHM_PORTABLE */
 
 #include "flat_hash_map.h"
 #include "impl/impl_flat_hash_map.h"
@@ -151,7 +151,7 @@ static_assert(
 
 /* Can we vectorize instructions? Also it is possible to specify we want a
 portable implementation. Consider exposing to user in header docs. */
-#if defined(__x86_64) && defined(__SSE2_) && !defined(CCC_FHM_PORTABLE)
+#if defined(__x86_64) && defined(__SSE2__) && !defined(CCC_FHM_PORTABLE)
 
 /** @private The 128 bit vector type for efficient SIMD group scanning. 16 one
 byte large tags fit in this type. */
@@ -230,7 +230,7 @@ enum : uint8_t
     TAG_BITS = sizeof(ccc_fhm_tag) * CHAR_BIT,
 };
 
-#endif /* defined(__x86_64) && defined(__SSE2_) && !CCC_FHM_PORTABLE */
+#endif /* defined(__x86_64) && defined(__SSE2__) && !CCC_FHM_PORTABLE */
 
 enum : uint8_t
 {
@@ -1627,7 +1627,7 @@ next_index(index_mask *const m)
 
 /** We have abstracted at much as we can before this point. Now implementations
 will need to vary based on availability of vectorized instructions. */
-#if defined(__x86_64) && defined(__SSE2_) && !defined(CCC_FHM_PORTABLE)
+#if defined(__x86_64) && defined(__SSE2__) && !defined(CCC_FHM_PORTABLE)
 
 /*=========================  Group Implementations   ========================*/
 
@@ -1722,7 +1722,7 @@ make_constants_empty_and_full_deleted(group const g)
     };
 }
 
-#elif defined(__ARM_NEON_) && !defined(CCC_FHM_PORTABLE)
+#elif defined(__ARM_NEON__) && !defined(CCC_FHM_PORTABLE)
 
 /** Below is the experimental NEON implementation for ARM architectures. This
 implementation assumes a little endian architecture as that is the norm in
@@ -1927,7 +1927,7 @@ make_constants_empty_and_full_deleted(group g)
     return g;
 }
 
-#endif /* defined(__x86_64) && defined(__SSE2_) && !CCC_FHM_PORTABLE */
+#endif /* defined(__x86_64) && defined(__SSE2__) && !CCC_FHM_PORTABLE */
 
 /*====================  Bit Counting for Index Mask   =======================*/
 
@@ -1937,7 +1937,7 @@ implementations can simply rely on counting zeros that yields correct results
 for their implementation. Each implementation attempts to use the built-ins
 first and then falls back to manual bit counting. */
 
-#if defined(__x86_64) && defined(__SSE2_) && !defined(CCC_FHM_PORTABLE)
+#if defined(__x86_64) && defined(__SSE2__) && !defined(CCC_FHM_PORTABLE)
 
 #    if defined(__has_builtin) && __has_builtin(__builtin_ctz)                 \
         && __has_builtin(__builtin_clz) && __has_builtin(__builtin_clzl)
@@ -2116,7 +2116,7 @@ clz_size_t(size_t n)
 #    endif /* !defined(__has_builtin) || !__has_builtin(__builtin_ctzl) ||     \
               !__has_builtin(__builtin_clzl) */
 
-#endif /* defined(__x86_64) && defined(__SSE2_) && !CCC_FHM_PORTABLE */
+#endif /* defined(__x86_64) && defined(__SSE2__) && !CCC_FHM_PORTABLE */
 
 /** The following Apache license follows as required by the Rust Hashbrown
 table which in turn is based on the Abseil Flat Hash Map developed at Google:

--- a/tests/checkers.h
+++ b/tests/checkers.h
@@ -20,7 +20,7 @@ typedef enum check_result (*test_fn)(void);
 #define CHECK_FAIL_PRINT(result, result_string, expected, expected_string)     \
     do                                                                         \
     {                                                                          \
-        char const *const format_string_ = _Generic((result_),                 \
+        char const *const format_string = _Generic((result),                   \
             _Bool: "%d",                                                       \
             char: "%c",                                                        \
             signed char: "%hhd",                                               \
@@ -48,9 +48,9 @@ typedef enum check_result (*test_fn)(void);
         (void)fprintf(stderr, "%sCHECK: result( %s ) == expected( %s )%s\n",   \
                       GREEN, result_string, expected_string, NONE);            \
         (void)fprintf(stderr, "%sERROR: result( ", RED);                       \
-        (void)fprintf(stderr, format_string_, result_);                        \
+        (void)fprintf(stderr, format_string, result);                          \
         (void)fprintf(stderr, " ) != expected( ");                             \
-        (void)fprintf(stderr, format_string_, expected_);                      \
+        (void)fprintf(stderr, format_string, expected);                        \
         (void)fprintf(stderr, " )\n%s", NONE);                                 \
     } while (0)
 
@@ -103,7 +103,7 @@ CHECK_BEGIN_STATIC_FN(insert_shuffled, ccc_ordered_multimap *pq,
 #define CHECK_BEGIN_STATIC_FN(test_name, ...)                                  \
     static enum check_result(test_name)(OPTIONAL_PARAMS(__VA_ARGS__))          \
     {                                                                          \
-        enum check_result check_macro_res_ = PASS;
+        enum check_result check_macro_res = PASS;
 
 /** @brief Define a test function that has a name and optionally
 additional parameters that one may wish to define a test function.
@@ -117,7 +117,7 @@ a test fails. See begin static test for examples. */
 #define CHECK_BEGIN_FN(test_name, ...)                                         \
     enum check_result(test_name)(OPTIONAL_PARAMS(__VA_ARGS__))                 \
     {                                                                          \
-        enum check_result check_macro_res_ = PASS;
+        enum check_result check_macro_res = PASS;
 
 /** @brief execute a check within the context of a test.
 @param [in] test_result the result value of some action.
@@ -142,13 +142,12 @@ though the braces are not required. */
 #define CHECK(test_result, test_expected, ...)                                 \
     do                                                                         \
     {                                                                          \
-        const __auto_type result_ = (test_result);                             \
-        typeof(result_) const expected_ = (test_expected);                     \
-        if (result_ != expected_)                                              \
+        const __auto_type result = (test_result);                              \
+        typeof(result) const expected = (test_expected);                       \
+        if (result != expected)                                                \
         {                                                                      \
-            CHECK_FAIL_PRINT(result_, #test_result, expected_,                 \
-                             #test_expected);                                  \
-            check_macro_res_ = FAIL;                                           \
+            CHECK_FAIL_PRINT(result, #test_result, expected, #test_expected);  \
+            check_macro_res = FAIL;                                            \
             __VA_OPT__((void)({__VA_ARGS__});)                                 \
             goto use_a_check_and_end_fn_with_one_of_the_CHECK_END_macros;      \
         }                                                                      \
@@ -180,13 +179,12 @@ though the braces are not required. */
 #define CHECK_ERROR(test_result, test_expected, ...)                           \
     do                                                                         \
     {                                                                          \
-        const __auto_type result_ = (test_result);                             \
-        typeof(result_) const expected_ = (test_expected);                     \
-        if (result_ != expected_)                                              \
+        const __auto_type result = (test_result);                              \
+        typeof(result) const expected = (test_expected);                       \
+        if (result != expected)                                                \
         {                                                                      \
-            CHECK_FAIL_PRINT(result_, #test_result, expected_,                 \
-                             #test_expected);                                  \
-            check_macro_res_ = ERROR;                                          \
+            CHECK_FAIL_PRINT(result, #test_result, expected, #test_expected);  \
+            check_macro_res = ERROR;                                           \
             __VA_OPT__((void)({__VA_ARGS__});)                                 \
             goto use_a_check_and_end_fn_with_one_of_the_CHECK_END_macros;      \
         }                                                                      \
@@ -218,7 +216,7 @@ CHECK_BEGIN_FN(my_test)
 
 This is not recommended as complex tests should be simplified such that one
 of the end test macros is sufficient. */
-#define CHECK_STATUS check_macro_res_
+#define CHECK_STATUS check_macro_res
 
 /** @brief End every test started with the end test macro.
 @param [in] ... optional code block with arbitrary cleanup code to be executed
@@ -239,7 +237,7 @@ grained control over nested scope is required upon a failure.*/
 #define CHECK_END_FN(...)                                                      \
 use_a_check_and_end_fn_with_one_of_the_CHECK_END_macros:                       \
     __VA_OPT__((void)({__VA_ARGS__});)                                         \
-    return check_macro_res_;                                                   \
+    return check_macro_res;                                                    \
     }
 
 /** @brief End every test started with the end pass macro.
@@ -260,12 +258,12 @@ macro if more fine grained control over nested scope is required upon a failure.
 #define CHECK_END_FN_PASS(...)                                                 \
 use_a_check_and_end_fn_with_one_of_the_CHECK_END_macros:                       \
     __VA_OPT__((void)({                                                        \
-                   if (check_macro_res_ == PASS)                               \
+                   if (check_macro_res == PASS)                                \
                    {                                                           \
                        __VA_ARGS__                                             \
                    }                                                           \
                });)                                                            \
-    return check_macro_res_;                                                   \
+    return check_macro_res;                                                    \
     }
 
 /** @brief End every test started with the end fail macros.
@@ -286,12 +284,12 @@ failure.*/
 #define CHECK_END_FN_FAIL(...)                                                 \
 use_a_check_and_end_fn_with_one_of_the_CHECK_END_macros:                       \
     __VA_OPT__((void)({                                                        \
-                   if (check_macro_res_ == FAIL)                               \
+                   if (check_macro_res == FAIL)                                \
                    {                                                           \
                        __VA_ARGS__                                             \
                    }                                                           \
                });)                                                            \
-    return check_macro_res_;                                                   \
+    return check_macro_res;                                                    \
     }
 
 /** @brief End every test started with the end error macro.
@@ -312,12 +310,12 @@ failure.*/
 #define CHECK_END_FN_ERROR(...)                                                \
 use_a_check_and_end_fn_with_one_of_the_CHECK_END_macros:                       \
     __VA_OPT__((void)({                                                        \
-                   if (check_macro_res_ == ERROR)                              \
+                   if (check_macro_res == ERROR)                               \
                    {                                                           \
                        __VA_ARGS__                                             \
                    }                                                           \
                });)                                                            \
-    return check_macro_res_;                                                   \
+    return check_macro_res;                                                    \
     }
 
 /** @brief Runs a list of test functions and returns the result.
@@ -333,17 +331,17 @@ will simply set the overall test state to fail and the user should examine the
 individual test that failed with FAIL or ERROR. */
 #define CHECK_RUN(test_fn_list...)                                             \
     ({                                                                         \
-        enum check_result const check_all_checks_[] = {test_fn_list};          \
-        enum check_result check_all_checks_res_ = PASS;                        \
+        enum check_result const check_all_checks[] = {test_fn_list};           \
+        enum check_result check_all_checks_res = PASS;                         \
         for (unsigned long long i = 0;                                         \
-             i < sizeof(check_all_checks_) / sizeof(enum check_result); ++i)   \
+             i < sizeof(check_all_checks) / sizeof(enum check_result); ++i)    \
         {                                                                      \
-            if (check_all_checks_[i] != PASS)                                  \
+            if (check_all_checks[i] != PASS)                                   \
             {                                                                  \
-                check_all_checks_res_ = FAIL;                                  \
+                check_all_checks_res = FAIL;                                   \
             }                                                                  \
         }                                                                      \
-        check_all_checks_res_;                                                 \
+        check_all_checks_res;                                                  \
     })
 
 #endif /* CHECKERS */

--- a/tests/fhmap/test_fhmap_erase.c
+++ b/tests/fhmap/test_fhmap_erase.c
@@ -96,7 +96,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_erase_fixed)
                                    fhmap_id_eq, NULL, NULL, fix_cap);
     int to_insert[fhm_fixed_capacity(standard_fixed_map)];
     iota(to_insert, fix_cap, 0);
-    rand_shuffle(sizeof(int), to_insert, fix_cap, &(int){});
+    rand_shuffle(sizeof(int), to_insert, fix_cap, &(int){0});
     int i = 0;
     do
     {
@@ -176,7 +176,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_erase_reserved)
     /* Give ourselves plenty more to insert so we don't run out before cap. */
     int to_insert[1024];
     iota(to_insert, 1024, 0);
-    rand_shuffle(sizeof(int), to_insert, 1024, &(int){});
+    rand_shuffle(sizeof(int), to_insert, 1024, &(int){0});
     int i = 0;
     do
     {
@@ -248,7 +248,7 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_erase_dynamic)
                    std_alloc, NULL, 0);
     int to_insert[1024];
     iota(to_insert, 1024, 0);
-    rand_shuffle(sizeof(int), to_insert, 1024, &(int){});
+    rand_shuffle(sizeof(int), to_insert, 1024, &(int){0});
     int inserted = 0;
     for (; inserted < 1024; ++inserted)
     {


### PR DESCRIPTION
flat hash map was getting portable fallback by mistake on x86