### PR TITLE
Flat Priority Queue Temp Argument

### DIFF
--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -27,6 +27,27 @@ The flat priority queue also offers a destructive heap sort option if the user
 desires an in-place strict `O(N * log(N))` and `O(1)` space sort that does not
 use recursion.
 
+Many functions in the interface request a temporary argument be passed as a swap
+slot. This is because a flat priority queue is backed by a binary heap and
+swaps elements to maintain its properties. Because the user may decide the
+flat priority queue has no allocation permission, the user must provide this
+swap slot. An easy way to do this in C99 and later is with anonymous compound
+literal references. For example, if we have a `int` flat priority queue we can
+provide a temporary slot inline to a function as follows.
+
+```
+ccc_fpq_push(&pq, &(int){0});
+```
+
+Any user defined struct can also use this technique.
+
+```
+ccc_fpq_push(&pq, &(struct my_type){});
+```
+
+This is the preferred method because the storage remains anonymous and
+inaccessible to other code in the calling scope.
+
 To shorten names in the interface, define the following preprocessor directive
 at the top of your file.
 
@@ -73,11 +94,7 @@ Initialize the container with memory, callbacks, and permissions. */
 @param [in] aux_data any auxiliary data needed for destruction of elements.
 @param [in] capacity the capacity of contiguous elements at mem_ptr.
 @return the initialized priority queue on the right hand side of an equality
