### PR TITLE
Flat Hash Map Initialization

### DIFF
--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -391,6 +391,7 @@ key is NULL. */
 /** @name Entry Interface
 Obtain and operate on container entries for efficient queries when non-trivial
 control flow is needed. */
+/**@{*/
 
 /** @brief Obtains an entry for the provided key in the table for future use.
 @param [in] h the hash table to be searched.

--- a/samples/graph.c
+++ b/samples/graph.c
@@ -410,8 +410,8 @@ static bool
 found_dst(struct graph *const graph, struct vertex *const src)
 {
     flat_hash_map parent_map
-        = fhm_init((struct path_backtrack_cell *)NULL, NULL, current,
-                   hash_parent_cells, eq_parent_cells, std_alloc, NULL, 0);
+        = fhm_init(NULL, struct path_backtrack_cell, current, hash_parent_cells,
+                   eq_parent_cells, std_alloc, NULL, 0);
     flat_double_ended_queue bfs
         = fdeq_init((struct point *)NULL, std_alloc, NULL, 0);
     entry *e = fhm_insert_or_assign_w(

--- a/samples/maze.c
+++ b/samples/maze.c
@@ -243,7 +243,7 @@ animate_maze(struct maze *maze)
     /* Test use case of reserve without reallocation permission. Guarantees
        exactly the needed memory and no more over lifetime of program. */
     flat_hash_map cost_map
-        = fhm_init((struct prim_cell *)NULL, NULL, cell, prim_cell_hash_fn,
+        = fhm_init(NULL, struct prim_cell, cell, prim_cell_hash_fn,
                    prim_cell_eq, NULL, NULL, 0);
     result r = fhm_reserve(&cost_map, ((maze->rows * maze->cols) / 2) + 1,
                            std_alloc);

--- a/tests/fhmap/test_fhmap_construct.c
+++ b/tests/fhmap/test_fhmap_construct.c
@@ -23,9 +23,8 @@ modw(ccc_any_type const u)
     v->val = *((int *)u.aux);
 }
 
-static small_fixed_map static_fh_mem;
 static ccc_flat_hash_map static_fh
-    = fhm_init(static_fh_mem.data, static_fh_mem.tag, key, fhmap_int_to_u64,
+    = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
                fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_static_init)
