### PR TITLE
Linear Time Constant Space Tree Clearing

### DIFF
--- a/src/flat_priority_queue.c
+++ b/src/flat_priority_queue.c
@@ -40,6 +40,7 @@ static size_t bubble_down(struct ccc_fpq *, char tmp[const], size_t);
 static size_t update_fixup(struct ccc_fpq *, void *e);
 static void heapify(struct ccc_fpq *fpq, size_t n);
 static size_t max(size_t, size_t);
+static void destroy_each(struct ccc_fpq *fpq, ccc_any_type_destructor_fn *fn);
 
 /*=====================       Interface      ================================*/
 
@@ -320,14 +321,7 @@ ccc_fpq_clear(ccc_flat_priority_queue *const fpq,
     }
     if (fn)
     {
-        size_t const count = fpq->buf.count;
-        for (size_t i = 0; i < count; ++i)
-        {
-            fn((ccc_any_type){
-                .any_type = at(fpq, i),
-                .aux = fpq->buf.aux,
-            });
-        }
+        destroy_each(fpq, fn);
     }
     return ccc_buf_size_set(&fpq->buf, 0);
 }
@@ -342,14 +336,7 @@ ccc_fpq_clear_and_free(ccc_flat_priority_queue *const fpq,
     }
     if (fn)
     {
-        size_t const count = fpq->buf.count;
-        for (size_t i = 0; i < count; ++i)
-        {
-            fn((ccc_any_type){
-                .any_type = at(fpq, i),
-                .aux = fpq->buf.aux,
-            });
-        }
+        destroy_each(fpq, fn);
     }
     return ccc_buf_alloc(&fpq->buf, 0, fpq->buf.alloc);
 }
@@ -365,14 +352,7 @@ ccc_fpq_clear_and_free_reserve(ccc_flat_priority_queue *const fpq,
     }
     if (destructor)
     {
-        size_t const count = fpq->buf.count;
-        for (size_t i = 0; i < count; ++i)
-        {
-            destructor((ccc_any_type){
-                .any_type = at(fpq, i),
-                .aux = fpq->buf.aux,
-            });
-        }
+        destroy_each(fpq, destructor);
     }
     return ccc_buf_alloc(&fpq->buf, 0, alloc);
 }
@@ -557,6 +537,19 @@ index_of(struct ccc_fpq const *const fpq, void const *const slot)
                       / fpq->buf.sizeof_type);
     assert(i < fpq->buf.count);
     return i;
+}
+
+static inline void
+destroy_each(struct ccc_fpq *const fpq, ccc_any_type_destructor_fn *const fn)
+{
+    size_t const count = fpq->buf.count;
+    for (size_t i = 0; i < count; ++i)
+    {
+        fn((ccc_any_type){
+            .any_type = at(fpq, i),
+            .aux = fpq->buf.aux,
+        });
+    }
 }
 
 static inline size_t

--- a/tests/pq/test_pq_erase.c
+++ b/tests/pq/test_pq_erase.c
@@ -1,5 +1,6 @@
 #define TRAITS_USING_NAMESPACE_CCC
 
+#include "alloc.h"
 #include "checkers.h"
 #include "pq_util.h"
 #include "priority_queue.h"
@@ -196,12 +197,35 @@ CHECK_BEGIN_STATIC_FN(pq_test_weak_srand)
     CHECK_END_FN();
 }
 
+CHECK_BEGIN_STATIC_FN(pq_test_weak_srand_alloc)
+{
+    ccc_priority_queue ppq
+        = ccc_pq_init(struct val, elem, CCC_LES, val_cmp, std_alloc, NULL);
+    /* Seed the test with any integer for reproducible random test sequence
+       currently this will change every test. NOLINTNEXTLINE */
+    srand(time(NULL));
+    int const num_heap_elems = 100;
+    for (int i = 0; i < num_heap_elems; ++i)
+    {
+        CHECK(push(&ppq,
+                   &(struct val){
+                       .id = i,
+                       .val = rand() /*NOLINT*/,
+                   }
+                        .elem)
+                  != NULL,
+              true);
+        CHECK(validate(&ppq), true);
+    }
+    CHECK_END_FN(ccc_pq_clear(&ppq, NULL););
+}
+
 int
 main()
 {
-    return CHECK_RUN(pq_test_insert_remove_four_dups(),
-                     pq_test_insert_extract_shuffled(), pq_test_pop_max(),
-                     pq_test_pop_min(),
-                     pq_test_delete_prime_shuffle_duplicates(),
-                     pq_test_prime_shuffle(), pq_test_weak_srand());
+    return CHECK_RUN(
+        pq_test_insert_remove_four_dups(), pq_test_insert_extract_shuffled(),
+        pq_test_pop_max(), pq_test_pop_min(),
+        pq_test_delete_prime_shuffle_duplicates(), pq_test_prime_shuffle(),
+        pq_test_weak_srand(), pq_test_weak_srand_alloc());
 }


### PR DESCRIPTION
Previously, all tree based maps and the priority queue used their respective erase or pop methods to pop from the container, destroy, and then deallocate each node. This meant an `O(log(N))` operation per node leading to overall `O(N*log(N))` time for the `clear` and `clear_and_free` operations.

Instead, binary trees can use a simple left rotation in place deletion method for linear time and constant space. The priority queue can use a slightly different method but the same idea; it instead splices in its left child ring if it has one in order to achieve a linear time constant space approach.

This allows linear time constant space deletions that importantly are able to avoid recursion.