-operator. (i.e. ccc_flat_priority_queue q = ccc_fpq_init(...);).
-
-Note that to avoid temporary or unpredictable allocation the fpq requires one
-slot for swapping. Therefore if the user wants a fixed size fpq of size N,
-N + 1 capacity is required. */
+operator. (i.e. ccc_flat_priority_queue q = ccc_fpq_init(...);). */
 #define ccc_fpq_init(mem_ptr, any_type_name, cmp_order, cmp_fn, alloc_fn,      \
                      aux_data, capacity)                                       \
     ccc_impl_fpq_init(mem_ptr, any_type_name, cmp_order, cmp_fn, alloc_fn,     \
@@ -93,11 +110,7 @@ N + 1 capacity is required. */
 @param [in] capacity the capacity of contiguous elements at mem_ptr.
 @param [in] size the size <= capacity.
 @return the initialized priority queue on the right hand side of an equality
-operator. (i.e. ccc_flat_priority_queue q = ccc_fpq_heapify_init(...);).
-
-Note that to avoid temporary or unpredictable allocation the fpq requires one
-slot for swapping. Therefore if the user wants a fixed size fpq of size N,
-N + 1 capacity is required. */
+operator. (i.e. ccc_flat_priority_queue q = ccc_fpq_heapify_init(...);). */
 #define ccc_fpq_heapify_init(mem_ptr, any_type_name, cmp_order, cmp_fn,        \
                              alloc_fn, aux_data, capacity, size)               \
     ccc_impl_fpq_heapify_init(mem_ptr, any_type_name, cmp_order, cmp_fn,       \

--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -373,7 +373,7 @@ Note that if this priority queue is min or max, the runtime is the same. */
 
 /** @brief Decrease e that is a handle to the stored fpq element. O(lgN).
 @param [in] fpq a pointer to the flat priority queue.
-@param [in] e a handle to the stored fpq element. Must be in the fpq.
+@param [in] elem a pointer to the stored fpq element. Must be in the fpq.
 @param [in] tmp a pointer to a dummy user type that will be used for swapping.
 @param [in] fn the update function to act on e.
 @param [in] aux any auxiliary data needed for the update function.
@@ -383,7 +383,7 @@ NULL if parameters are invalid or fpq is empty.
 
 A simple way to provide a temp for swapping is with an inline compound literal
 reference provided directly to the function argument `&(name_of_type){}`. */
-void *ccc_fpq_decrease(ccc_flat_priority_queue *fpq, void *e, void *tmp,
+void *ccc_fpq_decrease(ccc_flat_priority_queue *fpq, void *elem, void *tmp,
                        ccc_any_type_update_fn *fn, void *aux);
 
 /** @brief Increase the user type stored in the priority queue directly. O(lgN).

--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -556,6 +556,8 @@ typedef ccc_flat_priority_queue flat_priority_queue;
 #    define fpq_copy(args...) ccc_fpq_copy(args)
 #    define fpq_reserve(args...) ccc_fpq_reserve(args)
 #    define fpq_heapify(args...) ccc_fpq_heapify(args)
+#    define fpq_heapify_inplace(args...) ccc_fpq_heapify_inplace(args)
+#    define fpq_heapsort(args...) ccc_fpq_heapsort(args)
 #    define fpq_emplace(args...) ccc_fpq_emplace(args)
 #    define fpq_realloc(args...) ccc_fpq_realloc(args)
 #    define fpq_push(args...) ccc_fpq_push(args)

--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -217,6 +217,9 @@ provided. A permission error will occur if no allocation is allowed and the
 input array is larger than the fixed fpq capacity. A memory error will
 occur if reallocation is required to fit all elements but reallocation fails.
 
+A simple way to provide a temp for swapping is with an inline compound literal
+reference provided directly to the function argument `&(name_of_type){}`.
+
 Note that this version of heapify copies elements from the input array. If an
 in place heapify is required use the initializer version of this method. */
 ccc_result ccc_fpq_heapify(ccc_flat_priority_queue *fpq, void *tmp,
@@ -229,6 +232,9 @@ ccc_result ccc_fpq_heapify(ccc_flat_priority_queue *fpq, void *tmp,
 @param [in] n the number n of elements where  0 < (n + 1) <= capacity.
 @return the result of the heapify operation, ok if successful or an error if
 fpq is NULL or n is larger than the initialized capacity of the fpq.
+
+A simple way to provide a temp for swapping is with an inline compound literal
+reference provided directly to the function argument `&(name_of_type){}`.
 
 This is another method to order a heap that already has all the elements one
 needs sorted. The underlying buffer will be interpreted to have n valid elements
@@ -250,14 +256,20 @@ ccc_result ccc_fpq_alloc(ccc_flat_priority_queue *fpq, size_t new_capacity,
 @param [in] tmp a pointer to a dummy user type that will be used for swapping.
 @return a pointer to the inserted element or NULl if NULL args are provided or
 push required more memory and failed. Failure can occur if the fpq is full and
-allocation is not allowed or a resize failed when allocation is allowed. */
+allocation is not allowed or a resize failed when allocation is allowed.
+
+A simple way to provide a temp for swapping is with an inline compound literal
+reference provided directly to the function argument `&(name_of_type){}`. */
 [[nodiscard]] void *ccc_fpq_push(ccc_flat_priority_queue *fpq, void const *elem,
                                  void *tmp);
 
 /** @brief Pop the front element (min or max) element in the fpq. O(lgN).
 @param [in] fpq a pointer to the priority queue.
 @param [in] tmp a pointer to a dummy user type that will be used for swapping.
-@return OK if the pop succeeds or an input error if fpq is NULL or empty. */
+@return OK if the pop succeeds or an input error if fpq is NULL or empty.
+
+A simple way to provide a temp for swapping is with an inline compound literal
+reference provided directly to the function argument `&(name_of_type){}`. */
 ccc_result ccc_fpq_pop(ccc_flat_priority_queue *fpq, void *tmp);
 
 /** @brief Erase element e that is a handle to the stored fpq element.
@@ -268,7 +280,10 @@ ccc_result ccc_fpq_pop(ccc_flat_priority_queue *fpq, void *tmp);
 provided or the fpq is empty.
 @warning the user must ensure e is in the fpq.
 
-Note that the reference to e is invalidated after this call. */
+A simple way to provide a temp for swapping is with an inline compound literal
+reference provided directly to the function argument `&(name_of_type){}`.
+
+Note that the reference to elem is invalidated after this call. */
 ccc_result ccc_fpq_erase(ccc_flat_priority_queue *fpq, void *elem, void *tmp);
 
 /** @brief Update e that is a handle to the stored fpq element. O(lgN).
@@ -279,7 +294,10 @@ ccc_result ccc_fpq_erase(ccc_flat_priority_queue *fpq, void *elem, void *tmp);
 @param [in] aux any auxiliary data needed for the update function.
 @return a reference to the element at its new position in the fpq on success,
 NULL if parameters are invalid or fpq is empty.
-@warning the user must ensure e is in the fpq. */
+@warning the user must ensure e is in the fpq.
+
+A simple way to provide a temp for swapping is with an inline compound literal
+reference provided directly to the function argument `&(name_of_type){}`. */
 void *ccc_fpq_update(ccc_flat_priority_queue *fpq, void *elem, void *tmp,
                      ccc_any_type_update_fn *fn, void *aux);
 
@@ -312,7 +330,10 @@ Note that whether the key increases or decreases does not affect runtime. */
 @param [in] aux any auxiliary data needed for the update function.
 @return a reference to the element at its new position in the fpq on success,
 NULL if parameters are invalid or fpq is empty.
-@warning the user must ensure e is in the fpq. */
+@warning the user must ensure e is in the fpq.
+
+A simple way to provide a temp for swapping is with an inline compound literal
+reference provided directly to the function argument `&(name_of_type){}`. */
 void *ccc_fpq_increase(ccc_flat_priority_queue *fpq, void *elem, void *tmp,
                        ccc_any_type_update_fn *fn, void *aux);
 
@@ -345,7 +366,10 @@ Note that if this priority queue is min or max, the runtime is the same. */
 @param [in] aux any auxiliary data needed for the update function.
 @return a reference to the element at its new position in the fpq on success,
 NULL if parameters are invalid or fpq is empty.
-@warning the user must ensure e is in the fpq. */
+@warning the user must ensure e is in the fpq.
+
+A simple way to provide a temp for swapping is with an inline compound literal
+reference provided directly to the function argument `&(name_of_type){}`. */
 void *ccc_fpq_decrease(ccc_flat_priority_queue *fpq, void *e, void *tmp,
                        ccc_any_type_update_fn *fn, void *aux);
 
@@ -389,6 +413,9 @@ initialized and unusable.
 the fpq is unusable as a container after sorting. This function assumes the fpq
 has been previously initialized. Therefore, if the returned buffer value is not
 used the fpq memory is leaked.
+
+A simple way to provide a temp for swapping is with an inline compound literal
+reference provided directly to the function argument `&(name_of_type){}`.
 
 The underlying memory storage source for the fpq, a buffer, is not moved or
 copied during the sort. The sort is not inherently stable and uses the provided

--- a/ccc/impl/impl_flat_priority_queue.h
+++ b/ccc/impl/impl_flat_priority_queue.h
@@ -74,7 +74,7 @@ void *ccc_impl_fpq_update_fixup(struct ccc_fpq *, void *, void *tmp);
             impl_fpq_heapify_mem, impl_any_type_name, impl_cmp_order,          \
             impl_cmp_fn, impl_alloc_fn, impl_aux_data, impl_capacity);         \
         ccc_impl_fpq_in_place_heapify(&impl_fpq_heapify_res, (impl_size),      \
-                                      &(impl_any_type_name){});                \
+                                      &(impl_any_type_name){0});               \
         impl_fpq_heapify_res;                                                  \
     }))
 