@@ -70,12 +69,12 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_static_init)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc)
 {
-    small_fixed_map src_mem;
-    standard_fixed_map dst_mem;
-    flat_hash_map src = fhm_init(src_mem.data, src_mem.tag, key, fhmap_int_zero,
-                                 fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
-    flat_hash_map dst = fhm_init(dst_mem.data, dst_mem.tag, key, fhmap_int_zero,
-                                 fhmap_id_eq, NULL, NULL, STANDARD_FIXED_CAP);
+    flat_hash_map src
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_zero,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    flat_hash_map dst
+        = fhm_init(&(standard_fixed_map){}, struct val, key, fhmap_int_zero,
+                   fhmap_id_eq, NULL, NULL, STANDARD_FIXED_CAP);
     (void)swap_entry(&src, &(struct val){.key = 0});
     (void)swap_entry(&src, &(struct val){.key = 1, .val = 1});
     (void)swap_entry(&src, &(struct val){.key = 2, .val = 2});
@@ -97,12 +96,12 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc_fail)
 {
-    standard_fixed_map src_mem;
-    small_fixed_map dst_mem;
-    flat_hash_map src = fhm_init(src_mem.data, src_mem.tag, key, fhmap_int_zero,
-                                 fhmap_id_eq, NULL, NULL, STANDARD_FIXED_CAP);
-    flat_hash_map dst = fhm_init(dst_mem.data, dst_mem.tag, key, fhmap_int_zero,
-                                 fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    flat_hash_map src
+        = fhm_init(&(standard_fixed_map){}, struct val, key, fhmap_int_zero,
+                   fhmap_id_eq, NULL, NULL, STANDARD_FIXED_CAP);
+    flat_hash_map dst
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_zero,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     (void)swap_entry(&src, &(struct val){.key = 0});
     (void)swap_entry(&src, &(struct val){.key = 1, .val = 1});
     (void)swap_entry(&src, &(struct val){.key = 2, .val = 2});
@@ -115,9 +114,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_no_alloc_fail)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc)
 {
-    flat_hash_map src = fhm_init((struct val *)NULL, NULL, key, fhmap_int_zero,
+    flat_hash_map src = fhm_init(NULL, struct val, key, fhmap_int_zero,
                                  fhmap_id_eq, std_alloc, NULL, 0);
-    flat_hash_map dst = fhm_init((struct val *)NULL, NULL, key, fhmap_int_zero,
+    flat_hash_map dst = fhm_init(NULL, struct val, key, fhmap_int_zero,
                                  fhmap_id_eq, std_alloc, NULL, 0);
     (void)swap_entry(&src, &(struct val){.key = 0});
     (void)swap_entry(&src, &(struct val){.key = 1, .val = 1});
@@ -143,9 +142,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc_fail)
 {
-    flat_hash_map src = fhm_init((struct val *)NULL, NULL, key, fhmap_int_zero,
+    flat_hash_map src = fhm_init(NULL, struct val, key, fhmap_int_zero,
                                  fhmap_id_eq, std_alloc, NULL, 0);
-    flat_hash_map dst = fhm_init((struct val *)NULL, NULL, key, fhmap_int_zero,
+    flat_hash_map dst = fhm_init(NULL, struct val, key, fhmap_int_zero,
                                  fhmap_id_eq, std_alloc, NULL, 0);
     (void)swap_entry(&src, &(struct val){.key = 0});
     (void)swap_entry(&src, &(struct val){.key = 1, .val = 1});
@@ -159,9 +158,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_copy_alloc_fail)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_empty)
 {
-    small_fixed_map s;
-    flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_zero, fhmap_id_eq,
-                                NULL, NULL, SMALL_FIXED_CAP);
+    flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_zero,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     CHECK(is_empty(&fh), true);
     CHECK_END_FN();
 }

--- a/tests/fhmap/test_fhmap_entry.c
+++ b/tests/fhmap/test_fhmap_entry.c
@@ -64,9 +64,9 @@ CHECK_BEGIN_STATIC_FN(fill_n, ccc_flat_hash_map *const fh, size_t const n,
    the user on insert. Leave this test here to always catch this. */
 CHECK_BEGIN_STATIC_FN(fhmap_test_validate)
 {
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
 
     ccc_entry ent = swap_entry(&fh, &(struct val){.key = -1, .val = -1});
     CHECK(validate(&fh), true);
@@ -87,9 +87,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_validate)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     ccc_entry ent = swap_entry(&fh, &(struct val){.key = -1, .val = -1});
     CHECK(validate(&fh), true);
     CHECK(occupied(&ent), false);
@@ -145,9 +145,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 CHECK_BEGIN_STATIC_FN(fhmap_test_remove)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     ccc_entry ent = ccc_remove(&fh, &(struct val){.key = -1, .val = -1});
     CHECK(validate(&fh), true);
     CHECK(occupied(&ent), false);
@@ -215,9 +215,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_remove)
 CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     ccc_entry ent = try_insert(&fh, &(struct val){.key = -1, .val = -1});
     CHECK(validate(&fh), true);
     CHECK(occupied(&ent), false);
@@ -272,9 +272,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert)
 CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert_with)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     ccc_entry *ent = fhm_try_insert_w(&fh, -1, val(-1));
     CHECK(validate(&fh), true);
     CHECK(occupied(ent), false);
@@ -330,9 +330,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_try_insert_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     ccc_entry ent = insert_or_assign(&fh, &(struct val){.key = -1, .val = -1});
     CHECK(validate(&fh), true);
     CHECK(occupied(&ent), false);
@@ -387,9 +387,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign_with)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     ccc_entry *ent = fhm_insert_or_assign_w(&fh, -1, val(-1));
     CHECK(validate(&fh), true);
     CHECK(occupied(ent), false);
@@ -444,9 +444,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_or_assign_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     ccc_fhmap_entry *ent = entry_r(&fh, &(int){-1});
     CHECK(validate(&fh), true);
     CHECK(occupied(ent), false);
@@ -514,9 +514,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify)
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_aux)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     int aux = 1;
     ccc_fhmap_entry *ent = entry_r(&fh, &(int){-1});
     ent = and_modify_aux(ent, plusaux, &aux);
@@ -581,9 +581,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_aux)
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_with)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     ccc_fhmap_entry *ent = entry_r(&fh, &(int){-1});
     ent = fhm_and_modify_w(ent, struct val, { T->val++; });
     CHECK(size(&fh).count, 0);
@@ -647,9 +647,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_and_modify_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     struct val *v = or_insert(entry_r(&fh, &(int){-1}),
                               &(struct val){.key = -1, .val = -1});
     CHECK(validate(&fh), true);
