### PR TITLE
fix longest standing bug in pq update code

### DIFF
--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -357,6 +357,10 @@ decrease_fixup(struct ccc_pq *const pq, struct ccc_pq_elem *const e,
     pq->root = merge(pq, pq->root, e);
 }
 
+/** Cuts the child out of its current sibling list and redirects parent if
+this child is directly pointed to by parent. The child is then made into its
+own circular sibling list. The left child of this child, if one exists, is
+still pointed to and not modified by this function. */
 static void
 cut_child(struct ccc_pq_elem *const child)
 {
@@ -367,6 +371,7 @@ cut_child(struct ccc_pq_elem *const child)
         child->parent->child = child->next == child ? NULL : child->next;
     }
     child->parent = NULL;
+    child->next = child->prev = child;
 }
 
 static struct ccc_pq_elem *


### PR DESCRIPTION
This bug has been haunting the priority queue code for years. When updating a node via update, increase, or decrease, and we are able to execute the more simple cut child and re-merge at root, the child being cut must update its next and previous sibling pointers to point to itself in its own circular linked list. 

Previously these pointers were not updated causing the validate functions to find a nonsensical recursive traversal through the priority queue, probably detecting bad size or bad links. 

This happened so rarely in the tests because it only occurs when we are able to decrease the key in a min heap or increase it in a max heap. The test randomly updates keys based on if the randomly assigned original key falls under or over an arbitrary limit. So the behavior is hard to force consistently.