### PR TITLE
PQ and FPQ use T in closure

### DIFF
--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -264,25 +264,24 @@ void *ccc_fpq_update(ccc_flat_priority_queue *fpq, void *e,
 
 /** @brief Update the user type stored in the priority queue directly. O(lgN).
 @param [in] fpq_ptr a pointer to the flat priority queue.
-@param [in] T_ptr a pointer to the user type being updated.
+@param [in] any_type_ptr a pointer to the user type being updated.
 @param [in] update_closure_over_T the semicolon separated statements to execute
-on the user type at T_ptr (optionally wrapping {code here} in braces may help
+on the user type at T (optionally wrapping {code here} in braces may help
 with formatting). This closure may safely modify the key used to track the user
 element's priority in the priority queue.
 @return a reference to the element at its new position in the fpq on success,
 NULL if parameters are invalid or fpq is empty.
-@warning the user must ensure T_ptr is in the fpq.
+@warning the user must ensure any_type_ptr is in the fpq.
 
 ```
 #define FLAT_PRIORITY_QUEUE_USING_NAMESPACE_CCC
 flat_priority_queue fpq = build_rand_int_fpq();
-int *i = get_rand_fpq_elem(&fpq);
-(void)fpq_update_w(&fpq, i, { *i = rand_key(); });
+(void)fpq_update_w(&fpq, get_rand_fpq_elem(&fpq), { *T = rand_key(); });
 ```
 
 Note that whether the key increases or decreases does not affect runtime. */
-#define ccc_fpq_update_w(fpq_ptr, T_ptr, update_closure_over_T...)             \
-    ccc_impl_fpq_update_w(fpq_ptr, T_ptr, update_closure_over_T)
+#define ccc_fpq_update_w(fpq_ptr, any_type_ptr, update_closure_over_T...)      \
+    ccc_impl_fpq_update_w(fpq_ptr, any_type_ptr, update_closure_over_T)
 
 /** @brief Increase e that is a handle to the stored fpq element. O(lgN).
 @param [in] fpq a pointer to the flat priority queue.
@@ -297,25 +296,24 @@ void *ccc_fpq_increase(ccc_flat_priority_queue *fpq, void *e,
 
 /** @brief Increase the user type stored in the priority queue directly. O(lgN).
 @param [in] fpq_ptr a pointer to the flat priority queue.
-@param [in] T_ptr a pointer to the user type being updated.
+@param [in] any_type_ptr a pointer to the user type being updated.
 @param [in] increase_closure_over_T the semicolon separated statements to
-execute on the user type at T_ptr (optionally wrapping {code here} in braces may
-help with formatting). This closure may safely modify the key used to track the
-user element's priority in the priority queue.
+execute on the user type at T (optionally wrapping {code here} in
+braces may help with formatting). This closure may safely modify the key used to
+track the user element's priority in the priority queue.
 @return a reference to the element at its new position in the fpq on success,
 NULL if parameters are invalid or fpq is empty.
-@warning the user must ensure T_ptr is in the fpq.
+@warning the user must ensure any_type_ptr is in the fpq.
 
 ```
 #define FLAT_PRIORITY_QUEUE_USING_NAMESPACE_CCC
 flat_priority_queue fpq = build_rand_int_fpq();
-int *i = get_rand_fpq_elem(&fpq);
-(void)fpq_increase_w(&fpq, i, { (*i)++; });
+(void)fpq_increase_w(&fpq, get_rand_fpq_elem(&fpq), { (*T)++; });
 ```
 
 Note that if this priority queue is min or max, the runtime is the same. */
-#define ccc_fpq_increase_w(fpq_ptr, T_ptr, increase_closure_over_T...)         \
-    ccc_impl_fpq_increase_w(fpq_ptr, T_ptr, increase_closure_over_T)
+#define ccc_fpq_increase_w(fpq_ptr, any_type_ptr, increase_closure_over_T...)  \
+    ccc_impl_fpq_increase_w(fpq_ptr, any_type_ptr, increase_closure_over_T)
 
 /** @brief Decrease e that is a handle to the stored fpq element. O(lgN).
 @param [in] fpq a pointer to the flat priority queue.
@@ -330,25 +328,24 @@ void *ccc_fpq_decrease(ccc_flat_priority_queue *fpq, void *e,
 
 /** @brief Increase the user type stored in the priority queue directly. O(lgN).
 @param [in] fpq_ptr a pointer to the flat priority queue.
-@param [in] T_ptr a pointer to the user type being updated.
+@param [in] any_type_ptr a pointer to the user type being updated.
 @param [in] decrease_closure_over_T the semicolon separated statements to
-execute on the user type at T_ptr (optionally wrapping {code here} in braces may
-help with formatting). This closure may safely modify the key used to track the
-user element's priority in the priority queue.
+execute on the user type at T (optionally wrapping {code here} in
+braces may help with formatting). This closure may safely modify the key used to
+track the user element's priority in the priority queue.
 @return a reference to the element at its new position in the fpq on success,
 NULL if parameters are invalid or fpq is empty.
-@warning the user must ensure T_ptr is in the fpq.
+@warning the user must ensure any_type_ptr is in the fpq.
 
 ```
 #define FLAT_PRIORITY_QUEUE_USING_NAMESPACE_CCC
 flat_priority_queue fpq = build_rand_int_fpq();
-int *i = get_rand_fpq_elem(&fpq);
-(void)fpq_decrease_w(&fpq, i, { (*i)--; });
+(void)fpq_decrease_w(&fpq, get_rand_fpq_elem(&fpq), { (*T)--; });
 ```
 
 Note that if this priority queue is min or max, the runtime is the same. */
-#define ccc_fpq_decrease_w(fpq_ptr, T_ptr, decrease_closure_over_T...)         \
-    ccc_impl_fpq_decrease_w(fpq_ptr, T_ptr, decrease_closure_over_T)
+#define ccc_fpq_decrease_w(fpq_ptr, any_type_ptr, decrease_closure_over_T...)  \
+    ccc_impl_fpq_decrease_w(fpq_ptr, any_type_ptr, decrease_closure_over_T)
 
 /**@}*/
 

--- a/ccc/impl/impl_flat_priority_queue.h
+++ b/ccc/impl/impl_flat_priority_queue.h
@@ -124,14 +124,13 @@ void *ccc_impl_fpq_update_fixup(struct ccc_fpq *, void *);
 #define ccc_impl_fpq_update_w(fpq_ptr, T_ptr, update_closure_over_T...)        \
     (__extension__({                                                           \
         struct ccc_fpq *const impl_fpq = (fpq_ptr);                            \
-        void *impl_fpq_update_res = NULL;                                      \
-        void *const impl_fpq_t_ptr = (T_ptr);                                  \
-        if (impl_fpq && impl_fpq_t_ptr && !ccc_buf_is_empty(&impl_fpq->buf))   \
+        typeof(*T_ptr) *T = (T_ptr);                                           \
+        if (impl_fpq && !ccc_buf_is_empty(&impl_fpq->buf) && T)                \
         {                                                                      \
-            {update_closure_over_T} impl_fpq_update_res                        \
-                = ccc_impl_fpq_update_fixup(impl_fpq, impl_fpq_t_ptr);         \
+            {update_closure_over_T} T                                          \
+                = ccc_impl_fpq_update_fixup(impl_fpq, T);                      \
         }                                                                      \
-        impl_fpq_update_res;                                                   \
+        T;                                                                     \
     }))
 
 /** @private */

--- a/ccc/impl/impl_priority_queue.h
+++ b/ccc/impl/impl_priority_queue.h
@@ -124,6 +124,9 @@ void ccc_impl_pq_init_node(struct ccc_pq_elem *);
 /** @private */
 struct ccc_pq_elem *ccc_impl_pq_delete_node(struct ccc_pq *,
                                             struct ccc_pq_elem *);
+/** @private */
+void *ccc_impl_pq_struct_base(struct ccc_pq const *,
+                              struct ccc_pq_elem const *);
 
 /*=========================  Macro Implementations     ======================*/
 
@@ -168,47 +171,45 @@ struct ccc_pq_elem *ccc_impl_pq_delete_node(struct ccc_pq *,
     }))
 
 /** @private */