@@ -701,9 +701,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert)
 CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert_with)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     struct val *v = fhm_or_insert_w(entry_r(&fh, &(int){-1}), idval(-1, -1));
     CHECK(validate(&fh), true);
     CHECK(v != NULL, true);
@@ -753,9 +753,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_or_insert_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     struct val *v = insert_entry(entry_r(&fh, &(int){-1}),
                                  &(struct val){.key = -1, .val = -1});
     CHECK(validate(&fh), true);
@@ -807,9 +807,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry)
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry_with)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     struct val *v = fhm_insert_entry_w(entry_r(&fh, &(int){-1}), idval(-1, -1));
     CHECK(validate(&fh), true);
     CHECK(v != NULL, true);
@@ -859,9 +859,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_entry_with)
 CHECK_BEGIN_STATIC_FN(fhmap_test_remove_entry)
 {
     int const size = 30;
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     struct val *v = or_insert(entry_r(&fh, &(int){-1}),
                               &(struct val){.key = -1, .val = -1});
     CHECK(validate(&fh), true);

--- a/tests/fhmap/test_fhmap_erase.c
+++ b/tests/fhmap/test_fhmap_erase.c
@@ -14,9 +14,9 @@
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_erase)
 {
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_zero,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_zero,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     struct val query = {.key = 137, .val = 99};
     /* Nothing was there before so nothing is in the entry. */
     ccc_entry ent = swap_entry(&fh, &query);
@@ -44,10 +44,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_erase)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_insert_erase)
 {
-    ccc_flat_hash_map h
-        = fhm_init((struct val *)NULL, NULL, key, fhmap_int_to_u64, fhmap_id_eq,
-                   std_alloc, NULL, 0);
-
+    ccc_flat_hash_map h = fhm_init(NULL, struct val, key, fhmap_int_to_u64,
+                                   fhmap_id_eq, std_alloc, NULL, 0);
     int const to_insert = 100;
     int const larger_prime = 101;
     for (int i = 0, shuffle = larger_prime % to_insert; i < to_insert;
@@ -90,13 +88,12 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_insert_erase)
 /* This test will force us to test our in place hashing algorithm. */
 CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_erase_fixed)
 {
-    standard_fixed_map mem;
-    size_t const fix_cap = fhm_fixed_capacity(standard_fixed_map);
-    ccc_flat_hash_map h = fhm_init(mem.data, mem.tag, key, fhmap_int_to_u64,
-                                   fhmap_id_eq, NULL, NULL, fix_cap);
-    int to_insert[fhm_fixed_capacity(standard_fixed_map)];
-    iota(to_insert, fix_cap, 0);
-    rand_shuffle(sizeof(int), to_insert, fix_cap, &(int){0});
+    ccc_flat_hash_map h
+        = fhm_init(&(standard_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, STANDARD_FIXED_CAP);
+    int to_insert[STANDARD_FIXED_CAP];
+    iota(to_insert, STANDARD_FIXED_CAP, 0);
+    rand_shuffle(sizeof(int), to_insert, STANDARD_FIXED_CAP, &(int){0});
     int i = 0;
     do
     {
@@ -166,9 +163,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_erase_reserved)
     /* The map will be given dynamically reserved space but no ability to
        resize. All algorithms should function normally and in place rehashing
        should take effect. */
-    ccc_flat_hash_map h
-        = fhm_init((struct val *)NULL, NULL, key, fhmap_int_to_u64, fhmap_id_eq,
-                   NULL, NULL, 0);
+    ccc_flat_hash_map h = fhm_init(NULL, struct val, key, fhmap_int_to_u64,
+                                   fhmap_id_eq, NULL, NULL, 0);
     int const test_amount = 896;
     ccc_result const res_check = ccc_fhm_reserve(&h, test_amount, std_alloc);
     CHECK(res_check, CCC_RESULT_OK);
@@ -243,9 +239,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_erase_reserved)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_shuffle_erase_dynamic)
 {
-    ccc_flat_hash_map h
-        = fhm_init((struct val *)NULL, NULL, key, fhmap_int_to_u64, fhmap_id_eq,
-                   std_alloc, NULL, 0);
+    ccc_flat_hash_map h = fhm_init(NULL, struct val, key, fhmap_int_to_u64,
+                                   fhmap_id_eq, std_alloc, NULL, 0);
     int to_insert[1024];
     iota(to_insert, 1024, 0);
     rand_shuffle(sizeof(int), to_insert, 1024, &(int){0});

--- a/tests/fhmap/test_fhmap_insert.c
+++ b/tests/fhmap/test_fhmap_insert.c
@@ -13,9 +13,9 @@
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 {
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_zero,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_zero,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
 
     /* Nothing was there before so nothing is in the entry. */
     ccc_entry ent = swap_entry(&fh, &(struct val){.key = 137, .val = 99});
@@ -27,9 +27,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_macros)
 {
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_zero,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = ccc_fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_zero,
+                       fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
 
     struct val const *ins = ccc_fhm_or_insert_w(
         entry_r(&fh, &(int){2}), (struct val){.key = 2, .val = 0});
@@ -72,9 +72,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_overwrite)
 {
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_zero,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_zero,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
 
     struct val q = {.key = 137, .val = 99};
     ccc_entry ent = swap_entry(&fh, &q);
@@ -106,9 +106,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_overwrite)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_then_bad_ideas)
 {
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_zero,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_zero,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     struct val q = {.key = 137, .val = 99};
     ccc_entry ent = swap_entry(&fh, &q);
     CHECK(occupied(&ent), false);
@@ -137,10 +137,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_then_bad_ideas)
 CHECK_BEGIN_STATIC_FN(fhmap_test_entry_api_functional)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
