### PR TITLE
add group alignment requirements to fixed and dynamic sized maps

### DIFF
--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 /** @cond */
 #include <assert.h>
+#include <stdalign.h>
 #include <stddef.h>
 #include <stdint.h>
 /** @endcond */
@@ -203,7 +204,7 @@ declared and initialized containers which is very convenient in C. */
                   "128, 256, etc.)");                                          \
     typedef struct                                                             \
     {                                                                          \
-        key_val_type_name data[(capacity) + 1];                                \
+        alignas(CCC_FHM_GROUP_SIZE) key_val_type_name data[(capacity) + 1];    \
         ccc_fhm_tag tag[(capacity) + CCC_FHM_GROUP_SIZE];                      \
     }(fixed_map_type_name)
 

--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -185,14 +185,10 @@ The declaration specifies that we have one extra data slot for swapping during
 in place rehashing and some interface functions and an extra duplicate group
 of tags at the end of the tag array for safer group loading.
 
-Finally, we must align the leading user type to an alignment at least as strict
-as that of the group size. If the alignment of the leading user data array is a
-multiple greater than or equal to that of a group size, that is OK and the tag
-array will be aligned. If the leading user data type has a lower alignment than
-the group size, this technique brings the alignment up to the required size. For
-dynamic maps we also add the necessary byte padding at the end of the data array
-before the tag array at runtime so all code should not care whether the map is
-of fixed or dynamic size. */
+Finally, we must align the tag array to start on an aligned group size byte
+boundary to be able to perform aligned loads and stores. This allows the user
+data array to be tightly packed and any padding will be added after the last
+user data element to ensure the tag array is aligned to the group size. */
 #define ccc_impl_fhm_declare_fixed_map(fixed_map_type_name, key_val_type_name, \
                                        capacity)                               \
     static_assert((capacity) > 0,                                              \
@@ -205,8 +201,9 @@ of fixed or dynamic size. */
                   "128, 256, etc.)");                                          \
     typedef struct                                                             \
     {                                                                          \
-        alignas(CCC_FHM_GROUP_SIZE) key_val_type_name data[(capacity) + 1];    \
-        ccc_fhm_tag tag[(capacity) + CCC_FHM_GROUP_SIZE];                      \
+        key_val_type_name data[(capacity) + 1];                                \
+        alignas(CCC_FHM_GROUP_SIZE)                                            \
+            ccc_fhm_tag tag[(capacity) + CCC_FHM_GROUP_SIZE];                  \
     }(fixed_map_type_name)
 
 /** @private If the user does not want to remember the capacity they chose

--- a/ccc/impl/impl_flat_hash_map.h
+++ b/ccc/impl/impl_flat_hash_map.h
@@ -185,13 +185,14 @@ The declaration specifies that we have one extra data slot for swapping during
 in place rehashing and some interface functions and an extra duplicate group
 of tags at the end of the tag array for safer group loading.
 
-Finally, one consequence of allowing the user to declare this type is that the
-tag array is always aligned immediately after the user type array. This may not
-be aligned to the group size of the tag array meaning any group load
-instructions must be their unaligned equivalents. We cannot know at runtime
-whether our data and tag array pointers are to a fixed type or dynamic heap
-allocation so we assume unaligned loads every time. This allows compile time
-declared and initialized containers which is very convenient in C. */
+Finally, we must align the leading user type to an alignment at least as strict
+as that of the group size. If the alignment of the leading user data array is a
+multiple greater than or equal to that of a group size, that is OK and the tag
+array will be aligned. If the leading user data type has a lower alignment than
+the group size, this technique brings the alignment up to the required size. For
+dynamic maps we also add the necessary byte padding at the end of the data array
+before the tag array at runtime so all code should not care whether the map is
+of fixed or dynamic size. */
 #define ccc_impl_fhm_declare_fixed_map(fixed_map_type_name, key_val_type_name, \
                                        capacity)                               \
     static_assert((capacity) > 0,                                              \

--- a/samples/words.c
+++ b/samples/words.c
@@ -387,12 +387,12 @@ print_n(ccc_handle_ordered_map *const map, ccc_threeway_cmp const ord,
     }
     /* Because all CCC containers are complete they can be treated as copyable
        types like this. There is no opaque container in CCC. */
-    freqs = ccc_fpq_heapsort(&fpq, &(word){});
+    buffer sorted_freqs = ccc_fpq_heapsort(&fpq, &(word){});
     check(!fpq.buf.mem);
     int w = 0;
     /* Heap sort puts the root most nodes at the back of the buffer. */
-    for (word const *i = rbegin(&freqs); i != rend(&freqs) && w < n;
-         i = rnext(&freqs, i), ++w)
+    for (word const *i = rbegin(&sorted_freqs);
+         i != rend(&sorted_freqs) && w < n; i = rnext(&sorted_freqs, i), ++w)
     {
         char const *const arena_str = str_arena_at(a, &i->ofs);
         if (arena_str)

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -1828,10 +1828,13 @@ match_full(group const g)
 only considering the leading full slots from this position. Assumes start bit
 is 0 indexed such that only the exclusive range of leading bits is considered
 (start_tag, CCC_FHM_GROUP_SIZE). All trailing bits in the inclusive range from
-[0, start_tag] are zeroed out in the mask. */
+[0, start_tag] are zeroed out in the mask.
+
+Assumes start tag is less than group size. */
 static inline match_mask
 match_leading_full(group const g, size_t const start_tag)
 {
+    assert(start_tag < CCC_FHM_GROUP_SIZE);
     return (match_mask){(~match_empty_deleted(g).v)
                         & (MATCH_MASK_ALL_ON_BUT_0TH_TAG << start_tag)};
 }
@@ -1959,10 +1962,13 @@ group that are occupied by a user hash value leading from the provided start
 bit. These are those tags that have the most significant bit off and the lower 7
 bits occupied by user hash. All bits in the tags from [0, start_tag] are zeroed
 out such that only the tags in the range (start_tag, CCC_FHM_GROUP_SIZE) are
-considered. */
+considered.
+
+Assumes start tag is less than group size. */
 static inline match_mask
 match_leading_full(group const g, size_t const start_tag)
 {
+    assert(start_tag < CCC_FHM_GROUP_SIZE);
     uint8x8_t const cmp = vcgez_s8(vreinterpret_s8_u8(g.v));
     match_mask const res = {
         (vget_lane_u64(vreinterpret_u64_u8(cmp), 0)
@@ -2120,10 +2126,13 @@ group that are occupied by a user hash value leading from the provided start
 bit. These are those tags that have the most significant bit off and the lower 7
 bits occupied by user hash. All bits in the tags from [0, start_tag] are zeroed
 out such that only the tags in the range (start_tag, CCC_FHM_GROUP_SIZE) are
-considered. */
+considered.
+
+Assumes start_tag is less than group size. */
 static inline match_mask
 match_leading_full(group const g, size_t const start_tag)
 {
+    assert(start_tag < CCC_FHM_GROUP_SIZE);
     return to_little_endian((match_mask){
         ((~g.v) & (MATCH_MASK_ALL_ON_BUT_0TH_TAG << (start_tag * TAG_BITS)))
             & MATCH_MASK_TAGS_MSBS,


### PR DESCRIPTION
While I previously thought that it would not be practical to have aligned loads and stores for the SSE version of the flat hash map that uses vector instructions, it is possible. I thought both fixed and dynamic alignment would not be possible without excessive logic. However, thanks to C23's `alignas` macro, we can match the tag array start address to the alignment of a group. This ensures the tag array starts on the next aligned group size byte boundary. When we make dynamic allocations we simply add any extra alignment padding bytes to the end of the user data array and also calculate the position of the tag array to be at the next aligned boundary given the group size. This mainly affects the SIMD loads of the x86 version of the map, but the NEON and portable versions will of course benefit from proper alignment of their 8 byte groups.