### PR TITLE
consolidate preprocessor checks to one location for simd

### DIFF
--- a/src/bitset.c
+++ b/src/bitset.c
@@ -1701,12 +1701,8 @@ size_t_min(size_t a, size_t b)
 /** The following asserts assure that whether portable or built in bit
 operations are used in the coming section we are safe in our assumptions about
 widths and counts. */
-
-static_assert(__builtin_popcount((ccc_bitblock)~0) <= U8BLOCK_MAX);
 static_assert(BITBLOCK_MSB < BITBLOCK_ON);
 static_assert(SIZEOF_BLOCK == sizeof(unsigned));
-static_assert(__builtin_ctz(BITBLOCK_MSB) <= U8BLOCK_MAX);
-static_assert(__builtin_clz((ccc_bitblock)1) <= U8BLOCK_MAX);
 
 /** Built-ins are common on Clang and GCC but we have portable fallback. */
 #if defined(__has_builtin) && __has_builtin(__builtin_ctz)                     \
@@ -1718,6 +1714,7 @@ popcount(ccc_bitblock const b)
 {
     /* There are different pop counts for different integer widths. Be sure to
        catch the use of the wrong one by mistake here at compile time. */
+    static_assert(__builtin_popcount((ccc_bitblock)~0) <= U8BLOCK_MAX);
     return (ublock8)__builtin_popcount(b);
 }
 
@@ -1726,6 +1723,7 @@ significant bit. */
 static inline ublock8
 ctz(ccc_bitblock const b)
 {
+    static_assert(__builtin_ctz(BITBLOCK_MSB) <= U8BLOCK_MAX);
     return b ? (ublock8)__builtin_ctz(b) : BITBLOCK_BITS;
 }
 
@@ -1734,6 +1732,7 @@ bit. */
 static inline ublock8
 clz(ccc_bitblock const b)
 {
+    static_assert(__builtin_clz((ccc_bitblock)1) <= U8BLOCK_MAX);
     return b ? (ublock8)__builtin_clz(b) : BITBLOCK_BITS;
 }
 

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -43,7 +43,9 @@ better capabilities for 128 bit group operations. */
 #include "impl/impl_types.h"
 #include "types.h"
 
-/** Two platforms offer some form of vector instructions we can try. */
+/** Note that these includes must come after inclusion of the
+`impl/impl_flat_hash_map.h` header. Two platforms offer some form of vector
+instructions we can try. */
 #if defined(CCC_HAS_X86_SIMD)
 #    include <immintrin.h>
 #elif defined(CCC_HAS_ARM_SIMD)

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -196,12 +196,12 @@ typedef struct
 
 enum : uint64_t
 {
-    /** @private LSB tag bits used for byte and word level masking. */
-    INDEX_MASK_BYTE_LSBS = 0x101010101010101,
     /** @private MSB tag bit used for static assert. */
     INDEX_MASK_MSB = 0x8000000000000000,
     /** @private MSB tag bits used for byte and word level masking. */
     INDEX_MASK_BYTE_MSBS = 0x8080808080808080,
+    /** @private LSB tag bits used for byte and word level masking. */
+    INDEX_MASK_BYTE_LSBS = 0x101010101010101,
     /** @private Debug mode check for bits that must be off in index mask. */
     INDEX_MASK_BYTE_OFF_BITS = 0x7F7F7F7F7F7F7F7F,
 };
@@ -227,12 +227,12 @@ typedef struct
 
 enum : typeof((group){}.v)
 {
-    /** @private LSB tag bits used for byte and word level masking. */
-    INDEX_MASK_BYTE_LSBS = 0x101010101010101,
     /** @private MSB tag bit used for static assert. */
     INDEX_MASK_MSB = 0x8000000000000000,
     /** @private MSB tag bits used for byte and word level masking. */
     INDEX_MASK_BYTE_MSBS = 0x8080808080808080,
+    /** @private LSB tag bits used for byte and word level masking. */
+    INDEX_MASK_BYTE_LSBS = 0x101010101010101,
     /** @private Debug mode check for bits that must be off in index mask. */
     INDEX_MASK_BYTE_OFF_BITS = 0x7F7F7F7F7F7F7F7F,
 };