-    standard_fixed_map s;
-    ccc_flat_hash_map fh
-        = fhm_init(s.data, s.tag, key, fhmap_int_last_digit, fhmap_id_eq, NULL,
-                   NULL, STANDARD_FIXED_CAP);
+    ccc_flat_hash_map fh = fhm_init(&(standard_fixed_map){}, struct val, key,
+                                    fhmap_int_last_digit, fhmap_id_eq, NULL,
+                                    NULL, STANDARD_FIXED_CAP);
     size_t const size = 200;
 
     /* Test entry or insert with for all even values. Default should be
@@ -197,10 +196,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_via_entry)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
     size_t const size = 200;
-    standard_fixed_map s;
-    ccc_flat_hash_map fh
-        = fhm_init(s.data, s.tag, key, fhmap_int_last_digit, fhmap_id_eq, NULL,
-                   NULL, STANDARD_FIXED_CAP);
+    ccc_flat_hash_map fh = fhm_init(&(standard_fixed_map){}, struct val, key,
+                                    fhmap_int_last_digit, fhmap_id_eq, NULL,
+                                    NULL, STANDARD_FIXED_CAP);
 
     /* Test entry or insert with for all even values. Default should be
        inserted. All entries are hashed to last digit so many spread out
@@ -242,10 +240,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_via_entry_macros)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
     size_t const size = 200;
-    standard_fixed_map s;
-    ccc_flat_hash_map fh
-        = fhm_init(s.data, s.tag, key, fhmap_int_last_digit, fhmap_id_eq, NULL,
-                   NULL, STANDARD_FIXED_CAP);
+    ccc_flat_hash_map fh = fhm_init(&(standard_fixed_map){}, struct val, key,
+                                    fhmap_int_last_digit, fhmap_id_eq, NULL,
+                                    NULL, STANDARD_FIXED_CAP);
 
     /* Test entry or insert with for all even values. Default should be
        inserted. All entries are hashed to last digit so many spread out
@@ -284,10 +281,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_api_macros)
 {
     /* Over allocate size now because we don't want to worry about resizing. */
     int const size = 200;
