### PR TITLE
Flat Priority Queue Const Update

### DIFF
--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -494,7 +494,7 @@ flat_priority_queue is empty.
 A simple way to provide a temp for swapping is with an inline compound literal
 reference provided directly to the function argument `&(name_of_type){}`. */
 void *CCC_flat_priority_queue_update(
-    CCC_Flat_priority_queue *priority_queue,
+    CCC_Flat_priority_queue const *priority_queue,
     void *type,
     void *temp,
     CCC_Modifier const *modifier
@@ -548,7 +548,7 @@ flat_priority_queue is empty.
 A simple way to provide a temp for swapping is with an inline compound literal
 reference provided directly to the function argument `&(name_of_type){}`. */
 void *CCC_flat_priority_queue_increase(
-    CCC_Flat_priority_queue *priority_queue,
+    CCC_Flat_priority_queue const *priority_queue,
     void *type,
     void *temp,
     CCC_Modifier const *modifier
@@ -600,7 +600,7 @@ flat_priority_queue is empty.
 A simple way to provide a temp for swapping is with an inline compound literal
 reference provided directly to the function argument `&(name_of_type){}`. */
 void *CCC_flat_priority_queue_decrease(
-    CCC_Flat_priority_queue *priority_queue,
+    CCC_Flat_priority_queue const *priority_queue,
     void *type,
     void *temp,
     CCC_Modifier const *modifier

--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -481,7 +481,9 @@ CCC_Result CCC_flat_priority_queue_erase(
 
 /** @brief Update e that is a handle to the stored priority_queue element.
 O(lgN).
-@param[in] priority_queue a pointer to the flat priority queue.
+@param[in] priority_queue a pointer to the flat priority queue. No fields of the
+flat priority queue are modified but the contiguous user data pointed to by the
+priority queue may be reorganized.
 @param[in] type a pointer to the stored priority_queue element. Must be in
 the flat_priority_queue.
 @param[in] temp a pointer to a dummy user type that will be used for swapping.
@@ -501,7 +503,9 @@ void *CCC_flat_priority_queue_update(
 );
 
 /** @brief Update the held user type stored in the priority queue. O(lgN).
-@param[in] priority_queue_pointer a pointer to the flat priority queue.
+@param[in] priority_queue_pointer a pointer to the flat priority queue. No
+fields of the flat priority queue are modified but the contiguous user data
+pointed to by the priority queue may be reorganized.
 @param[in] closure_parameter a pointer variable to the user type being updated.
 @param[in] update_closure_over_closure_parameter the semicolon separated
 statements to execute on the user type provided (optionally wrapping {code here}
@@ -535,7 +539,9 @@ Note that whether the key increases or decreases does not affect runtime. */
 
 /** @brief Increase type that is a handle to the stored flat_priority_queue
 element. O(lgN).
-@param[in] priority_queue a pointer to the flat priority queue.
+@param[in] priority_queue a pointer to the flat priority queue. No fields of the
+flat priority queue are modified but the contiguous user data pointed to by the
+priority queue may be reorganized.
 @param[in] type a pointer to the stored priority_queue element. Must be in the
 flat_priority_queue.
 @param[in] temp a pointer to a dummy user type that will be used for swapping.
@@ -555,7 +561,9 @@ void *CCC_flat_priority_queue_increase(
 );
 
 /** @brief Increase the user type stored in the priority queue directly. O(lgN).
-@param[in] flat_priority_queue_pointer a pointer to the flat priority queue.
+@param[in] priority_queue_pointer a pointer to the flat priority queue. No
+fields of the flat priority queue are modified but the contiguous user data
+pointed to by the priority queue may be reorganized.
 @param[in] closure_parameter a pointer variable to user type being increased.
 @param[in] increase_closure_over_closure_parameter the semicolon separated
 statements to execute on the user type provided (optionally wrapping {code here}
@@ -575,19 +583,21 @@ int *e = get_rand_flat_priority_queue_node(&flat_priority_queue);
 
 Note that if this priority queue is min or max, the runtime is the same. */
 #define CCC_flat_priority_queue_increase_with(                                 \
-    flat_priority_queue_pointer,                                               \
+    priority_queue_pointer,                                                    \
     closure_parameter,                                                         \
     increase_closure_over_closure_parameter...                                 \
 )                                                                              \
     CCC_private_flat_priority_queue_increase_with(                             \
-        flat_priority_queue_pointer,                                           \
+        priority_queue_pointer,                                                \
         closure_parameter,                                                     \
         increase_closure_over_closure_parameter                                \
     )
 
 /** @brief Decrease e that is a handle to the stored flat_priority_queue
 element. O(lgN).
-@param[in] priority_queue a pointer to the flat priority queue.
+@param[in] priority_queue a pointer to the flat priority queue. No fields of the
+flat priority queue are modified but the contiguous user data pointed to by the
+priority queue may be reorganized.
 @param[in] type a pointer to the stored priority_queue element. Must be in
 the flat_priority_queue.
 @param[in] temp a pointer to a dummy user type that will be used for swapping.
@@ -607,7 +617,9 @@ void *CCC_flat_priority_queue_decrease(
 );
 
 /** @brief Increase the user type stored in the priority queue directly. O(lgN).
-@param[in] flat_priority_queue_pointer a pointer to the flat priority queue.
+@param[in] priority_queue_pointer a pointer to the flat priority queue. No
+fields of the flat priority queue are modified but the contiguous user data
+pointed to by the priority queue may be reorganized.
 @param[in] closure_parameter a pointer variable to user type being decreased.
 @param[in] decrease_closure_over_closure_parameter the semicolon separated
 statements to execute on the user type provided (optionally wrapping {code here}
@@ -626,12 +638,12 @@ int *e = get_rand_flat_priority_queue_node(&flat_priority_queue);
 
 Note that if this priority queue is min or max, the runtime is the same. */
 #define CCC_flat_priority_queue_decrease_with(                                 \
-    flat_priority_queue_pointer,                                               \
+    priority_queue_pointer,                                                    \
     closure_parameter,                                                         \
     decrease_closure_over_closure_parameter...                                 \
 )                                                                              \
     CCC_private_flat_priority_queue_decrease_with(                             \
-        flat_priority_queue_pointer,                                           \
+        priority_queue_pointer,                                                \
         closure_parameter,                                                     \
         decrease_closure_over_closure_parameter                                \
     )

--- a/ccc/private/private_flat_priority_queue.h
+++ b/ccc/private/private_flat_priority_queue.h
@@ -46,15 +46,15 @@ struct CCC_Flat_priority_queue {
 
 /** @internal */
 size_t CCC_private_flat_priority_queue_bubble_up(
-    struct CCC_Flat_priority_queue *, void *, size_t
+    struct CCC_Flat_priority_queue const *, void *, size_t
 );
 /** @internal */
 void CCC_private_flat_priority_queue_heap_order(
-    struct CCC_Flat_priority_queue *, void *
+    struct CCC_Flat_priority_queue const *, void *
 );
 /** @internal */
 void *CCC_private_flat_priority_queue_update_fixup(
-    struct CCC_Flat_priority_queue *, void *, void *
+    struct CCC_Flat_priority_queue const *, void *, void *
 );
 
 /*======================    Macro Implementations    ========================*/

--- a/ccc/private/private_flat_priority_queue.h
+++ b/ccc/private/private_flat_priority_queue.h
@@ -233,8 +233,8 @@ to the user. GCC is not so forgiving. */
     update_closure_over_closure_parameter...                                   \
 )                                                                              \
     (__extension__({                                                           \
-        struct CCC_Flat_priority_queue *const private_flat_priority_queue      \
-            = (flat_priority_queue_pointer);                                   \
+        struct CCC_Flat_priority_queue const *const                            \
+            private_flat_priority_queue = (flat_priority_queue_pointer);       \
         typeof(*closure_parameter) *                                           \
             private_flat_priority_queue_updated_element = (closure_parameter); \
         if (private_flat_priority_queue                                        \

--- a/ccc/sort.h
+++ b/ccc/sort.h
@@ -61,7 +61,7 @@ as `&(My_type){}`, passed directly as an argument.
 The sort is not inherently stable and uses the provided comparison function to
 order the elements. */
 CCC_Result CCC_sort_heapsort(
-    CCC_Flat_buffer *buffer,
+    CCC_Flat_buffer const *buffer,
     void *temp,
     CCC_Order order,
     CCC_Comparator const *comparator

--- a/ccc/sort.h
+++ b/ccc/sort.h
@@ -38,7 +38,8 @@ Various sorting algorithms for different containers in the collection. */
 
 /** @brief Sorts the input buffer in `O(N * log(N))` time and `O(1)` space
 according to the desired input order.
-@param[in] buffer the buffer to be modified and sorted in place.
+@param[in] buffer the buffer to be sorted. No fields of the buffer struct are
+modified, but the contiguous user data pointed to by the buffer is reorganized.
 @param[in] temp a pointer to a dummy user type that will be used for swapping.
 @param[in] order the desired order of the sorted buffer. CCC_ORDER_LESSER places
 elements in non-decreasing order starting from index `[0, N)`, where N is the

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -33,19 +33,24 @@ enum : size_t {
 static size_t index_of(struct CCC_Flat_priority_queue const *, void const *);
 static CCC_Tribool
 wins(void const *, void const *, CCC_Order, CCC_Comparator const *);
-static size_t
-bubble_up(CCC_Flat_buffer *, size_t, void *, CCC_Order, CCC_Comparator const *);
-static size_t bubble_down(
-    CCC_Flat_buffer *, size_t, void *, CCC_Order, CCC_Comparator const *
+static size_t bubble_up(
+    CCC_Flat_buffer const *, size_t, void *, CCC_Order, CCC_Comparator const *
 );
-static size_t update_fixup(struct CCC_Flat_priority_queue *, void *, void *);
+static size_t bubble_down(
+    CCC_Flat_buffer const *,
+    size_t,
+    size_t,
+    void *,
+    CCC_Order,
+    CCC_Comparator const *
+);
+static size_t
+update_fixup(struct CCC_Flat_priority_queue const *, void *, void *);
 static void
-heapify(CCC_Flat_buffer *, void *, CCC_Order, CCC_Comparator const *);
-static void
-heapsort(CCC_Flat_buffer *, void *, CCC_Order, CCC_Comparator const *);
+heapify(CCC_Flat_buffer const *, void *, CCC_Order, CCC_Comparator const *);
 static void
 destroy_each(struct CCC_Flat_priority_queue *, CCC_Destructor const *);
-static void swap(CCC_Flat_buffer *, void *, void *, void *);
+static void swap(CCC_Flat_buffer const *, void *, void *, void *);
 static void *at(CCC_Flat_buffer const *buffer, size_t i);
 
 /*=====================       Interface      ================================*/
@@ -152,6 +157,7 @@ CCC_flat_priority_queue_pop(
     (void)bubble_down(
         &priority_queue->buffer,
         0,
+        priority_queue->buffer.count,
         temp,
         priority_queue->order,
         &priority_queue->comparator
@@ -198,6 +204,7 @@ CCC_flat_priority_queue_erase(
         (void)bubble_down(
             &priority_queue->buffer,
             i,
+            priority_queue->buffer.count,
             temp,
             priority_queue->order,
             &priority_queue->comparator
@@ -208,7 +215,7 @@ CCC_flat_priority_queue_erase(
 
 void *
 CCC_flat_priority_queue_update(
-    CCC_Flat_priority_queue *const priority_queue,
+    CCC_Flat_priority_queue const *const priority_queue,
     void *const type,
     void *const temp,
     CCC_Modifier const *const modifier
@@ -229,7 +236,7 @@ CCC_flat_priority_queue_update(
 /* There are no efficiency benefits in knowing an increase will occur. */
 void *
 CCC_flat_priority_queue_increase(
-    CCC_Flat_priority_queue *const priority_queue,
+    CCC_Flat_priority_queue const *const priority_queue,
     void *const type,
     void *const temp,
     CCC_Modifier const *const modifier
@@ -240,7 +247,7 @@ CCC_flat_priority_queue_increase(
 /* There are no efficiency benefits in knowing an decrease will occur. */
 void *
 CCC_flat_priority_queue_decrease(
-    CCC_Flat_priority_queue *const priority_queue,
+    CCC_Flat_priority_queue const *const priority_queue,
     void *const type,
     void *const temp,
     CCC_Modifier const *const modifier
@@ -430,7 +437,7 @@ CCC_flat_priority_queue_validate(
 
 CCC_Result
 CCC_sort_heapsort(
-    CCC_Flat_buffer *const buffer,
+    CCC_Flat_buffer const *const buffer,
     void *const temp,
     CCC_Order order,
     CCC_Comparator const *const comparator
@@ -445,8 +452,15 @@ CCC_sort_heapsort(
        heap sort fills a buffer from back to front, so flip it. */
     order == CCC_ORDER_GREATER ? (order = CCC_ORDER_LESSER)
                                : (order = CCC_ORDER_GREATER);
-    heapify(buffer, temp, order, comparator);
-    heapsort(buffer, temp, order, comparator);
+    if (buffer->count > 1) {
+        heapify(buffer, temp, order, comparator);
+        size_t count = buffer->count;
+        void *const root = at(buffer, 0);
+        while (--count) {
+            swap(buffer, temp, root, at(buffer, count));
+            (void)bubble_down(buffer, 0, count, temp, order, comparator);
+        }
+    }
     return CCC_RESULT_OK;
 }
 
@@ -454,7 +468,7 @@ CCC_sort_heapsort(
 
 size_t
 CCC_private_flat_priority_queue_bubble_up(
-    struct CCC_Flat_priority_queue *const priority_queue,
+    struct CCC_Flat_priority_queue const *const priority_queue,
     void *const temp,
     size_t index
 ) {
@@ -469,7 +483,7 @@ CCC_private_flat_priority_queue_bubble_up(
 
 void *
 CCC_private_flat_priority_queue_update_fixup(
-    struct CCC_Flat_priority_queue *const priority_queue,
+    struct CCC_Flat_priority_queue const *const priority_queue,
     void *const type,
     void *const temp
 ) {
@@ -480,7 +494,7 @@ CCC_private_flat_priority_queue_update_fixup(
 
 void
 CCC_private_flat_priority_queue_heap_order(
-    struct CCC_Flat_priority_queue *const priority_queue, void *const temp
+    struct CCC_Flat_priority_queue const *const priority_queue, void *const temp
 ) {
     heapify(
         &priority_queue->buffer,
@@ -495,39 +509,21 @@ CCC_private_flat_priority_queue_heap_order(
 /* Orders the heap in O(N) time. Assumes n > 0 and n <= capacity. */
 static inline void
 heapify(
-    CCC_Flat_buffer *const buffer,
+    CCC_Flat_buffer const *const buffer,
     void *temp,
     CCC_Order const order,
     CCC_Comparator const *const comparator
 ) {
     size_t i = ((buffer->count - 1) / 2) + 1;
     while (i--) {
-        (void)bubble_down(buffer, i, temp, order, comparator);
-    }
-}
-
-static inline void
-heapsort(
-    CCC_Flat_buffer *const buffer,
-    void *const temp,
-    CCC_Order const order,
-    CCC_Comparator const *const comparator
-) {
-    if (buffer->count > 1) {
-        size_t const start = buffer->count;
-        void *const root = at(buffer, 0);
-        while (--buffer->count) {
-            swap(buffer, temp, root, at(buffer, buffer->count));
-            (void)bubble_down(buffer, 0, temp, order, comparator);
-        }
-        buffer->count = start;
+        (void)bubble_down(buffer, i, buffer->count, temp, order, comparator);
     }
 }
 
 /* Fixes the position of element e after its key value has been changed. */
 static size_t
 update_fixup(
-    struct CCC_Flat_priority_queue *const priority_queue,
+    struct CCC_Flat_priority_queue const *const priority_queue,
     void *const type,
     void *const temp
 ) {
@@ -536,6 +532,7 @@ update_fixup(
         return bubble_down(
             &priority_queue->buffer,
             0,
+            priority_queue->buffer.count,
             temp,
             priority_queue->order,
             &priority_queue->comparator
@@ -560,6 +557,7 @@ update_fixup(
         return bubble_down(
             &priority_queue->buffer,
             index,
+            priority_queue->buffer.count,
             temp,
             priority_queue->order,
             &priority_queue->comparator
@@ -571,7 +569,7 @@ update_fixup(
 /* Returns the sorted position of the element starting at position i. */
 static inline size_t
 bubble_up(
-    CCC_Flat_buffer *const buffer,
+    CCC_Flat_buffer const *const buffer,
     size_t index,
     void *const temp,
     CCC_Order const order,
@@ -593,18 +591,19 @@ bubble_up(
 /* Returns the sorted position of the element starting at position i. */
 static inline size_t
 bubble_down(
-    CCC_Flat_buffer *const buffer,
+    CCC_Flat_buffer const *const buffer,
     size_t index,
+    size_t const count,
     void *const temp,
     CCC_Order const order,
     CCC_Comparator const *const comparator
 ) {
     for (size_t next = 0, left = (index * 2) + 1, right = left + 1;
-         left < buffer->count;
+         left < count;
          index = next, left = (index * 2) + 1, right = left + 1) {
         void const *const left_pointer = at(buffer, left);
         next = left;
-        if (right < buffer->count) {
+        if (right < count) {
             void const *const right_pointer = at(buffer, right);
             if (wins(right_pointer, left_pointer, order, comparator)) {
                 next = right;
@@ -662,7 +661,7 @@ index_of(
 temp are non-null. */
 static inline void
 swap(
-    CCC_Flat_buffer *const buffer,
+    CCC_Flat_buffer const *const buffer,
     void *const temp,
     void *const a,
     void *const b


### PR DESCRIPTION
Many operations that modify the underlying buffer of user data of the `CCC_Flat_priority_queue` do not actually modify any fields of the metadata struct itself. While we may be swapping elements in the buffer of user data, if we do not resize the buffer, free the buffer, or modify any fields of the flat priority queue struct, then the function signature should reflect this with const. This is nice for things like heapifying and sorting because it communicates what the operation changes and what it does not more clearly.