@@ -94,7 +94,7 @@ void *ccc_impl_fpq_update_fixup(struct ccc_fpq *, void *, void *tmp);
                 impl_fpq_res                                                   \
                     = ccc_buf_at(&impl_fpq->buf,                               \
                                  ccc_impl_fpq_bubble_up(                       \
-                                     impl_fpq, &(typeof(type_initializer)){},  \
+                                     impl_fpq, &(typeof(type_initializer)){0}, \
                                      impl_fpq->buf.count - 1));                \
             }                                                                  \
             else                                                               \
@@ -113,8 +113,8 @@ void *ccc_impl_fpq_update_fixup(struct ccc_fpq *, void *, void *tmp);
         typeof(*T_ptr) *T = (T_ptr);                                           \
         if (impl_fpq && !ccc_buf_is_empty(&impl_fpq->buf) && T)                \
         {                                                                      \
-            {update_closure_over_T} T                                          \
-                = ccc_impl_fpq_update_fixup(impl_fpq, T, &(typeof(*T_ptr)){}); \
+            {update_closure_over_T} T = ccc_impl_fpq_update_fixup(             \
+                impl_fpq, T, &(typeof(*T_ptr)){0});                            \
         }                                                                      \
         T;                                                                     \
     }))

--- a/ccc/impl/impl_traits.h
+++ b/ccc/impl/impl_traits.h
@@ -425,10 +425,11 @@ limitations under the License.
         ccc_singly_linked_list *: ccc_sll_push_front)((container_ptr),         \
                                                       container_handle_ptr)
 