-    standard_fixed_map s;
-    ccc_flat_hash_map fh
-        = fhm_init(s.data, s.tag, key, fhmap_int_last_digit, fhmap_id_eq, NULL,
-                   NULL, STANDARD_FIXED_CAP);
+    ccc_flat_hash_map fh = fhm_init(&(standard_fixed_map){}, struct val, key,
+                                    fhmap_int_last_digit, fhmap_id_eq, NULL,
+                                    NULL, STANDARD_FIXED_CAP);
 
     /* Test entry or insert with for all even values. Default should be
        inserted. All entries are hashed to last digit so many spread out
@@ -338,9 +334,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_entry_api_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_two_sum)
 {
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     int const addends[10] = {1, 3, -980, 6, 7, 13, 44, 32, 995, -1};
     int const target = 15;
     int solution_indices[2] = {-1, -1};
@@ -365,10 +361,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_two_sum)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_resize)
 {
-    ccc_flat_hash_map fh
-        = fhm_init((struct val *)NULL, NULL, key, fhmap_int_to_u64, fhmap_id_eq,
-                   std_alloc, NULL, 0);
-
+    ccc_flat_hash_map fh = fhm_init(NULL, struct val, key, fhmap_int_to_u64,
+                                    fhmap_id_eq, std_alloc, NULL, 0);
     int const to_insert = 1000;
     int const larger_prime = 1009;
     for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
@@ -398,9 +392,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_resize_macros)
 {
-    ccc_flat_hash_map fh
-        = fhm_init((struct val *)NULL, NULL, key, fhmap_int_to_u64, fhmap_id_eq,
-                   std_alloc, NULL, 0);
+    ccc_flat_hash_map fh = fhm_init(NULL, struct val, key, fhmap_int_to_u64,
+                                    fhmap_id_eq, std_alloc, NULL, 0);
     int const to_insert = 1000;
     int const larger_prime = 1009;
     for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
@@ -438,9 +431,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null)
 {
-    ccc_flat_hash_map fh
-        = fhm_init((struct val *)NULL, NULL, key, fhmap_int_to_u64, fhmap_id_eq,
-                   std_alloc, NULL, 0);
+    ccc_flat_hash_map fh = fhm_init(NULL, struct val, key, fhmap_int_to_u64,
+                                    fhmap_id_eq, std_alloc, NULL, 0);
     int const to_insert = 1000;
     int const larger_prime = 1009;
     for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
@@ -468,9 +460,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null_macros)
 {
-    ccc_flat_hash_map fh
-        = fhm_init((struct val *)NULL, NULL, key, fhmap_int_to_u64, fhmap_id_eq,
-                   std_alloc, NULL, 0);
+    ccc_flat_hash_map fh = fhm_init(NULL, struct val, key, fhmap_int_to_u64,
+                                    fhmap_id_eq, std_alloc, NULL, 0);
     int const to_insert = 1000;
     int const larger_prime = 1009;
     for (int i = 0, shuffled_index = larger_prime % to_insert; i < to_insert;
@@ -508,9 +499,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_resize_from_null_macros)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_limit)
 {
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
 
     int const size = SMALL_FIXED_CAP;
     int const larger_prime = 1097;
@@ -569,10 +560,9 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_limit)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_insert_and_find)
 {
-    small_fixed_map s;
-    ccc_flat_hash_map fh = fhm_init(s.data, s.tag, key, fhmap_int_to_u64,
-                                    fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
-
+    ccc_flat_hash_map fh
+        = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
+                   fhmap_id_eq, NULL, NULL, SMALL_FIXED_CAP);
     int const size = SMALL_FIXED_CAP;
 
     for (int i = 0; i < size; i += 2)
@@ -605,9 +595,8 @@ CHECK_BEGIN_STATIC_FN(fhmap_test_insert_and_find)
 
 CHECK_BEGIN_STATIC_FN(fhmap_test_reserve_without_permissions)
 {
-    ccc_flat_hash_map fh
-        = fhm_init((struct val *)NULL, NULL, key, fhmap_int_to_u64, fhmap_id_eq,
-                   NULL, NULL, 0);
+    ccc_flat_hash_map fh = fhm_init(NULL, struct val, key, fhmap_int_to_u64,
+                                    fhmap_id_eq, std_alloc, NULL, 0);
     /* The map must insert all of the requested elements but has no permission
        to resize. This ensures the reserve function works as expected. */
     int const to_insert = 1000;

--- a/tests/fhmap/test_fhmap_lru.c
+++ b/tests/fhmap/test_fhmap_lru.c
@@ -98,15 +98,13 @@ enum : size_t
 
 static_assert(CAP * 1UL < SMALL_FIXED_CAP * 1UL);
 
-static small_fixed_map map_mem;
-
 /* This is a good opportunity to test the static initialization capabilities
    of the hash table and list. */
 static struct lru_cache lru_cache = {
     .cap = CAP,
     .l = dll_init(lru_cache.l, struct key_val, list_elem, cmp_by_key, std_alloc,
                   NULL),
-    .fh = fhm_init(map_mem.data, map_mem.tag, key, fhmap_int_to_u64,
+    .fh = fhm_init(&(small_fixed_map){}, struct val, key, fhmap_int_to_u64,
                    lru_lookup_cmp, NULL, NULL, SMALL_FIXED_CAP),
 };
 


### PR DESCRIPTION
This change fixes initialization of the `ccc_flat_hash_map`. Now the initialization no longer requires dangling references to fixed size maps to be left in user code. The user can use anonymous compound literal references so that the flat hash map completely owns the fixed size memory. We also eliminate the initialization flag as its easy to figure out if the container is initialized based on the data and tag array NULL statuses.