@@ -2049,24 +2049,24 @@ clz_size_t(size_t n)
 static_assert(
     sizeof((index_mask){}.v) == sizeof(long),
     "builtin assumes an integer width that must be compatible with index mask");
-static_assert(
-    __builtin_ctzl(INDEX_MASK_MSB) / CCC_FHM_GROUP_SIZE
-        == CCC_FHM_GROUP_SIZE - 1,
-    "builtin trailing zeros must produce number of bits we expect for mask");
-static_assert(
-    __builtin_clzl((index_mask){1}.v) / CCC_FHM_GROUP_SIZE
-        == CCC_FHM_GROUP_SIZE - 1,
-    "builtin trailing zeros must produce number of bits we expect for mask");
 
 static inline unsigned
 ctz(index_mask const m)
 {
+    static_assert(__builtin_ctzl(INDEX_MASK_MSB) / CCC_FHM_GROUP_SIZE
+                      == CCC_FHM_GROUP_SIZE - 1,
+                  "builtin trailing zeros must produce number of bits we "
+                  "expect for mask");
     return m.v ? __builtin_ctzl(m.v) / CCC_FHM_GROUP_SIZE : CCC_FHM_GROUP_SIZE;
 }
 
 static inline unsigned
 clz(index_mask const m)
 {
+    static_assert(__builtin_clzl((index_mask){1}.v) / CCC_FHM_GROUP_SIZE
+                      == CCC_FHM_GROUP_SIZE - 1,
+                  "builtin trailing zeros must produce number of bits we "
+                  "expect for mask");
     return m.v ? __builtin_clzl(m.v) / CCC_FHM_GROUP_SIZE : CCC_FHM_GROUP_SIZE;
 }
 

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -199,11 +199,11 @@ enum : uint64_t
     /** @private MSB tag bit used for static assert. */
     INDEX_MASK_MSB = 0x8000000000000000,
     /** @private MSB tag bits used for byte and word level masking. */
-    INDEX_MASK_TAG_MSBS = 0x8080808080808080,
+    INDEX_MASK_TAGS_MSBS = 0x8080808080808080,
     /** @private LSB tag bits used for byte and word level masking. */
-    INDEX_MASK_TAG_LSBS = 0x101010101010101,
+    INDEX_MASK_TAGS_LSBS = 0x101010101010101,
     /** @private Debug mode check for bits that must be off in index mask. */
-    INDEX_MASK_TAG_OFF_BITS = 0x7F7F7F7F7F7F7F7F,
+    INDEX_MASK_TAGS_OFF_BITS = 0x7F7F7F7F7F7F7F7F,
 };
 
 #else /* PORTABLE FALLBACK */
@@ -230,11 +230,11 @@ enum : typeof((group){}.v)
     /** @private MSB tag bit used for static assert. */
     INDEX_MASK_MSB = 0x8000000000000000,
     /** @private MSB tag bits used for byte and word level masking. */
-    INDEX_MASK_TAG_MSBS = 0x8080808080808080,
+    INDEX_MASK_TAGS_MSBS = 0x8080808080808080,
     /** @private LSB tag bits used for byte and word level masking. */
-    INDEX_MASK_TAG_LSBS = 0x101010101010101,
+    INDEX_MASK_TAGS_LSBS = 0x101010101010101,
     /** @private Debug mode check for bits that must be off in index mask. */
-    INDEX_MASK_TAG_OFF_BITS = 0x7F7F7F7F7F7F7F7F,
+    INDEX_MASK_TAGS_OFF_BITS = 0x7F7F7F7F7F7F7F7F,
 };
 
 enum : uint8_t