-#define ccc_impl_pop(container_ptr)                                            \
+#define ccc_impl_pop(container_ptr, ...)                                       \
     _Generic((container_ptr),                                                  \
         ccc_flat_priority_queue *: ccc_fpq_pop,                                \
-        ccc_priority_queue *: ccc_pq_pop)((container_ptr))
+        ccc_priority_queue                                                     \
+            *: ccc_pq_pop)((container_ptr)__VA_OPT__(, __VA_ARGS__))
 
 #define ccc_impl_pop_front(container_ptr)                                      \
     _Generic((container_ptr),                                                  \

--- a/ccc/traits.h
+++ b/ccc/traits.h
@@ -323,10 +323,12 @@ See container documentation for specific behavior. */
 
 /** @brief Pop an element from a container.
 @param [in] container_ptr a pointer to the container.
+@param [in] pop_args any supplementary args a container may have for the pop.
 @return a result of the pop operation.
 
 See container documentation for specific behavior. */
-#define ccc_pop(container_ptr) ccc_impl_pop(container_ptr)
+#define ccc_pop(container_ptr, pop_args...)                                    \
+    ccc_impl_pop(container_ptr, pop_args)
 
 /** @brief Pop an element from the front of a container.
 @param [in] container_ptr a pointer to the container.

--- a/samples/ccczip.c
+++ b/samples/ccczip.c
@@ -369,10 +369,10 @@ build_encoding_tree(FILE *const f)
     {
         /* Small elements and we need the pair so we can't hold references. */
         struct fpq_elem zero = *(struct fpq_elem *)front(&pq);
-        ccc_result r = pop(&pq);
+        ccc_result r = pop(&pq, &(struct fpq_elem){});
         check(r == CCC_RESULT_OK);
         struct fpq_elem one = *(struct fpq_elem *)front(&pq);
-        r = pop(&pq);
+        r = pop(&pq, &(struct fpq_elem){});
         check(r == CCC_RESULT_OK);
         struct huffman_node *const internal_one
             = push_back(&ret.bump_arena, &(struct huffman_node){
@@ -383,10 +383,12 @@ build_encoding_tree(FILE *const f)
         node_at(&ret, zero.node)->parent = new_root;
         node_at(&ret, one.node)->parent = new_root;
         struct fpq_elem const *const pushed
-            = push(&pq, &(struct fpq_elem){
-                            .freq = zero.freq + one.freq,
-                            .node = new_root,
-                        });
+            = push(&pq,
+                   &(struct fpq_elem){
+                       .freq = zero.freq + one.freq,
+                       .node = new_root,
+                   },
+                   &(struct fpq_elem){});
         check(pushed);
         ret.root = new_root;
     }

--- a/samples/maze.c
+++ b/samples/maze.c
@@ -261,7 +261,7 @@ animate_maze(struct maze *maze)
         entry_r(&cost_map, &s),
         (struct prim_cell){.cell = s, .cost = rand_range(0, 100)});
     check(first);
-    (void)push(&cell_pq, first);
+    (void)push(&cell_pq, first, &(struct prim_cell){});
     while (!is_empty(&cell_pq))
     {
         struct prim_cell const *const c = front(&cell_pq);
@@ -289,11 +289,11 @@ animate_maze(struct maze *maze)
         if (min != INT_MAX)
         {
             join_squares_animated(maze, c->cell, min_cell.cell, speed);
-            (void)push(&cell_pq, &min_cell);
+            (void)push(&cell_pq, &min_cell, &(struct prim_cell){});
         }
         else
         {
-            (void)pop(&cell_pq);
+            (void)pop(&cell_pq, &(struct prim_cell){});
         }
     }
     /* If a container is reserved without allocation permission it has no way

--- a/samples/words.c
+++ b/samples/words.c
@@ -364,7 +364,7 @@ static struct frequency_alloc
 copy_frequencies(handle_ordered_map const *const map)
 {
     check(!is_empty(map));
-    size_t const cap = sizeof(struct frequency) * (count(map).count + 1);
+    size_t const cap = sizeof(struct frequency) * count(map).count;
     struct frequency *const freqs = malloc(cap);
     check(freqs);
     size_t i = 0;

--- a/samples/words.c
+++ b/samples/words.c
@@ -391,7 +391,7 @@ print_n(ccc_handle_ordered_map *const map, ccc_threeway_cmp const ord,
     {
         n = count(&fpq).count;
     }
-    ccc_buffer b = ccc_fpq_heapsort(&fpq);
+    ccc_buffer b = ccc_fpq_heapsort(&fpq, &(struct frequency){});
     check(!fpq.buf.mem);
     int w = 0;
     /* Heap sort puts the root most nodes at the back of the buffer. */

--- a/src/flat_priority_queue.c
+++ b/src/flat_priority_queue.c
@@ -93,7 +93,7 @@ ccc_buffer
 ccc_fpq_heapsort(ccc_flat_priority_queue *const fpq, void *const tmp)
 {
     ccc_buffer ret = {};
-    if (!fpq || !tmp || fpq->buf.count >= fpq->buf.capacity)
+    if (!fpq || !tmp)
     {
         return ret;
     }

--- a/src/flat_priority_queue.c
+++ b/src/flat_priority_queue.c
@@ -275,7 +275,7 @@ ccc_result
 ccc_fpq_reserve(ccc_flat_priority_queue *const fpq, size_t const to_add,
                 ccc_any_alloc_fn *const fn)
 {
-    if (!fpq || !fn)
+    if (!fpq)
     {
         return CCC_RESULT_ARG_ERROR;
     }

--- a/src/flat_priority_queue.c
+++ b/src/flat_priority_queue.c
@@ -154,10 +154,10 @@ ccc_fpq_pop(ccc_flat_priority_queue *const fpq, void *const tmp)
 }
 
 ccc_result
-ccc_fpq_erase(ccc_flat_priority_queue *const fpq, void *const e,
+ccc_fpq_erase(ccc_flat_priority_queue *const fpq, void *const elem,
               void *const tmp)
 {
-    if (!fpq || !e || !tmp || !fpq->buf.count)
+    if (!fpq || !elem || !tmp || !fpq->buf.count)
     {
         return CCC_RESULT_ARG_ERROR;
     }
@@ -165,7 +165,7 @@ ccc_fpq_erase(ccc_flat_priority_queue *const fpq, void *const e,
     {
         return ccc_buf_pop_back(&fpq->buf);
     }
-    size_t const i = index_of(fpq, e);
+    size_t const i = index_of(fpq, elem);
     if (i == fpq->buf.count - 1)
     {
         return ccc_buf_pop_back(&fpq->buf);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ add_buf_test(test_buf_iter)
 
 #############  Heap Priority Queue  ##########################
 add_library(fpq_util fpq/fpq_util.h fpq/fpq_util.c)
+target_include_directories(fpq_util PRIVATE "../util")
 target_link_libraries(fpq_util
   PRIVATE
     ccc

--- a/tests/fpq/fpq_util.c
+++ b/tests/fpq/fpq_util.c
@@ -78,5 +78,6 @@ CHECK_BEGIN_FN(inorder_fill, int vals[const], size_t const size,
         CHECK(prev->val <= v->val, CCC_TRUE);
         vals[i++] = v->val;
     }
+    CHECK(i, fpq_count(fpq).count);
     CHECK_END_FN(clear_and_free(&b, NULL););
 }

--- a/tests/fpq/fpq_util.c
+++ b/tests/fpq/fpq_util.c
@@ -43,7 +43,7 @@ CHECK_BEGIN_FN(insert_shuffled, ccc_flat_priority_queue *pq, struct val vals[],
     for (size_t i = 0; i < size; ++i)
     {
         vals[i].id = vals[i].val = (int)shuffled_index;
-        CHECK(push(pq, &vals[i]) != NULL, CCC_TRUE);
+        CHECK(push(pq, &vals[i], &(struct val){}) != NULL, CCC_TRUE);
         CHECK(ccc_fpq_count(pq).count, i + 1);
         CHECK(validate(pq), true);
         shuffled_index = (shuffled_index + larger_prime) % size;
@@ -76,7 +76,7 @@ CHECK_BEGIN_FN(inorder_fill, int vals[], size_t size,
             &fpq_copy, (struct val){.id = front->id, .val = front->val});
         CHECK(v != NULL, true);
         CHECK(prev < ccc_fpq_count(&fpq_copy).count, true);
-        (void)pop(fpq);
+        (void)pop(fpq, &(struct val){});
     }
     i = 0;
     while (!ccc_fpq_is_empty(&fpq_copy) && i < size)
@@ -88,7 +88,7 @@ CHECK_BEGIN_FN(inorder_fill, int vals[], size_t size,
         CHECK(e != NULL, true);
         CHECK(prev < ccc_fpq_count(fpq).count, true);
         CHECK(vals[i++], v->val);
-        (void)pop(&fpq_copy);
+        (void)pop(&fpq_copy, &(struct val){});
     };
     CHECK_END_FN(free(copy_buf););
 }

--- a/tests/fpq/fpq_util.h
+++ b/tests/fpq/fpq_util.h
@@ -16,7 +16,7 @@ struct val
 ccc_threeway_cmp val_cmp(ccc_any_type_cmp);
 void val_update(ccc_any_type);
 size_t rand_range(size_t min, size_t max);
-enum check_result inorder_fill(int[], size_t, ccc_flat_priority_queue *);
+enum check_result inorder_fill(int[], size_t, ccc_flat_priority_queue const *);
 enum check_result insert_shuffled(ccc_flat_priority_queue *pq,
                                   struct val vals[], size_t size,
                                   int larger_prime);

--- a/tests/fpq/test_fpq_construct.c
+++ b/tests/fpq/test_fpq_construct.c
@@ -41,7 +41,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_macro)
     CHECK(res != NULL, true);
     CHECK(fpq_is_empty(&pq), false);
     struct val *res2 = fpq_emplace(&pq, (struct val){.val = 0, .id = 0});
-    CHECK(res2 == NULL, true);
+    CHECK(res2 != NULL, true);
     CHECK_END_FN();
 }
 
@@ -63,7 +63,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_push)
     flat_priority_queue pq
         = fpq_init(vals, struct val, CCC_LES, val_cmp, NULL, NULL,
                    (sizeof(vals) / sizeof(struct val)));
-    struct val *res = push(&pq, &vals[0]);
+    struct val *res = push(&pq, &vals[0], &(struct val){});
     CHECK(res != NULL, true);
     CHECK(fpq_is_empty(&pq), false);
     CHECK_END_FN();
@@ -75,7 +75,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_raw_type)
     flat_priority_queue pq = fpq_init(vals, int, CCC_LES, int_cmp, NULL, NULL,
                                       (sizeof(vals) / sizeof(int)));
     int val = 1;
-    int *res = push(&pq, &val);
+    int *res = push(&pq, &val, &(int){0});
     CHECK(res != NULL, true);
     CHECK(fpq_is_empty(&pq), false);
     res = fpq_emplace(&pq, -1);
@@ -99,11 +99,11 @@ CHECK_BEGIN_STATIC_FN(fpq_test_heapify_init)
         = fpq_heapify_init(heap, int, CCC_LES, int_cmp, NULL, NULL,
                            (sizeof(heap) / sizeof(int)), size);
     int prev = *((int *)fpq_front(&pq));
-    (void)pop(&pq);
+    (void)pop(&pq, &(int){0});
     while (!fpq_is_empty(&pq))
     {
         int cur = *((int *)fpq_front(&pq));
-        (void)pop(&pq);
+        (void)pop(&pq, &(int){0});
         CHECK(cur >= prev, true);
         prev = cur;
     }
@@ -121,15 +121,16 @@ CHECK_BEGIN_STATIC_FN(fpq_test_heapify_copy)
     {
         input[i] = rand_range(-99, 99); /* NOLINT */
     }
-    CHECK(fpq_heapify(&pq, input, sizeof(input) / sizeof(int), sizeof(int)),
+    CHECK(fpq_heapify(&pq, &(int){0}, input, sizeof(input) / sizeof(int),
+                      sizeof(int)),
           CCC_RESULT_OK);
     CHECK(fpq_count(&pq).count, sizeof(input) / sizeof(int));
     int prev = *((int *)fpq_front(&pq));
-    (void)pop(&pq);
+    (void)pop(&pq, &(int){0});
     while (!fpq_is_empty(&pq))
     {
         int cur = *((int *)fpq_front(&pq));
-        (void)pop(&pq);
+        (void)pop(&pq, &(int){0});
         CHECK(cur >= prev, true);
         prev = cur;
     }
@@ -150,7 +151,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_heapsort)
     }
     flat_priority_queue pq = fpq_heapify_init(heap, int, CCC_LES, int_cmp, NULL,
                                               NULL, HPSORTCAP, HPSORTCAP - 1);
-    ccc_buffer const b = ccc_fpq_heapsort(&pq);
+    ccc_buffer const b = ccc_fpq_heapsort(&pq, &(int){0});
     int const *prev = begin(&b);
     CHECK(prev != NULL, true);
     CHECK(ccc_buf_count(&b).count, HPSORTCAP - 1);
@@ -171,9 +172,9 @@ CHECK_BEGIN_STATIC_FN(fpq_test_copy_no_alloc)
         = fpq_init((int[4]){}, int, CCC_LES, int_cmp, NULL, NULL, 4);
     flat_priority_queue dst
         = fpq_init((int[5]){}, int, CCC_LES, int_cmp, NULL, NULL, 5);
-    (void)push(&src, &(int){0});
-    (void)push(&src, &(int){1});
-    (void)push(&src, &(int){2});
+    (void)push(&src, &(int){0}, &(int){0});
+    (void)push(&src, &(int){1}, &(int){0});
+    (void)push(&src, &(int){2}, &(int){0});
     CHECK(count(&src).count, 3);
     CHECK(*(int *)front(&src), 0);
     CHECK(is_empty(&dst), true);
@@ -184,8 +185,8 @@ CHECK_BEGIN_STATIC_FN(fpq_test_copy_no_alloc)
     {
         int f1 = *(int *)front(&src);
         int f2 = *(int *)front(&dst);
-        (void)pop(&src);
-        (void)pop(&dst);
+        (void)pop(&src, &(int){0});
+        (void)pop(&dst, &(int){0});
         CHECK(f1, f2);
     }
     CHECK(is_empty(&src), is_empty(&dst));
@@ -198,9 +199,9 @@ CHECK_BEGIN_STATIC_FN(fpq_test_copy_no_alloc_fail)
         = fpq_init((int[4]){}, int, CCC_LES, int_cmp, NULL, NULL, 4);
     flat_priority_queue dst
         = fpq_init((int[2]){}, int, CCC_LES, int_cmp, NULL, NULL, 2);
-    (void)push(&src, &(int){0});
-    (void)push(&src, &(int){1});
-    (void)push(&src, &(int){2});
+    (void)push(&src, &(int){0}, &(int){0});
+    (void)push(&src, &(int){1}, &(int){0});
+    (void)push(&src, &(int){2}, &(int){0});
     CHECK(count(&src).count, 3);
     CHECK(*(int *)front(&src), 0);
     CHECK(is_empty(&dst), true);
@@ -215,9 +216,9 @@ CHECK_BEGIN_STATIC_FN(fpq_test_copy_alloc)
         = fpq_init(NULL, int, CCC_LES, int_cmp, std_alloc, NULL, 0);
     flat_priority_queue dst
         = fpq_init(NULL, int, CCC_LES, int_cmp, std_alloc, NULL, 0);
-    (void)push(&src, &(int){0});
-    (void)push(&src, &(int){1});
-    (void)push(&src, &(int){2});
+    (void)push(&src, &(int){0}, &(int){0});
+    (void)push(&src, &(int){1}, &(int){0});
+    (void)push(&src, &(int){2}, &(int){0});
     CHECK(*(int *)front(&src), 0);
     CHECK(is_empty(&dst), true);
     ccc_result res = fpq_copy(&dst, &src, std_alloc);
@@ -227,8 +228,8 @@ CHECK_BEGIN_STATIC_FN(fpq_test_copy_alloc)
     {
         int f1 = *(int *)front(&src);
         int f2 = *(int *)front(&dst);
-        (void)pop(&src);
-        (void)pop(&dst);
+        (void)pop(&src, &(int){0});
+        (void)pop(&dst, &(int){0});
         CHECK(f1, f2);
     }
     CHECK(is_empty(&src), is_empty(&dst));
@@ -244,9 +245,9 @@ CHECK_BEGIN_STATIC_FN(fpq_test_copy_alloc_fail)
         = fpq_init(NULL, int, CCC_LES, int_cmp, std_alloc, NULL, 0);
     flat_priority_queue dst
         = fpq_init(NULL, int, CCC_LES, int_cmp, std_alloc, NULL, 0);
-    (void)push(&src, &(int){0});
-    (void)push(&src, &(int){1});
-    (void)push(&src, &(int){2});
+    (void)push(&src, &(int){0}, &(int){0});
+    (void)push(&src, &(int){1}, &(int){0});
+    (void)push(&src, &(int){2}, &(int){0});
     CHECK(*(int *)front(&src), 0);
     CHECK(is_empty(&dst), true);
     ccc_result res = fpq_copy(&dst, &src, NULL);

--- a/tests/fpq/test_fpq_construct.c
+++ b/tests/fpq/test_fpq_construct.c
@@ -89,15 +89,17 @@ CHECK_BEGIN_STATIC_FN(fpq_test_raw_type)
 CHECK_BEGIN_STATIC_FN(fpq_test_heapify_init)
 {
     srand(time(NULL)); /* NOLINT */
-    int heap[100] = {};
-    size_t const size = 99;
-    for (size_t i = 0; i < size; ++i)
+    enum : size_t
     {
-        heap[i] = rand_range(-99, size); /* NOLINT */
+        HEAPIFY_CAP = 100,
+    };
+    int heap[HEAPIFY_CAP] = {};
+    for (size_t i = 0; i < HEAPIFY_CAP; ++i)
+    {
+        heap[i] = rand_range(-99, (int)HEAPIFY_CAP); /* NOLINT */
     }
-    flat_priority_queue pq
-        = fpq_heapify_init(heap, int, CCC_LES, int_cmp, NULL, NULL,
-                           (sizeof(heap) / sizeof(int)), size);
+    flat_priority_queue pq = fpq_heapify_init(heap, int, CCC_LES, int_cmp, NULL,
+                                              NULL, HEAPIFY_CAP, HEAPIFY_CAP);
     int prev = *((int *)fpq_front(&pq));
     (void)pop(&pq, &(int){0});
     while (!fpq_is_empty(&pq))
@@ -113,18 +115,21 @@ CHECK_BEGIN_STATIC_FN(fpq_test_heapify_init)
 CHECK_BEGIN_STATIC_FN(fpq_test_heapify_copy)
 {
     srand(time(NULL)); /* NOLINT */
-    int heap[100] = {};
-    flat_priority_queue pq = fpq_init(heap, int, CCC_LES, int_cmp, NULL, NULL,
-                                      (sizeof(heap) / sizeof(int)));
-    int input[99] = {};
-    for (size_t i = 0; i < (size_t)(sizeof(input) / sizeof(int)); ++i)
+    enum : size_t
+    {
+        HEAPIFY_COPY_CAP = 100,
+    };
+    int heap[HEAPIFY_COPY_CAP] = {};
+    flat_priority_queue pq
+        = fpq_init(heap, int, CCC_LES, int_cmp, NULL, NULL, HEAPIFY_COPY_CAP);
+    int input[HEAPIFY_COPY_CAP] = {};
+    for (size_t i = 0; i < HEAPIFY_COPY_CAP; ++i)
     {
         input[i] = rand_range(-99, 99); /* NOLINT */
     }
-    CHECK(fpq_heapify(&pq, &(int){0}, input, sizeof(input) / sizeof(int),
-                      sizeof(int)),
+    CHECK(fpq_heapify(&pq, &(int){0}, input, HEAPIFY_COPY_CAP, sizeof(int)),
           CCC_RESULT_OK);
-    CHECK(fpq_count(&pq).count, sizeof(input) / sizeof(int));
+    CHECK(fpq_count(&pq).count, HEAPIFY_COPY_CAP);
     int prev = *((int *)fpq_front(&pq));
     (void)pop(&pq, &(int){0});
     while (!fpq_is_empty(&pq))
@@ -145,16 +150,16 @@ CHECK_BEGIN_STATIC_FN(fpq_test_heapsort)
     };
     srand(time(NULL)); /* NOLINT */
     int heap[HPSORTCAP] = {};
-    for (size_t i = 0; i < HPSORTCAP - 1; ++i)
+    for (size_t i = 0; i < HPSORTCAP; ++i)
     {
-        heap[i] = rand_range(-99, (int)(HPSORTCAP - 1)); /* NOLINT */
+        heap[i] = rand_range(-99, (int)(HPSORTCAP)); /* NOLINT */
     }
     flat_priority_queue pq = fpq_heapify_init(heap, int, CCC_LES, int_cmp, NULL,
-                                              NULL, HPSORTCAP, HPSORTCAP - 1);
+                                              NULL, HPSORTCAP, HPSORTCAP);
     ccc_buffer const b = ccc_fpq_heapsort(&pq, &(int){0});
     int const *prev = begin(&b);
     CHECK(prev != NULL, true);
-    CHECK(ccc_buf_count(&b).count, HPSORTCAP - 1);
+    CHECK(ccc_buf_count(&b).count, HPSORTCAP);
     size_t count = 1;
     for (int const *cur = next(&b, prev); cur != end(&b); cur = next(&b, cur))
     {
@@ -162,7 +167,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_heapsort)
         prev = cur;
         ++count;
     }
-    CHECK(count, HPSORTCAP - 1);
+    CHECK(count, HPSORTCAP);
     CHECK_END_FN();
 }
 

