### PR TITLE
Sort via iterators

### DIFF
--- a/tests/buf/buf_util.h
+++ b/tests/buf/buf_util.h
@@ -1,6 +1,8 @@
 #ifndef BUF_UTIL_H
 #define BUF_UTIL_H
 
+#include <stddef.h>
+
 #include "ccc/buffer.h"
 #include "ccc/types.h"
 


### PR DESCRIPTION
To further test the buffer container sort with iterators instead of indices. This is probably slower but its fun. It also eliminates concerns over signed under and overflow given the nature of quick sort algorithm.