### PR TITLE
Group Aligned Loads During Rehash

### DIFF
--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -309,7 +309,7 @@ struct query
 
 /*===========================   Prototypes   ================================*/
 
-static void swap(char tmp[const], void *a, void *b, size_t ab_size);
+static void swap(void *tmp, void *a, void *b, size_t ab_size);
 static struct ccc_fhash_entry container_entry(struct ccc_fhmap *h,
                                               void const *key);
 static struct query find(struct ccc_fhmap *h, void const *key, uint64_t hash);
@@ -1595,7 +1595,7 @@ swap_slot(struct ccc_fhmap const *h)
 }
 
 static inline void
-swap(char tmp[const], void *const a, void *const b, size_t const ab_size)
+swap(void *const tmp, void *const a, void *const b, size_t const ab_size)
 {
     if (unlikely(!a || !b || a == b))
     {

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -117,7 +117,7 @@ enum : uint64_t
     MATCH_MASK_TAGS_LSBS = 0x101010101010101,
     /** @private Debug mode check for bits that must be off in match. */
     MATCH_MASK_TAGS_OFF_BITS = 0x7F7F7F7F7F7F7F7F,
-    /** @private All bits on for each tag except for the 0th tag. */
+    /** @private The MSB of each byte on except 0th is 0x00. */
     MATCH_MASK_0TH_TAG_OFF = 0x8080808080808000,
 };
 

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -1359,10 +1359,12 @@ rehash_in_place(struct ccc_fhmap *const h)
     (void)memcpy(h->tag + (mask + 1), h->tag, CCC_FHM_GROUP_SIZE);
     size_t group_start = 0;
     match_mask deleted = {};
-    /* Due to the load factor being roughly 87% we could have large spans of
-       unoccupied slots in large tables (full slots we have converted to deleted
-       tags). We can speed things up by performing aligned group scans checking
-       for any groups with elements that need to be rehashed. */
+    /* Because the load factor is roughly 87% we could have large spans of
+       unoccupied slots in large tables due to full slots we have converted to
+       deleted tags. There could also be many tombstones that were just
+       converted to empty slots in the prep loop earlier. We can speed things up
+       by performing aligned group scans checking for any groups with elements
+       that need to be rehashed. */
     while ((deleted = find_first_deleted_group(h, &group_start)).v)
     {
         size_t tag_i = 0;

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -118,7 +118,7 @@ enum : uint64_t
     /** @private Debug mode check for bits that must be off in match. */
     MATCH_MASK_TAGS_OFF_BITS = 0x7F7F7F7F7F7F7F7F,
     /** @private All bits on for each tag except for the 0th tag. */
-    MATCH_MASK_0TH_TAG_OFF = 0xFFFFFFFFFFFFFF00,
+    MATCH_MASK_0TH_TAG_OFF = 0x8080808080808000,
 };
 
 enum : typeof((ccc_fhm_tag){}.v)
@@ -2091,9 +2091,8 @@ match_leading_full(group const g, size_t const start_tag)
     assert(start_tag < CCC_FHM_GROUP_SIZE);
     uint8x8_t const cmp = vcgez_s8(vreinterpret_s8_u8(g.v));
     match_mask const res = {
-        (vget_lane_u64(vreinterpret_u64_u8(cmp), 0)
-         & (MATCH_MASK_0TH_TAG_OFF << (start_tag * TAG_BITS)))
-            & MATCH_MASK_TAGS_MSBS,
+        vget_lane_u64(vreinterpret_u64_u8(cmp), 0)
+            & (MATCH_MASK_0TH_TAG_OFF << (start_tag * TAG_BITS)),
     };
     assert(
         (res.v & MATCH_MASK_TAGS_OFF_BITS) == 0

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -249,9 +249,14 @@ static_assert((offsetof(struct fixed_map_test_type, tag) % CCC_FHM_GROUP_SIZE)
 /** @private Range of constants specified as special for this hash table. Same
 general design as Rust Hashbrown table. Importantly, we know these are special
 constants because the most significant bit is on and then empty can be easily
-distinguished from deleted by the least significant bit. The full case occurs
-when the most significant bit is off and the next 7 bits are available for the
-fingerprint of the user hash. */
+distinguished from deleted by the least significant bit.
+
+The full case is implicit in the table as it cannot be quantified by a simple
+enum value.
+
+TAG_FULL = 0b0???_????
+
+The most significant bit is off and the lower 7 make up the hash bits. */
 enum : typeof((ccc_fhm_tag){}.v)
 {
     /** @private Deleted is applied when a removed value in a group must signal
@@ -260,7 +265,6 @@ enum : typeof((ccc_fhm_tag){}.v)
     /** @private Empty is the starting tag value and applied when other empties
     are in a group upon removal. */
     TAG_EMPTY = 0xFF,
-    /* TAG_FULL = 0b0???????, */
     /** @private Used to verify if tag is constant or hash data. */
     TAG_MSB = TAG_DELETED,
     /** @private Used to create a one byte fingerprint of user hash. */

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -158,8 +158,8 @@ enum : typeof((group){}.v)
     MATCH_MASK_TAGS_LSBS = 0x101010101010101,
     /** @private Debug mode check for bits that must be off in match. */
     MATCH_MASK_TAGS_OFF_BITS = 0x7F7F7F7F7F7F7F7F,
-    /** @private All bits on for each tag except for the 0th tag. */
-    MATCH_MASK_0TH_TAG_OFF = 0xFFFFFFFFFFFFFF00,
+    /** @private The MSB of each byte on except 0th is 0x00. */
+    MATCH_MASK_0TH_TAG_OFF = 0x8080808080808000,
 };
 
 enum : typeof((ccc_fhm_tag){}.v)
@@ -2303,9 +2303,10 @@ static inline match_mask
 match_leading_full(group const g, size_t const start_tag)
 {
     assert(start_tag < CCC_FHM_GROUP_SIZE);
+    /* The 0th tag off mask we use also happens to ensure only the MSB in each
+       byte of a match is on as the assert confirms after. */
     match_mask const res = to_little_endian((match_mask){
-        ((~g.v) & (MATCH_MASK_0TH_TAG_OFF << (start_tag * TAG_BITS)))
-            & MATCH_MASK_TAGS_MSBS,
+        (~g.v) & (MATCH_MASK_0TH_TAG_OFF << (start_tag * TAG_BITS)),
     });
     assert(
         (res.v & MATCH_MASK_TAGS_OFF_BITS) == 0

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -664,7 +664,7 @@ ccc_fhm_next(ccc_flat_hash_map const *const h,
     size_t const aligned_group_start
         = i.count & ~((typeof(i.count))(CCC_FHM_GROUP_SIZE - 1));
     match_mask m = match_leading_full(group_loada(&h->tag[aligned_group_start]),
-                                      i.count % CCC_FHM_GROUP_SIZE);
+                                      i.count & (CCC_FHM_GROUP_SIZE - 1));
     size_t const bit = match_next_one(&m);
     if (bit != CCC_FHM_GROUP_SIZE)
     {

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -1292,10 +1292,10 @@ find_first_deleted_group(struct ccc_fhmap const *const h, size_t *const start)
     assert((*start & ~((size_t)(CCC_FHM_GROUP_SIZE - 1))) == *start);
     while (*start < (h->mask + 1))
     {
-        match_mask const full = match_deleted(group_loada(&h->tag[*start]));
-        if (full.v)
+        match_mask const deleted = match_deleted(group_loada(&h->tag[*start]));
+        if (deleted.v)
         {
-            return full;
+            return deleted;
         }
         *start += CCC_FHM_GROUP_SIZE;
     }

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -1399,7 +1399,8 @@ rehash_in_place(struct ccc_fhmap *const h)
                 }
                 /* The other slots data has been swapped and we rehash every
                    element for this algorithm so there is no need to write its
-                   tag to this slot. It's data is correct location already. */
+                   tag to this slot. It's data is in the correct location and
+                   we now will loop to try to find it a rehashed slot. */
                 assert(occupant.v == TAG_DELETED);
                 swap(swap_slot(h), data_at(h, i), data_at(h, new_i),
                      h->sizeof_type);

--- a/src/flat_hash_map.c
+++ b/src/flat_hash_map.c
@@ -863,8 +863,8 @@ ccc_fhm_copy(ccc_flat_hash_map *const dst, ccc_flat_hash_map const *const src,
     match_mask full = {};
     while ((full = find_first_full_group(src, &group_start)).v)
     {
-        for (size_t tag = match_next_one(&full); tag != CCC_FHM_GROUP_SIZE;
-             tag = match_next_one(&full))
+        size_t tag = 0;
+        while ((tag = match_next_one(&full)) != CCC_FHM_GROUP_SIZE)
         {
             size_t const i = group_start + tag;
             uint64_t const hash = hash_fn(src, key_at(src, i));
@@ -1128,8 +1128,8 @@ find_key_or_slot(struct ccc_fhmap const *const h, void const *const key,
     {
         group const g = group_loadu(&h->tag[p.i]);
         match_mask m = match_tag(g, tag);
-        for (size_t i_match = match_next_one(&m); i_match != CCC_FHM_GROUP_SIZE;
-             i_match = match_next_one(&m))
+        size_t i_match = 0;
+        while ((i_match = match_next_one(&m)) != CCC_FHM_GROUP_SIZE)
         {
             i_match = (p.i + i_match) & mask;
             if (likely(eq_fn(h, key, i_match)))
@@ -1187,8 +1187,8 @@ find_key_or_fail(struct ccc_fhmap const *const h, void const *const key,
     {
         group const g = group_loadu(&h->tag[p.i]);
         match_mask m = match_tag(g, tag);
-        for (size_t i_match = match_next_one(&m); i_match != CCC_FHM_GROUP_SIZE;
-             i_match = match_next_one(&m))
+        size_t i_match = 0;
+        while ((i_match = match_next_one(&m)) != CCC_FHM_GROUP_SIZE)
         {
             i_match = (p.i + i_match) & mask;
             if (likely(eq_fn(h, key, i_match)))
@@ -1365,8 +1365,8 @@ rehash_in_place(struct ccc_fhmap *const h)
        for any groups with elements that need to be rehashed. */
     while ((deleted = find_first_deleted_group(h, &group_start)).v)
     {
-        for (size_t tag = match_next_one(&deleted); tag != CCC_FHM_GROUP_SIZE;
-             tag = match_next_one(&deleted))
+        size_t tag = 0;
+        while ((tag = match_next_one(&deleted)) != CCC_FHM_GROUP_SIZE)
         {
             size_t const i = group_start + tag;
             /* The inner loop swap case may have made a previously deleted entry
@@ -1463,8 +1463,8 @@ rehash_resize(struct ccc_fhmap *const h, size_t const to_add,
     match_mask full = {};
     while ((full = find_first_full_group(h, &group_start)).v)
     {
-        for (size_t tag = match_next_one(&full); tag != CCC_FHM_GROUP_SIZE;
-             tag = match_next_one(&full))
+        size_t tag = 0;
+        while ((tag = match_next_one(&full)) != CCC_FHM_GROUP_SIZE)
         {
             size_t const i = group_start + tag;
             uint64_t const hash = hash_fn(h, key_at(h, i));


### PR DESCRIPTION
Applying group-wise scans to the resizing rehash function and rehash in place function can net large wins for large tables. Rehashing is always a pain point of tombstone based hash tables so applying the aligned load logic we have already put in place should be worth it during the rehash process. Large spans of unoccupied slots will be skipped.

This optimization is straightforward for the rehash resize case when rehashing full elements to a new table. The choice is more complicated in the in place rehash case, but the core concept is the same and we should take advantage of group scans that will skip empty group sections due to load factor.