--- a/tests/fpq/test_fpq_erase.c
+++ b/tests/fpq/test_fpq_erase.c
@@ -20,7 +20,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_insert_remove_four_dups)
     for (int i = 0; i < 4; ++i)
     {
         three_vals[i].val = 0;
-        CHECK(push(&fpq, &three_vals[i]) != NULL, true);
+        CHECK(push(&fpq, &three_vals[i], &(struct val){}) != NULL, true);
         CHECK(validate(&fpq), true);
         size_t const size_check = i + 1;
         CHECK(ccc_fpq_count(&fpq).count, size_check);
@@ -29,7 +29,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_insert_remove_four_dups)
     for (int i = 0; i < 4; ++i)
     {
         three_vals[i].val = 0;
-        (void)pop(&fpq);
+        (void)pop(&fpq, &(struct val){});
         CHECK(validate(&fpq), true);
     }
     CHECK(ccc_fpq_count(&fpq).count, (size_t)0);
@@ -57,7 +57,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_insert_erase_shuffled)
     {
         size_t const rand_index
             = rand_range(0, (int)ccc_fpq_count(&fpq).count - 1);
-        (void)ccc_fpq_erase(&fpq, &vals[rand_index]);
+        (void)ccc_fpq_erase(&fpq, &vals[rand_index], &(struct val){});
         CHECK(validate(&fpq), true);
     }
     CHECK(ccc_fpq_count(&fpq).count, (size_t)0);