@@ -1776,10 +1776,10 @@ match_tag(group const g, ccc_fhm_tag const m)
 
     index_mask const res = {
         vget_lane_u64(vreinterpret_u64_u8(vceq_u8(g.v, vdup_n_u8(m.v))), 0)
-            & INDEX_MASK_TAG_MSBS,
+            & INDEX_MASK_TAGS_MSBS,
     };
     assert(
-        (res.v & INDEX_MASK_TAG_OFF_BITS) == 0
+        (res.v & INDEX_MASK_TAGS_OFF_BITS) == 0
         && "For bit counting and iteration purposes the most significant bit "
            "in every byte will indicate a match for a tag has occurred.");
     return res;
@@ -1803,10 +1803,10 @@ match_empty_or_deleted(group const g)
 {
     uint8x8_t const cmp = vcltz_s8(vreinterpret_s8_u8(g.v));
     index_mask const res = {
-        vget_lane_u64(vreinterpret_u64_u8(cmp), 0) & INDEX_MASK_TAG_MSBS,
+        vget_lane_u64(vreinterpret_u64_u8(cmp), 0) & INDEX_MASK_TAGS_MSBS,
     };
     assert(
-        (res.v & INDEX_MASK_TAG_OFF_BITS) == 0
+        (res.v & INDEX_MASK_TAGS_OFF_BITS) == 0
         && "For bit counting and iteration purposes the most significant bit "
            "in every byte will indicate a match for a tag has occurred.");
     return res;
@@ -1901,10 +1901,10 @@ match_tag(group g, ccc_fhm_tag const m)
                | (((typeof(g.v))m.v) << TAG_BITS) | (m.v)),
     };
     index_mask const res = to_little_endian((index_mask){
-        (cmp.v - INDEX_MASK_TAG_LSBS) & ~cmp.v & INDEX_MASK_TAG_MSBS,
+        (cmp.v - INDEX_MASK_TAGS_LSBS) & ~cmp.v & INDEX_MASK_TAGS_MSBS,
     });
     assert(
-        (res.v & INDEX_MASK_TAG_OFF_BITS) == 0
+        (res.v & INDEX_MASK_TAGS_OFF_BITS) == 0
         && "For bit counting and iteration purposes the most significant bit "
            "in every byte will indicate a match for a tag has occurred.");
     return res;
@@ -1918,7 +1918,7 @@ match_empty(group const g)
     /* EMPTY has all bits on and DELETED has the most significant bit on so
        EMPTY must have the top 2 bits on. Make sure the mask is only MSB's. */
     return to_little_endian(
-        (index_mask){g.v & (g.v << 1) & INDEX_MASK_TAG_MSBS});
+        (index_mask){g.v & (g.v << 1) & INDEX_MASK_TAGS_MSBS});
 }
 
 /** Returns an index mask with the most significant bit in every byte on if
@@ -1926,7 +1926,7 @@ that tag in g is empty or deleted. This is found by the most significant bit. */
 static inline index_mask
 match_empty_or_deleted(group const g)
 {
-    return to_little_endian((index_mask){g.v & INDEX_MASK_TAG_MSBS});
+    return to_little_endian((index_mask){g.v & INDEX_MASK_TAGS_MSBS});
 }
 
 /** Converts the empty and deleted constants all TAG_EMPTY and the full
@@ -1936,7 +1936,7 @@ significant bit. This does not affect user hashed data. */
 static inline group
 make_constants_empty_and_full_deleted(group g)
 {
-    g.v = ~g.v & INDEX_MASK_TAG_MSBS;
+    g.v = ~g.v & INDEX_MASK_TAGS_MSBS;
     g.v = ~g.v + (g.v >> (TAG_BITS - 1));
     return g;
 }


### PR DESCRIPTION
Given the accidental underscore deletion bug we fixed, complex preprocessor checks should be one location only.