-#define ccc_impl_pq_update_w(pq_ptr, pq_elem_ptr, update_closure_over_T...)    \
+#define ccc_impl_pq_update_w(pq_ptr, any_type_ptr, update_closure_over_T...)   \
     (__extension__({                                                           \
         struct ccc_pq *const impl_pq = (pq_ptr);                               \
-        ccc_tribool impl_pq_update_res = CCC_FALSE;                            \
-        struct ccc_pq_elem *const impl_pq_node_ptr = (pq_elem_ptr);            \
-        if (impl_pq && impl_pq_node_ptr && impl_pq_node_ptr->next              \
-            && impl_pq_node_ptr->prev)                                         \
+        typeof(*any_type_ptr) *T = (any_type_ptr);                             \
+        if (impl_pq && T)                                                      \
         {                                                                      \
-            impl_pq_update_res = CCC_TRUE;                                     \
-            if (impl_pq_node_ptr->parent                                       \
-                && ccc_impl_pq_cmp(impl_pq, impl_pq_node_ptr,                  \
-                                   impl_pq_node_ptr->parent)                   \
+            struct ccc_pq_elem *const impl_pq_elem_ptr                         \
+                = ccc_impl_pq_elem_in(impl_pq, T);                             \
+            if (impl_pq_elem_ptr->parent                                       \
+                && ccc_impl_pq_cmp(impl_pq, impl_pq_elem_ptr,                  \
+                                   impl_pq_elem_ptr->parent)                   \
                        == impl_pq->order)                                      \
             {                                                                  \
-                ccc_impl_pq_cut_child(impl_pq_node_ptr);                       \
+                ccc_impl_pq_cut_child(impl_pq_elem_ptr);                       \
                 {update_closure_over_T} impl_pq->root = ccc_impl_pq_merge(     \
-                    impl_pq, impl_pq->root, impl_pq_node_ptr);                 \
+                    impl_pq, impl_pq->root, impl_pq_elem_ptr);                 \
             }                                                                  \
             else                                                               \
             {                                                                  \
                 impl_pq->root                                                  \
-                    = ccc_impl_pq_delete_node(impl_pq, impl_pq_node_ptr);      \
-                ccc_impl_pq_init_node(impl_pq_node_ptr);                       \
+                    = ccc_impl_pq_delete_node(impl_pq, impl_pq_elem_ptr);      \
+                ccc_impl_pq_init_node(impl_pq_elem_ptr);                       \
                 {update_closure_over_T} impl_pq->root = ccc_impl_pq_merge(     \
-                    impl_pq, impl_pq->root, impl_pq_node_ptr);                 \
+                    impl_pq, impl_pq->root, impl_pq_elem_ptr);                 \
             }                                                                  \
         }                                                                      \
-        impl_pq_update_res;                                                    \
+        T;                                                                     \
     }))
 
 /** @private */