@@ -82,7 +82,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_pop_max)
     {
         struct val const *const front = front(&fpq);
         CHECK(front->val, sorted_check[i]);
-        (void)pop(&fpq);
+        (void)pop(&fpq, &(struct val){});
     }
     CHECK(ccc_fpq_is_empty(&fpq), true);
     CHECK_END_FN();
@@ -106,7 +106,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_pop_min)
     {
         struct val const *const front = front(&fpq);
         CHECK(front->val, sorted_check[i]);
-        (void)pop(&fpq);
+        (void)pop(&fpq, &(struct val){});
     }
     CHECK(ccc_fpq_is_empty(&fpq), true);
     CHECK_END_FN();
@@ -130,7 +130,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_delete_prime_shuffle_duplicates)
     {
         vals[i].val = shuffled_index;
         vals[i].id = i;
-        CHECK(push(&fpq, &vals[i]) != NULL, true);
+        CHECK(push(&fpq, &vals[i], &(struct val){}) != NULL, true);
         CHECK(validate(&fpq), true);
         size_t const s = i + 1;
         CHECK(ccc_fpq_count(&fpq).count, s);
@@ -142,7 +142,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_delete_prime_shuffle_duplicates)
     {
         size_t const rand_index
             = rand_range(0, (int)ccc_fpq_count(&fpq).count - 1);
-        (void)ccc_fpq_erase(&fpq, &vals[rand_index]);
+        (void)ccc_fpq_erase(&fpq, &vals[rand_index], &(struct val){});
         CHECK(validate(&fpq), true);
         --cur_size;
         CHECK(ccc_fpq_count(&fpq).count, cur_size);
@@ -166,7 +166,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_prime_shuffle)
     {
         vals[i].val = shuffled_index;
         vals[i].id = shuffled_index;
-        CHECK(push(&fpq, &vals[i]) != NULL, true);
+        CHECK(push(&fpq, &vals[i], &(struct val){}) != NULL, true);
         CHECK(validate(&fpq), true);
         shuffled_index = (shuffled_index + prime) % (size - less);
     }
@@ -177,7 +177,9 @@ CHECK_BEGIN_STATIC_FN(fpq_test_prime_shuffle)
     {
         size_t const rand_index
             = rand_range(0, (int)ccc_fpq_count(&fpq).count - 1);
-        CHECK(ccc_fpq_erase(&fpq, &vals[rand_index]) == CCC_RESULT_OK, true);
+        CHECK(ccc_fpq_erase(&fpq, &vals[rand_index], &(struct val){})
+                  == CCC_RESULT_OK,
+              true);
         CHECK(validate(&fpq), true);
         --cur_size;
         CHECK(ccc_fpq_count(&fpq).count, cur_size);
@@ -199,14 +201,16 @@ CHECK_BEGIN_STATIC_FN(fpq_test_weak_srand)
     {
         vals[i].val = rand(); // NOLINT
         vals[i].id = i;
-        CHECK(push(&fpq, &vals[i]) != NULL, true);
+        CHECK(push(&fpq, &vals[i], &(struct val){}) != NULL, true);
         CHECK(validate(&fpq), true);
     }
     while (!ccc_fpq_is_empty(&fpq))
     {
         size_t const rand_index
             = rand_range(0, (int)ccc_fpq_count(&fpq).count - 1);
-        CHECK(ccc_fpq_erase(&fpq, &vals[rand_index]) == CCC_RESULT_OK, true);
+        CHECK(ccc_fpq_erase(&fpq, &vals[rand_index], &(struct val){})
+                  == CCC_RESULT_OK,
+              true);
         CHECK(validate(&fpq), true);
     }
     CHECK(ccc_fpq_is_empty(&fpq), true);

--- a/tests/fpq/test_fpq_insert.c
+++ b/tests/fpq/test_fpq_insert.c
@@ -18,7 +18,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_insert_one)
         = ccc_fpq_init(single, struct val, CCC_LES, val_cmp, NULL, NULL,
                        (sizeof(single) / sizeof(single[0])));
     single[0].val = 0;