-#define ccc_impl_pq_increase_w(pq_ptr, pq_elem_ptr,                            \
+#define ccc_impl_pq_increase_w(pq_ptr, any_type_ptr,                           \
                                increase_closure_over_T...)                     \
     (__extension__({                                                           \
         struct ccc_pq *const impl_pq = (pq_ptr);                               \
-        ccc_tribool impl_pq_increase_res = CCC_FALSE;                          \
-        struct ccc_pq_elem *const impl_pq_elem_ptr = (pq_elem_ptr);            \
-        if (impl_pq && impl_pq_elem_ptr && impl_pq_elem_ptr->next              \
-            && impl_pq_elem_ptr->prev)                                         \
+        typeof(*any_type_ptr) *T = (any_type_ptr);                             \
+        if (impl_pq && T)                                                      \
         {                                                                      \
-            impl_pq_increase_res = CCC_TRUE;                                   \
+            struct ccc_pq_elem *const impl_pq_elem_ptr                         \
+                = ccc_impl_pq_elem_in(impl_pq, T);                             \
             if (impl_pq->order == CCC_GRT)                                     \
             {                                                                  \
                 ccc_impl_pq_cut_child(impl_pq_elem_ptr);                       \
@@ -222,20 +223,19 @@ struct ccc_pq_elem *ccc_impl_pq_delete_node(struct ccc_pq *,
             {increase_closure_over_T} impl_pq->root                            \
                 = ccc_impl_pq_merge(impl_pq, impl_pq->root, impl_pq_elem_ptr); \
         }                                                                      \
-        impl_pq_increase_res;                                                  \
+        T;                                                                     \
     }))
 
 /** @private */
-#define ccc_impl_pq_decrease_w(pq_ptr, pq_elem_ptr,                            \
+#define ccc_impl_pq_decrease_w(pq_ptr, any_type_ptr,                           \
                                decrease_closure_over_T...)                     \
     (__extension__({                                                           \
         struct ccc_pq *const impl_pq = (pq_ptr);                               \
-        ccc_tribool impl_pq_decrease_res = CCC_FALSE;                          \
-        struct ccc_pq_elem *const impl_pq_elem_ptr = (pq_elem_ptr);            \
-        if (impl_pq && impl_pq_elem_ptr && impl_pq_elem_ptr->next              \
-            && impl_pq_elem_ptr->prev)                                         \
+        typeof(*any_type_ptr) *T = (any_type_ptr);                             \
+        if (impl_pq && T)                                                      \
         {                                                                      \
-            impl_pq_decrease_res = CCC_TRUE;                                   \
+            struct ccc_pq_elem *const impl_pq_elem_ptr                         \
+                = ccc_impl_pq_elem_in(impl_pq, T);                             \
             if (impl_pq->order == CCC_LES)                                     \
             {                                                                  \
                 ccc_impl_pq_cut_child(impl_pq_elem_ptr);                       \
@@ -249,7 +249,7 @@ struct ccc_pq_elem *ccc_impl_pq_delete_node(struct ccc_pq *,
             {decrease_closure_over_T} impl_pq->root                            \
                 = ccc_impl_pq_merge(impl_pq, impl_pq->root, impl_pq_elem_ptr); \
         }                                                                      \
-        impl_pq_decrease_res;                                                  \
+        T;                                                                     \
     }))
 
 /* NOLINTEND(readability-identifier-naming) */

--- a/samples/graph.c
+++ b/samples/graph.c
@@ -738,11 +738,13 @@ dijkstra_shortest_path(struct graph *const graph, char const src,
             if (alt < v->dist)
             {
                 /* Build the map with the appropriate best candidate parent. */
-                bool const relax = pq_decrease_w(&distances, &v->pq_elem, {
-                    v->dist = alt;
-                    v->from = u->name;
-                });
-                prog_assert(relax == true);
+                struct dijkstra_vertex const *const relax
+                    = pq_decrease_w(&distances, v,
+                                    {
+                                        T->dist = alt;
+                                        T->from = u->name;
+                                    });
+                prog_assert(relax == v);
                 paint_edge(graph, u->name, v->name, MAG);
                 nanosleep(&graph->speed, NULL);
             }

--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -174,44 +174,44 @@ ccc_pq_size(ccc_priority_queue const *const pq)
    to check if the value has exceeded the value of the first left child as
    any sibling of that left child may be bigger than or smaller than that
    left child value. */
-ccc_tribool
+void *
 ccc_pq_update(ccc_priority_queue *const pq, ccc_pq_elem *const e,
               ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!pq || !e || !fn || !e->next || !e->prev)
     {
-        return CCC_TRIBOOL_ERROR;
+        return NULL;
     }
     update_fixup(pq, e, fn, aux);
-    return CCC_TRUE;
+    return struct_base(pq, e);
 }
 
 /* Preferable to use this function if it is known the value is increasing.
    Much more efficient. */
-ccc_tribool
+void *
 ccc_pq_increase(ccc_priority_queue *const pq, ccc_pq_elem *const e,
                 ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!pq || !e || !fn || !e->next || !e->prev)
     {
-        return CCC_TRIBOOL_ERROR;
+        return NULL;
     }
     increase_fixup(pq, e, fn, aux);
-    return CCC_TRUE;
+    return struct_base(pq, e);
 }
 
 /* Preferable to use this function if it is known the value is decreasing.
    Much more efficient. */
-ccc_tribool
+void *
 ccc_pq_decrease(ccc_priority_queue *const pq, ccc_pq_elem *const e,
                 ccc_any_type_update_fn *const fn, void *const aux)
 {
     if (!pq || !e || !fn || !e->next || !e->prev)
     {
-        return CCC_TRIBOOL_ERROR;
+        return NULL;
     }
     decrease_fixup(pq, e, fn, aux);
-    return CCC_TRUE;
+    return struct_base(pq, e);
 }
 
 ccc_tribool
@@ -283,6 +283,13 @@ struct ccc_pq_elem *
 ccc_impl_pq_delete_node(struct ccc_pq *const pq, struct ccc_pq_elem *const root)
 {
     return delete_node(pq, root);
+}
+
+void *
+ccc_impl_pq_struct_base(struct ccc_pq const *const pq,
+                        struct ccc_pq_elem const *const e)
+{
+    return struct_base(pq, e);
 }
 
 /*========================   Static Helpers  ================================*/

--- a/tests/fpq/test_fpq_update.c
+++ b/tests/fpq/test_fpq_update.c
@@ -134,14 +134,13 @@ CHECK_BEGIN_STATIC_FN(fpq_test_priority_update_with)
     int const limit = 400;
     for (size_t val = 0; val < num_nodes; ++val)
     {
-        struct val *cur = &vals[val];
-        int backoff = cur->val / 2;
-        if (cur->val > limit)
+        int backoff = vals[val].val / 2;
+        if (vals[val].val > limit)
         {
             struct val const *const updated
-                = ccc_fpq_update_w(&fpq, cur,
+                = ccc_fpq_update_w(&fpq, &vals[val],
                                    {
-                                       cur->val = backoff;
+                                       T->val = backoff;
                                    });
             CHECK(updated != NULL, true);
             CHECK(updated->val, backoff);

--- a/tests/pq/test_pq_update.c
+++ b/tests/pq/test_pq_update.c
@@ -93,7 +93,8 @@ CHECK_BEGIN_STATIC_FN(pq_test_priority_update)
         int backoff = i->val / 2;
         if (i->val > limit)
         {
-            CHECK(ccc_pq_update(&pq, &i->elem, val_update, &backoff), true);
+            CHECK(ccc_pq_update(&pq, &i->elem, val_update, &backoff) != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
     }
@@ -121,11 +122,12 @@ CHECK_BEGIN_STATIC_FN(pq_test_priority_update_with)
     int const limit = 400;
     for (size_t val = 0; val < num_nodes; ++val)
     {
-        struct val *i = &vals[val];
-        int backoff = i->val / 2;
-        if (i->val > limit)
+        int backoff = vals[val].val / 2;
+        if (vals[val].val > limit)
         {
-            CHECK(ccc_pq_update_w(&pq, &i->elem, { i->val = backoff; }), true);
+            CHECK(ccc_pq_update_w(&pq, &vals[val], { T->val = backoff; })
+                      != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
     }
@@ -158,12 +160,14 @@ CHECK_BEGIN_STATIC_FN(pq_test_priority_increase)
         int dec = i->val / 2;
         if (i->val >= limit)
         {
-            CHECK(ccc_pq_decrease(&pq, &i->elem, val_update, &dec), true);
+            CHECK(ccc_pq_decrease(&pq, &i->elem, val_update, &dec) != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
         else
         {
-            CHECK(ccc_pq_increase(&pq, &i->elem, val_update, &inc), true);
+            CHECK(ccc_pq_increase(&pq, &i->elem, val_update, &inc) != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
     }
@@ -191,17 +195,18 @@ CHECK_BEGIN_STATIC_FN(pq_test_priority_increase_with)
     int const limit = 400;
     for (size_t val = 0; val < num_nodes; ++val)
     {
-        struct val *const i = &vals[val];
         int inc = limit * 2;
-        int dec = i->val / 2;
-        if (i->val >= limit)
+        int dec = vals[val].val / 2;
+        if (vals[val].val >= limit)
         {
-            CHECK(ccc_pq_decrease_w(&pq, &i->elem, { i->val = dec; }), true);
+            CHECK(ccc_pq_decrease_w(&pq, &vals[val], { T->val = dec; }) != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
         else
         {
-            CHECK(ccc_pq_increase_w(&pq, &i->elem, { i->val = inc; }), true);
+            CHECK(ccc_pq_increase_w(&pq, &vals[val], { T->val = inc; }) != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
     }
@@ -234,12 +239,14 @@ CHECK_BEGIN_STATIC_FN(pq_test_priority_decrease)
         int dec = i->val / 2;
         if (i->val < limit)
         {
-            CHECK(ccc_pq_increase(&pq, &i->elem, val_update, &inc), true);
+            CHECK(ccc_pq_increase(&pq, &i->elem, val_update, &inc) != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
         else
         {
-            CHECK(ccc_pq_decrease(&pq, &i->elem, val_update, &dec), true);
+            CHECK(ccc_pq_decrease(&pq, &i->elem, val_update, &dec) != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
     }
@@ -267,17 +274,18 @@ CHECK_BEGIN_STATIC_FN(pq_test_priority_decrease_with)
     int const limit = 400;
     for (size_t val = 0; val < num_nodes; ++val)
     {
-        struct val *const i = &vals[val];
         int inc = limit * 2;
-        int dec = i->val / 2;
-        if (i->val < limit)
+        int dec = vals[val].val / 2;
+        if (vals[val].val < limit)
         {
-            CHECK(ccc_pq_increase_w(&pq, &i->elem, { i->val = inc; }), true);
+            CHECK(ccc_pq_increase_w(&pq, &vals[val], { T->val = inc; }) != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
         else
         {
-            CHECK(ccc_pq_decrease_w(&pq, &i->elem, { i->val = dec; }), true);
+            CHECK(ccc_pq_decrease_w(&pq, &vals[val], { T->val = dec; }) != NULL,
+                  true);
             CHECK(validate(&pq), true);
         }
     }


### PR DESCRIPTION
The priority queue and the flat priority queue now appropriately use T in their closures. They also now both return a reference to the updated element for a consistent interface.