-    (void)push(&fpq, &single[0]);
+    (void)push(&fpq, &single[0], &(struct val){});
     CHECK(ccc_fpq_is_empty(&fpq), false);
     CHECK_END_FN();
 }
@@ -33,7 +33,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_insert_three)
     for (size_t i = 0; i < size; ++i)
     {
         three_vals[i].val = (int)i;
-        (void)push(&fpq, &three_vals[i]);
+        (void)push(&fpq, &three_vals[i], &(struct val){});
         CHECK(validate(&fpq), true);
         CHECK(ccc_fpq_count(&fpq).count, i + 1);
     }
@@ -80,7 +80,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_insert_three_dups)
     for (int i = 0; i < 3; ++i)
     {
         three_vals[i].val = 0;
-        (void)push(&fpq, &three_vals[i]);
+        (void)push(&fpq, &three_vals[i], &(struct val){});
         CHECK(validate(&fpq), true);
         CHECK(ccc_fpq_count(&fpq).count, (size_t)i + 1);
     }
@@ -166,7 +166,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_read_max_min)
     for (size_t i = 0; i < size; ++i)
     {
         vals[i].val = (int)size - (int)i;
-        (void)push(&fpq, &vals[i]);
+        (void)push(&fpq, &vals[i], &(struct val){});
         CHECK(validate(&fpq), true);
         CHECK(ccc_fpq_count(&fpq).count, i + 1);
     }

--- a/tests/fpq/test_fpq_update.c
+++ b/tests/fpq/test_fpq_update.c
@@ -26,13 +26,13 @@ CHECK_BEGIN_STATIC_FN(fpq_test_insert_iterate_pop)
         /* Force duplicates. */
         vals[i].val = rand() % (num_nodes + 1); // NOLINT
         vals[i].id = (int)i;
-        CHECK(push(&fpq, &vals[i]) != NULL, true);
+        CHECK(push(&fpq, &vals[i], &(struct val){}) != NULL, true);
         CHECK(validate(&fpq), true);
     }
     size_t pop_count = 0;
     while (!is_empty(&fpq))
     {
-        (void)pop(&fpq);
+        (void)pop(&fpq, &(struct val){});
         ++pop_count;
         CHECK(validate(&fpq), true);
     }
@@ -67,7 +67,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_priority_removal)
         struct val *cur = &vals[seen];
         if (cur->val > limit)
         {
-            (void)erase(&fpq, cur);
+            (void)erase(&fpq, cur, &(struct val){});
             CHECK(validate(&fpq), true);
             --remaining;
         }
@@ -104,7 +104,7 @@ CHECK_BEGIN_STATIC_FN(fpq_test_priority_update)
         if (cur->val > limit)
         {
             struct val const *const updated
-                = update(&fpq, cur, val_update, &backoff);
+                = update(&fpq, cur, &(struct val){}, val_update, &backoff);
             CHECK(updated != NULL, true);
             CHECK(updated->val, backoff);
             CHECK(validate(&fpq), true);


### PR DESCRIPTION
The flat priority queue interface should make the user provide the temporary slot needed for swapping in the binary heap. This has the following benefits.

- The user can select any size they want for the backing buffer. Exact power of two sizes and full `count == capacity` heaps no longer pose a challenge.
- Significant branch reduction in code paths of priority queue now that we don't maintain an open swap slot in the buffer.
- Anonymous compound literal references exist in C99+ that allow for inline unreachable temporary allocations, likely from the stack.
- The capacity and count behaviors on initialization and push behave more like the user would expect without them having to read the docs for the off by one logic.

This does add an argument to many interface functions but it is a small cost to pay for much easier to understand flat priority queue memory allocations. Also, other node based containers do this for functions that need swap space so it is not completely foreign among interfaces.