### PR TITLE
add alignment constraint to allocator interface

### DIFF
--- a/DOXYGEN_README.md
+++ b/DOXYGEN_README.md
@@ -77,14 +77,20 @@ user provided allocator function internally.
 - If input is NULL and bytes 0, NULL is returned.
 - If input is NULL with non-zero bytes, new memory is allocated and returned
   with the base address aligned to the alignment argument. If alignment is zero,
-  the default alignment of the allocator is used.
+  the default alignment of the allocator is used (usually `max_align_t`).
 - If input is non-NULL it has been previously allocated by the allocator.
 - If input is non-NULL with non-zero size, input is resized to at least bytes
   size. The pointer returned is NULL if resizing fails. Upon success, the
   pointer returned might not be equal to the pointer provided and is aligned to
   the provided alignment argument. If alignment is zero, the default alignment
-  of the allocator is used.
-- If input is non-NULL and size is 0, input is freed and NULL is returned. */
+  of the allocator is used (usually `max_align_t`).
+- If input is non-NULL and size is 0, input is freed and NULL is returned.
+
+@warning Wrapping `malloc`, `realloc`, and `free` is sufficient for hosted
+environments where allocation alignment requirements do not exceed
+`max_align_t`. For fully portable C Container Collection code, regardless of
+user type alignment requirements, users are encouraged to use allocators that
+respect alignment for allocating and resizing. */
 typedef void *CCC_Allocator_interface(CCC_Allocator_arguments);
 
 void *

--- a/DOXYGEN_README.md
+++ b/DOXYGEN_README.md
@@ -48,30 +48,43 @@ Follow the links to the C Container Collection headers.
 Traditionally, dynamic memory is obtained, resized, and freed through an OS or language provided interface such as `malloc`, `realloc`, and `free`; these three functions manage a global allocator. However, these three core functionalities of an allocator can be united into one function. This is the approach that the C Container Collection takes. This is the implementation of the standard library allocator through the `CCC_Allocator_interface` type function.
 
 ```c
+/** @brief A bundle of arguments to pass to the user-implemented
+Allocator_interface function interface. This ensures clarity in inputs and
+expected outputs to an allocator function the user wishes to use for managing
+containers. Additional context can be provided for more complex allocation
+schemes.
+
+The pointers are const to bind the input closely with its context, if context is
+provided. Because container code is providing the user a reference to a user
+type it currently stores, or data it manages, it is critical the user does not
+accidentally move or misuse the pointer to jeopardize container invariants. */
 typedef struct {
     /** The input to the allocation function. NULL or previously allocated. */
     void *const input;
     /** The bytes being requested from the allocator. 0 is a free request. */
     size_t bytes;
+    /** The alignment for the base address of the returned bytes. */
+    size_t alignment;
     /** Additional state to pass to the allocator to help manage memory. */
     void *const context;
 } CCC_Allocator_arguments;
 
-/** @brief An allocation function at the core of all containers.
+/** @brief The function interface for allocating, resizing, and freeing memory.
 
-An allocation function implements the following behavior, when it has been
-passed an allocator context. Context is passed to a container upon its
-initialization and the programmer may choose how to best utilize this reference.
+The C Container Collection relies on the following behaviors when calling the
+user provided allocator function internally.
 
 - If input is NULL and bytes 0, NULL is returned.
-- If input is NULL with non-zero bytes, new memory is allocated/returned.
+- If input is NULL with non-zero bytes, new memory is allocated and returned
+  with the base address aligned to the alignment argument. If alignment is zero,
+  the default alignment of the allocator is used.
 - If input is non-NULL it has been previously allocated by the allocator.
 - If input is non-NULL with non-zero size, input is resized to at least bytes
   size. The pointer returned is NULL if resizing fails. Upon success, the
-  pointer returned might not be equal to the pointer provided.
-- If input is non-NULL and size is 0, input is freed and NULL is returned.
-
-This allocator does not need context. */
+  pointer returned might not be equal to the pointer provided and is aligned to
+  the provided alignment argument. If alignment is zero, the default alignment
+  of the allocator is used.
+- If input is non-NULL and size is 0, input is freed and NULL is returned. */
 typedef void *CCC_Allocator_interface(CCC_Allocator_arguments);
 
 void *

--- a/README.md
+++ b/README.md
@@ -874,9 +874,31 @@ typedef struct {
 } CCC_Allocator;
 ```
 
-The `CCC_Allocator_interface` function type implements a unified interface for allocation, reallocation, and deallocation. See `types.h` for the full contract. A standard library backed allocator might look like this:
+The `CCC_Allocator_interface` function type implements a unified interface for allocation, reallocation, and deallocation. See `types.h` for the full contract.
 
 ```c
+/** @brief The function interface for allocating, resizing, and freeing memory.
+
+The C Container Collection relies on the following behaviors when calling the
+user provided allocator function internally.
+
+- If input is NULL and bytes 0, NULL is returned.
+- If input is NULL with non-zero bytes, new memory is allocated and returned
+  with the base address aligned to the alignment argument. If alignment is zero,
+  the default alignment of the allocator is used (usually `max_align_t`).
+- If input is non-NULL it has been previously allocated by the allocator.
+- If input is non-NULL with non-zero size, input is resized to at least bytes
+  size. The pointer returned is NULL if resizing fails. Upon success, the
+  pointer returned might not be equal to the pointer provided and is aligned to
+  the provided alignment argument. If alignment is zero, the default alignment
+  of the allocator is used (usually `max_align_t`).
+- If input is non-NULL and size is 0, input is freed and NULL is returned.
+
+@warning Wrapping `malloc`, `realloc`, and `free` is sufficient for hosted
+environments where allocation alignment requirements do not exceed
+`max_align_t`. For fully portable C Container Collection code, regardless of
+user type alignment requirements, users are encouraged to use allocators that
+respect alignment for allocating and resizing. */
 void *
 std_allocate(CCC_Allocator_arguments const arguments)
 {

--- a/ccc/adaptive_map.h
+++ b/ccc/adaptive_map.h
@@ -44,7 +44,7 @@ All types and functions can then be written without the `CCC_` prefix. */
 /** @endcond */
 
 #include "private/private_adaptive_map.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/array_adaptive_map.h
+++ b/ccc/array_adaptive_map.h
@@ -88,53 +88,22 @@ typedef struct CCC_Array_adaptive_map_handle CCC_Array_adaptive_map_handle;
 Initialize the container with memory, callbacks, and permissions. */
 /**@{*/
 
-/** @brief Create the underlying fixed size storage for a user declared compound
-literal array of the type the user intends to store.
+/** @brief Provides the fixed size type layout and underlying storage for a
+fixed size map. Helpful if the size in bytes of the underlying storage block is
+needed.
 @param[in] user_type_compound_literal_array a compound literal array of the type
-around which the map will be built.
-@param[in] optional_storage_specifier a storage specifier for the backing struct
-of array storage may be added on newer compilers such as static.
-@warning If using an allocation function that accepts an alignment argument,
-the following must be true for the provided alignment argument:
-`alignment >= alignof(struct CCC_Array_adaptive_map_node)`. This helper should
-rarely be used. If a fixed size map is desired simply use the
-CCC_array_adaptive_map_with_storage() initializer. For dynamic maps, there are
-also many other options.
+around which the map will be built. Must be a power of 2 capacity array.
+@note Size of the underlying storage can be obtained via the following macro
+`sizeof(CCC_array_adaptive_map_storage_for(...))`, as needed.
+@warning See CCC_array_adaptive_map_with_allocator_storage() if you wish to
+allocate a fixed size map dynamically at runtime due to strict memory
+requirements. A `CCC_Allocator` must be provided to that interface function to
+complete the allocation.
 
-This macro is required to support the edge case for the user allocating a fixed
-size map dynamically from an allocator at runtime. In this case, the user needs
-access to the compound literal struct of arrays map to know how many bytes to
-allocate. See the below example.
-
-```
-struct Val
-{
-    int key;
-    int val;
-};
-
-int
-main(void)
-{
-    void *const map = malloc(
-        sizeof(CCC_array_adaptive_map_storage_for((struct Val[4096]){}))
-    );
-    defer free(map);
-    CCC_Array_adaptive_map map = CCC_array_adaptive_map_for(
-        struct Val,
-        key,
-        (CCC_Key_comparator){.compare = order_vals},
-        4096,
-        map
-    );
-}
-```
-
-Usually, using a dynamic map and the reserve interface would be sufficient.
-However, the reserve interface only guarantees that at least the needed bytes
-are allocated. When the user must know the exact size of the backing object due
-to strict memory requirements, this is helpful. Such a use case may be rare, but
-must be supported by this container. */
+If the user wishes to dynamically allocate a fixed size map at runtime this
+macro can be used to obtain the total bytes of the underlying storage as needed.
+See CCC_array_adaptive_map_with_allocator_storage() for how to dynamically
+allocate a fixed size map. This is not a common use case. */
 #define CCC_array_adaptive_map_storage_for(                                    \
     user_type_compound_literal_array, optional_storage_specifier...            \
 )                                                                              \
@@ -324,6 +293,23 @@ This can help eliminate boilerplate in initializers. */
         comparator,                                                            \
         compound_literal,                                                      \
         optional_storage_specifier                                             \
+    )
+
+/** Obtain a fixed size map dynamically at runtime from an allocator.
+@param[in] key_field the field of the struct used for key storage.
+@param[in] comparator a CCC_Key_comparator that configures the key comparator
+function and context for comparison.
+@param[in] compound_literal the compound literal array of a type provided by the
+user around which the struct of arrays backing storage for the map is built.
+@return the map initialized on the right hand side of equality operator. If
+dynamic allocation is successful the map is initialized with the specified
+capacity. If allocation fails the map will have a capacity of 0 and NULL
+internal pointers. */
+#define CCC_array_adaptive_map_with_allocator_storage(                         \
+    key_field, comparator, allocator, compound_literal                         \
+)                                                                              \
+    CCC_private_array_adaptive_map_with_allocator_storage(                     \
+        key_field, comparator, allocator, compound_literal                     \
     )
 
 /** @brief Copy the map at source to destination.
@@ -1082,6 +1068,8 @@ typedef CCC_Array_adaptive_map_handle Array_adaptive_map_handle;
         CCC_array_adaptive_map_with_capacity(arguments)
 #    define array_adaptive_map_with_storage(arguments...)                      \
         CCC_array_adaptive_map_with_storage(arguments)
+#    define array_adaptive_map_with_allocator_storage(arguments...)            \
+        CCC_array_adaptive_map_with_allocator_storage(arguments)
 #    define array_adaptive_map_at(arguments...)                                \
         CCC_array_adaptive_map_at(arguments)
 #    define array_adaptive_map_as(arguments...)                                \

--- a/ccc/array_adaptive_map.h
+++ b/ccc/array_adaptive_map.h
@@ -62,7 +62,7 @@ All types and functions can then be written without the `CCC_` prefix. */
 /** @endcond */
 
 #include "private/private_array_adaptive_map.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/array_adaptive_map.h
+++ b/ccc/array_adaptive_map.h
@@ -94,9 +94,12 @@ literal array of the type the user intends to store.
 around which the map will be built.
 @param[in] optional_storage_specifier a storage specifier for the backing struct
 of array storage may be added on newer compilers such as static.
-@warning This should rarely be used. If a fixed size map is desired simply use
-the CCC_array_adaptive_map_with_storage() initializer. For dynamic
-maps, there are also many other options.
+@warning If using an allocation function that accepts an alignment argument,
+the following must be true for the provided alignment argument:
+`alignment >= alignof(struct CCC_Array_adaptive_map_node)`. This helper should
+rarely be used. If a fixed size map is desired simply use the
+CCC_array_adaptive_map_with_storage() initializer. For dynamic maps, there are
+also many other options.
 
 This macro is required to support the edge case for the user allocating a fixed
 size map dynamically from an allocator at runtime. In this case, the user needs

--- a/ccc/array_tree_map.h
+++ b/ccc/array_tree_map.h
@@ -95,53 +95,22 @@ typedef struct CCC_Array_tree_map_handle CCC_Array_tree_map_handle;
 Initialize the container with memory, callbacks, and permissions. */
 /**@{*/
 
-/** @brief Create the underlying fixed size map storage from a user declared
-compound literal array of the type the user intends to store.
+/** @brief Provides the fixed size type layout and underlying storage for a
+fixed size map. Helpful if the size in bytes of the underlying storage block is
+needed.
 @param[in] user_type_compound_literal_array a compound literal array of the type
-around which the map will be built.
-@param[in] optional_storage_specifier a storage specifier for the backing struct
-of array storage may be added on newer compilers such as static.
-@warning If using an allocation function that accepts an alignment argument,
-the following must be true for the provided alignment argument:
-`alignment >= alignof(struct CCC_Array_tree_map_node)`. This helper should
-rarely be used. If a fixed size map is desired simply use the
-CCC_array_tree_map_with_storage() initializer. For dynamic maps, there are
-also many other options.
+around which the map will be built. Must be a power of 2 capacity array.
+@note Size of the underlying storage can be obtained via the following macro
+`sizeof(CCC_array_tree_map_storage_for(...))`, as needed.
+@warning See CCC_array_tree_map_with_allocator_storage() if you wish to allocate
+a fixed size map dynamically at runtime due to strict memory requirements. A
+`CCC_Allocator` must be provided to that interface function to complete the
+allocation.
 
-This macro is required to support the edge case for the user allocating a fixed
-size map dynamically from an allocator at runtime. In this case, the user needs
-access to the compound literal struct of arrays map to know how many bytes to
-allocate. See the below example.
-
-```
-struct Val
-{
-    int key;
-    int val;
-};
-
-int
-main(void)
-{
-    void *const map = malloc(
-        sizeof(CCC_array_tree_map_storage_for((struct Val[4096]){}))
-    );
-    defer free(map);
-    CCC_Array_tree_map map = CCC_array_tree_map_for(
-        struct Val,
-        key,
-        (CCC_Key_comparator){.compare = order_vals},
-        4096,
-        map
-    );
-}
-```
-
-Usually, using a dynamic map and the reserve interface would be sufficient.
-However, the reserve interface only guarantees that at least the needed bytes
-are allocated. When the user must know the exact size of the backing object due
-to strict memory requirements, this is helpful. Such a use case may be rare, but
-must be supported by this container. */
+If the user wishes to dynamically allocate a fixed size map at runtime this
+macro can be used to obtain the total bytes of the underlying storage as needed.
+See CCC_array_tree_map_with_allocator_storage() for how to dynamically allocate
+a fixed size map. This is not a common use case. */
 #define CCC_array_tree_map_storage_for(                                        \
     user_type_compound_literal_array, optional_storage_specifier...            \
 )                                                                              \
@@ -328,6 +297,23 @@ This can help eliminate boilerplate in initializers. */
         comparator,                                                            \
         compound_literal,                                                      \
         optional_storage_specifier                                             \
+    )
+
+/** Obtain a fixed size map dynamically at runtime from an allocator.
+@param[in] key_field the field of the struct used for key storage.
+@param[in] comparator a CCC_Key_comparator that configures the key comparator
+function and context for comparison.
+@param[in] compound_literal the compound literal array of a type provided by the
+user around which the struct of arrays backing storage for the map is built.
+@return the map initialized on the right hand side of equality operator. If
+dynamic allocation is successful the map is initialized with the specified
+capacity. If allocation fails the map will have a capacity of 0 and NULL
+internal pointers. */
+#define CCC_array_tree_map_with_allocator_storage(                             \
+    key_field, comparator, allocator, compound_literal                         \
+)                                                                              \
+    CCC_private_array_tree_map_with_allocator_storage(                         \
+        key_field, comparator, allocator, compound_literal                     \
     )
 
 /** @brief Copy the map at source to destination.
@@ -1082,6 +1068,8 @@ typedef CCC_Array_tree_map_handle Array_tree_map_handle;
         CCC_array_tree_map_with_capacity(arguments)
 #    define array_tree_map_with_storage(arguments...)                          \
         CCC_array_tree_map_with_storage(arguments)
+#    define array_tree_map_with_allocator_storage(arguments...)                \
+        CCC_array_tree_map_with_allocator_storage(arguments)
 #    define array_tree_map_copy(arguments...) CCC_array_tree_map_copy(arguments)
 #    define array_tree_map_reserve(arguments...)                               \
         CCC_array_tree_map_reserve(arguments)

--- a/ccc/array_tree_map.h
+++ b/ccc/array_tree_map.h
@@ -101,9 +101,12 @@ compound literal array of the type the user intends to store.
 around which the map will be built.
 @param[in] optional_storage_specifier a storage specifier for the backing struct
 of array storage may be added on newer compilers such as static.
-@warning This should rarely be used. If a fixed size map is desired simply use
-the CCC_array_tree_map_with_storage() initializer. For dynamic maps,
-there are also many other options.
+@warning If using an allocation function that accepts an alignment argument,
+the following must be true for the provided alignment argument:
+`alignment >= alignof(struct CCC_Array_tree_map_node)`. This helper should
+rarely be used. If a fixed size map is desired simply use the
+CCC_array_tree_map_with_storage() initializer. For dynamic maps, there are
+also many other options.
 
 This macro is required to support the edge case for the user allocating a fixed
 size map dynamically from an allocator at runtime. In this case, the user needs

--- a/ccc/array_tree_map.h
+++ b/ccc/array_tree_map.h
@@ -65,7 +65,7 @@ All types and functions can then be written without the `CCC_` prefix. */
 /** @endcond */
 
 #include "private/private_array_tree_map.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/doubly_linked_list.h
+++ b/ccc/doubly_linked_list.h
@@ -49,7 +49,7 @@ All types and functions can then be written without the `CCC_` prefix. */
 /** @endcond */
 
 #include "private/private_doubly_linked_list.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/flat_bitset.h
+++ b/ccc/flat_bitset.h
@@ -65,7 +65,7 @@ All types and functions can then be written without the `CCC_` prefix. */
 /** @endcond */
 
 #include "private/private_flat_bitset.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/flat_buffer.h
+++ b/ccc/flat_buffer.h
@@ -59,7 +59,7 @@ Then, the `CCC_` prefix can be dropped from all types and functions. */
 /** @endcond */
 
 #include "private/private_flat_buffer.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/flat_double_ended_queue.h
+++ b/ccc/flat_double_ended_queue.h
@@ -46,9 +46,10 @@ All types and functions can then be written without the `CCC_` prefix. */
 #include <stddef.h>
 /** @endcond */
 
-#include "flat_buffer.h"
 #include "private/private_flat_double_ended_queue.h"
-#include "types.h"
+
+#include "flat_buffer.h" /* IWYU pragma: export */
+#include "types.h"       /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -126,61 +126,24 @@ Subsequent functions that request an allocator can then be passed the empty
 allocator argument, `&(CCC_Allocator){}`. */
 /**@{*/
 
-/** @brief Create the underlying fixed size storage for a user declared compound
-literal array of the type the user intends to store.
+/** @brief Provides the fixed size type layout and underlying storage for a
+fixed size map. Helpful if the size in bytes of the underlying storage block is
+needed.
 @param[in] user_type_compound_literal_array a compound literal array of the type
 around which the map will be built. Must be a power of 2 capacity array.
-@param[in] optional_storage_specifier a storage specifier for the backing struct
-of array storage may be added on newer compilers such as static.
-@warning If using an allocation function that accepts an alignment argument,
-the following must be true for the provided alignment argument:
-`alignment >= CCC_FLAT_HASH_MAP_GROUP_COUNT`. If using regular malloc than the
-user should assert that `alignof(max_align_t) >= CCC_FLAT_HASH_MAP_GROUP_COUNT`.
-This helper should rarely be used. If a fixed size map is desired simply use the
-CCC_flat_hash_map_with_storage() initializer. For dynamic maps, there are
-also many other options.
+@note Size of the underlying storage can be obtained via the following macro
+`sizeof(CCC_flat_hash_map_storage_for(...))`, as needed.
+@warning See CCC_flat_hash_map_with_allocator_storage() if you wish to allocate
+a fixed size map dynamically at runtime due to strict memory requirements. A
+`CCC_Allocator` must be provided to that interface function to complete the
+allocation.
 
-This macro is required to support the edge case for the user allocating a fixed
-size map dynamically from an allocator at runtime. In this case, the user needs
-access to the underlying map storage object to know how many bytes to allocate.
-See the below example.
-
-```
-struct Val
-{
-    int key;
-    int val;
-};
-
-int
-main(void)
-{
-    void *const storage = malloc(
-        sizeof(CCC_flat_hash_map_storage_for((struct Val[4096]){}))
-    );
-    defer free(storage);
-    CCC_Flat_hash_map hash_map = CCC_flat_hash_map_for(
-        struct Val,
-        key,
-        ((CCC_Hasher){.hash = hash_int, .compare = key_order}),
-        4096,
-        storage
-    );
-    return 0;
-}
-```
-
-Usually, using a dynamic map and the reserve interface would be sufficient.
-However, the reserve interface only guarantees that at least the needed bytes
-are allocated. When the user must know the exact size of the backing object due
-to strict memory requirements, this is helpful. Such a use case may be rare, but
-must be supported by this container. */
-#define CCC_flat_hash_map_storage_for(                                         \
-    user_type_compound_literal_array, optional_storage_specifier...            \
-)                                                                              \
-    CCC_private_flat_hash_map_storage_for(                                     \
-        user_type_compound_literal_array, optional_storage_specifier           \
-    )
+If the user wishes to dynamically allocate a fixed size map at runtime this
+macro can be used to obtain the total bytes of the underlying storage as needed.
+See CCC_flat_hash_map_with_allocator_storage() for how to dynamically allocate
+a fixed size map. This is not a common use case. */
+#define CCC_flat_hash_map_storage_for(user_type_compound_literal_array)        \
+    CCC_private_flat_hash_map_storage_for(user_type_compound_literal_array)
 
 /** @brief Initialize a default empty map at compile time or runtime.
 @param[in] type_name the name of the user defined type stored in the map.
@@ -384,6 +347,23 @@ This saves on boilerplate compared to the raw initializer. */
 )                                                                              \
     CCC_private_flat_hash_map_with_storage(                                    \
         key_field, hasher, compound_literal, optional_storage_specifier        \
+    )
+
+/** Obtain a fixed size map dynamically at runtime from an allocator.
+@param[in] key_field the field of the struct used for key storage.
+@param[in] hasher a CCC_Hasher that configures the hash function, key comparator
+function, and context for both hashing and comparison.
+@param[in] compound_literal the compound literal array of a type provided by the
+user around which the struct of arrays backing storage for the map is built.
+@return the map initialized on the right hand side of equality operator. If
+dynamic allocation is successful the map is initialized with the specified
+capacity. If allocation fails the map will have a capacity of 0 and NULL
+internal pointers. */
+#define CCC_flat_hash_map_with_allocator_storage(                              \
+    key_field, hasher, allocator, compound_literal                             \
+)                                                                              \
+    CCC_private_flat_hash_map_with_allocator_storage(                          \
+        key_field, hasher, allocator, compound_literal                         \
     )
 
 /** @brief Copy the map at source to destination.
@@ -1024,6 +1004,8 @@ typedef CCC_Flat_hash_map_entry Flat_hash_map_entry;
         CCC_flat_hash_map_with_capacity(arguments)
 #    define flat_hash_map_with_storage(arguments...)                           \
         CCC_flat_hash_map_with_storage(arguments)
+#    define flat_hash_map_with_allocator_storage(arguments...)                 \
+        CCC_flat_hash_map_with_allocator_storage(arguments)
 #    define flat_hash_map_copy(arguments...) CCC_flat_hash_map_copy(arguments)
 #    define flat_hash_map_and_modify_with(arguments...)                        \
         CCC_flat_hash_map_and_modify_with(arguments)

--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -131,6 +131,8 @@ fixed size map. Helpful if the size in bytes of the underlying storage block is
 needed.
 @param[in] user_type_compound_literal_array a compound literal array of the type
 around which the map will be built. Must be a power of 2 capacity array.
+@param[in] optional_storage_specifier an optional storage duration specifier if
+different from the default for the map at the declared location.
 @note Size of the underlying storage can be obtained via the following macro
 `sizeof(CCC_flat_hash_map_storage_for(...))`, as needed.
 @warning See CCC_flat_hash_map_with_allocator_storage() if you wish to allocate
@@ -142,8 +144,12 @@ If the user wishes to dynamically allocate a fixed size map at runtime this
 macro can be used to obtain the total bytes of the underlying storage as needed.
 See CCC_flat_hash_map_with_allocator_storage() for how to dynamically allocate
 a fixed size map. This is not a common use case. */
-#define CCC_flat_hash_map_storage_for(user_type_compound_literal_array)        \
-    CCC_private_flat_hash_map_storage_for(user_type_compound_literal_array)
+#define CCC_flat_hash_map_storage_for(                                         \
+    user_type_compound_literal_array, optional_storage_duration...             \
+)                                                                              \
+    CCC_private_flat_hash_map_storage_for(                                     \
+        user_type_compound_literal_array, optional_storage_duration            \
+    )
 
 /** @brief Initialize a default empty map at compile time or runtime.
 @param[in] type_name the name of the user defined type stored in the map.

--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -132,9 +132,13 @@ literal array of the type the user intends to store.
 around which the map will be built. Must be a power of 2 capacity array.
 @param[in] optional_storage_specifier a storage specifier for the backing struct
 of array storage may be added on newer compilers such as static.
-@warning This should rarely be used. If a fixed size map is desired simply use
-the CCC_flat_hash_map_with_storage() initializer. For dynamic maps,
-there are also many other options.
+@warning If using an allocation function that accepts an alignment argument,
+the following must be true for the provided alignment argument:
+`alignment >= CCC_FLAT_HASH_MAP_GROUP_COUNT`. If using regular malloc than the
+user should assert that `alignof(max_align_t) >= CCC_FLAT_HASH_MAP_GROUP_COUNT`.
+This helper should rarely be used. If a fixed size map is desired simply use the
+CCC_flat_hash_map_with_storage() initializer. For dynamic maps, there are
+also many other options.
 
 This macro is required to support the edge case for the user allocating a fixed
 size map dynamically from an allocator at runtime. In this case, the user needs

--- a/ccc/flat_hash_map.h
+++ b/ccc/flat_hash_map.h
@@ -97,8 +97,8 @@ All types and functions can then be written without the `CCC_` prefix. */
 #include <stddef.h>
 /** @endcond */
 
-#include "private/private_flat_hash_map.h"
-#include "types.h"
+#include "private/private_flat_hash_map.h" /* IWYU pragma: export */
+#include "types.h"                         /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/flat_priority_queue.h
+++ b/ccc/flat_priority_queue.h
@@ -63,9 +63,10 @@ All types and functions can then be written without the `CCC_` prefix. */
 #include <stddef.h>
 /** @endcond */
 
-#include "flat_buffer.h"
 #include "private/private_flat_priority_queue.h"
-#include "types.h"
+
+#include "flat_buffer.h" /* IWYU pragma: export */
+#include "types.h"       /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/priority_queue.h
+++ b/ccc/priority_queue.h
@@ -38,7 +38,7 @@ All types and functions can then be written without the `CCC_` prefix. */
 /** @endcond */
 
 #include "private/private_priority_queue.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/private/private_adaptive_map.h
+++ b/ccc/private/private_adaptive_map.h
@@ -60,6 +60,8 @@ struct CCC_Adaptive_map {
     size_t count;
     /** @internal The size of the user type stored in the tree. */
     size_t sizeof_type;
+    /** @internal The alignment of the stored type. */
+    size_t alignof_type;
     /** @internal The byte offset of the intrusive element. */
     size_t type_intruder_offset;
     /** @internal The byte offset of the user key in the user type. */
@@ -118,6 +120,7 @@ void *CCC_private_adaptive_map_insert(
 )                                                                              \
     (struct CCC_Adaptive_map) {                                                \
         .sizeof_type = sizeof(private_struct_name),                            \
+        .alignof_type = alignof(private_struct_name),                          \
         .type_intruder_offset                                                  \
             = offsetof(private_struct_name, private_node_node_field),          \
         .key_offset = offsetof(private_struct_name, private_key_node_field),   \
@@ -133,6 +136,7 @@ void *CCC_private_adaptive_map_insert(
 )                                                                              \
     (struct CCC_Adaptive_map) {                                                \
         .root = NULL, .count = 0, .sizeof_type = sizeof(private_struct_name),  \
+        .alignof_type = alignof(private_struct_name),                          \
         .type_intruder_offset                                                  \
             = offsetof(private_struct_name, private_node_node_field),          \
         .key_offset = offsetof(private_struct_name, private_key_node_field),   \
@@ -181,6 +185,7 @@ void *CCC_private_adaptive_map_insert(
                         ){                                                     \
                             .input = NULL,                                     \
                             .bytes = private_map.sizeof_type,                  \
+                            .alignment = private_map.alignof_type,             \
                             .context = private_adaptive_map_allocator.context, \
                         });                                                    \
                     if (!private_new_slot) {                                   \
@@ -227,6 +232,8 @@ void *CCC_private_adaptive_map_insert(
                       ->allocate((CCC_Allocator_arguments){                    \
                           .input = NULL,                                       \
                           .bytes = (adaptive_map_entry)->map->sizeof_type,     \
+                          .alignment                                           \
+                          = (adaptive_map_entry)->map->alignof_type,           \
                           .context = (private_allocator)->context,             \
                       });                                                      \
         }                                                                      \

--- a/ccc/private/private_array_adaptive_map.h
+++ b/ccc/private/private_array_adaptive_map.h
@@ -154,6 +154,7 @@ size_t CCC_private_array_adaptive_map_allocate_slot(
 /** @internal */
 #define CCC_private_array_adaptive_map_for(                                    \
     private_type_name,                                                         \
+    private_key_field,                                                         \
     private_comparator,                                                        \
     private_capacity,                                                          \
     private_memory_pointer                                                     \
@@ -163,7 +164,7 @@ size_t CCC_private_array_adaptive_map_allocate_slot(
         .capacity = (private_capacity), .count = 0, .root = 0, .free_list = 0, \
         .sizeof_type = sizeof(private_type_name),                              \
         .alignof_type = alignof(private_type_name),                            \
-        .key_offset = offsetof(private_type_name, private_key_node_field),     \
+        .key_offset = offsetof(private_type_name, private_key_field),          \
         .comparator = (private_comparator),                                    \
     }
 
@@ -306,6 +307,55 @@ metadata. */
         ),                                                                     \
         .comparator = (private_comparator),                                    \
     }
+
+/** @internal Helper for allocating a fixed size map dynamically. */
+#define CCC_private_array_adaptive_map_with_allocator_storage(                  \
+    private_key_field,                                                          \
+    private_comparator,                                                         \
+    private_allocator,                                                          \
+    private_compound_literal                                                    \
+)                                                                               \
+    (__extension__({                                                            \
+        CCC_Allocator const *const private_allocator_pointer                    \
+            = &(private_allocator);                                             \
+        void *private_data_base = NULL;                                         \
+        if (private_allocator_pointer->allocate) {                              \
+            private_data_base = private_allocator_pointer->allocate((           \
+                CCC_Allocator_arguments                                         \
+            ){                                                                  \
+                .input = NULL,                                                  \
+                .bytes = sizeof(CCC_private_array_adaptive_map_storage_for(     \
+                    private_compound_literal                                    \
+                )),                                                             \
+                .alignment = alignof(struct CCC_Array_adaptive_map_node)        \
+                                   > alignof(*(private_compound_literal))       \
+                               ? alignof(struct CCC_Array_adaptive_map_node)    \
+                               : alignof(*(private_compound_literal)),          \
+                .context = private_allocator_pointer->context,                  \
+            });                                                                 \
+        }                                                                       \
+        struct CCC_Array_adaptive_map private_array_adaptive_map = {};          \
+        if (private_data_base) {                                                \
+            private_array_adaptive_map = CCC_private_array_adaptive_map_for(    \
+                typeof(*(private_compound_literal)),                            \
+                private_key_field,                                              \
+                private_comparator,                                             \
+                CCC_private_array_adaptive_map_compound_literal_array_capacity( \
+                    private_compound_literal                                    \
+                ),                                                              \
+                private_data_base                                               \
+            );                                                                  \
+        } else {                                                                \
+            private_array_adaptive_map = CCC_private_array_adaptive_map_for(    \
+                typeof(*(private_compound_literal)),                            \
+                private_key_field,                                              \
+                private_comparator,                                             \
+                0,                                                              \
+                NULL                                                            \
+            );                                                                  \
+        }                                                                       \
+        private_array_adaptive_map;                                             \
+    }))
 
 /** @internal */
 #define CCC_private_array_adaptive_map_as(                                     \

--- a/ccc/private/private_array_adaptive_map.h
+++ b/ccc/private/private_array_adaptive_map.h
@@ -60,6 +60,14 @@ Here is the layout in one contiguous array.
 └───┴───┴───┴───┴───┴───┴───┴───┘
 ```
 
+The base allocation, the 0th user data element, is required to satisfy
+max(alignof(T), alignof(struct CCC_Array_adaptive_map_node)), where T is the
+user type. This ensures that both the user data array and the node array begin
+at valid alignment boundaries for their respective element types. Each
+subsequent region is derived via explicit byte-offset computation using aligned
+rounding, guaranteeing that the start of each array is aligned to at least its
+required element alignment.
+
 This layout costs us in consulting both the data and nodes array during the
 top down splay operation. However, the benefit of space saving and no wasted
 padding bytes between element fields or multiple elements in an array is the
@@ -258,7 +266,12 @@ metadata. */
             ) > 1,                                                             \
             "fixed size map must have capacity greater than 1"                 \
         );                                                                     \
-        typeof(*(private_type_compound_literal_array)) data                    \
+        alignas(                                                               \
+            alignof(*(private_type_compound_literal_array))                    \
+                    > alignof(struct CCC_Array_adaptive_map_node)              \
+                ? alignof(*(private_type_compound_literal_array))              \
+                : alignof(struct CCC_Array_adaptive_map_node)                  \
+        ) typeof(*(private_type_compound_literal_array)) data                  \
             [CCC_private_array_adaptive_map_compound_literal_array_capacity(   \
                 private_type_compound_literal_array                            \
             )];                                                                \

--- a/ccc/private/private_array_adaptive_map.h
+++ b/ccc/private/private_array_adaptive_map.h
@@ -80,6 +80,8 @@ struct CCC_Array_adaptive_map {
     size_t free_list;
     /** @internal The size of the type stored in the map. */
     size_t sizeof_type;
+    /** @internal The alignment of the type being stored. */
+    size_t alignof_type;
     /** @internal Where user key can be found in type. */
     size_t key_offset;
     /** @internal The provided key comparison function and context. */
@@ -136,6 +138,7 @@ size_t CCC_private_array_adaptive_map_allocate_slot(
 )                                                                              \
     (struct CCC_Array_adaptive_map) {                                          \
         .sizeof_type = sizeof(private_type_name),                              \
+        .alignof_type = alignof(private_type_name),                            \
         .key_offset = offsetof(private_type_name, private_key_node_field),     \
         .comparator = private_comparator,                                      \
     }
@@ -151,6 +154,7 @@ size_t CCC_private_array_adaptive_map_allocate_slot(
         .data = (private_memory_pointer), .nodes = NULL,                       \
         .capacity = (private_capacity), .count = 0, .root = 0, .free_list = 0, \
         .sizeof_type = sizeof(private_type_name),                              \
+        .alignof_type = alignof(private_type_name),                            \
         .key_offset = offsetof(private_type_name, private_key_node_field),     \
         .comparator = (private_comparator),                                    \
     }
@@ -283,6 +287,7 @@ metadata. */
             ),                                                                 \
         .count = 0, .root = 0, .free_list = 0,                                 \
         .sizeof_type = sizeof(*(private_compound_literal)),                    \
+        .alignof_type = alignof(*(private_compound_literal)),                  \
         .key_offset = offsetof(                                                \
             typeof(*(private_compound_literal)), private_key_node_field        \
         ),                                                                     \

--- a/ccc/private/private_array_tree_map.h
+++ b/ccc/private/private_array_tree_map.h
@@ -147,6 +147,8 @@ struct CCC_Array_tree_map {
     size_t count;
     /** @internal The size of the type stored in the map. */
     size_t sizeof_type;
+    /** @internal The alignment of the type stored in the map. */
+    size_t alignof_type;
     /** @internal Where user key can be found in type. */
     size_t key_offset;
     /** @internal The provided key comparison function and context. */
@@ -239,6 +241,7 @@ metadata. */
 )                                                                              \
     (struct CCC_Array_tree_map) {                                              \
         .sizeof_type = sizeof(private_type_name),                              \
+        .alignof_type = alignof(private_type_name),                            \
         .key_offset = offsetof(private_type_name, private_key_field),          \
         .comparator = (private_comparator),                                    \
     }
@@ -259,6 +262,7 @@ runtime. */
         .data = (private_memory_pointer), .nodes = NULL, .parity = NULL,       \
         .capacity = (private_capacity), .count = 0, .root = 0, .free_list = 0, \
         .sizeof_type = sizeof(private_type_name),                              \
+        .alignof_type = alignof(private_type_name),                            \
         .key_offset = offsetof(private_type_name, private_key_field),          \
         .comparator = (private_comparator),                                    \
     }
@@ -365,6 +369,7 @@ runtime. */
             ),                                                                 \
         .count = 0, .root = 0, .free_list = 0,                                 \
         .sizeof_type = sizeof(*(private_compound_literal)),                    \
+        .alignof_type = alignof(*(private_compound_literal)),                  \
         .key_offset = offsetof(                                                \
             typeof(*(private_compound_literal)), private_key_node_field        \
         ),                                                                     \

--- a/ccc/private/private_array_tree_map.h
+++ b/ccc/private/private_array_tree_map.h
@@ -398,6 +398,55 @@ runtime. */
         (array_tree_map_pointer), (handle)                                     \
     ))
 
+/** @internal Helper for allocating a fixed size map dynamically. */
+#define CCC_private_array_tree_map_with_allocator_storage(                     \
+    private_key_field,                                                         \
+    private_comparator,                                                        \
+    private_allocator,                                                         \
+    private_compound_literal                                                   \
+)                                                                              \
+    (__extension__({                                                           \
+        CCC_Allocator const *const private_allocator_pointer                   \
+            = &(private_allocator);                                            \
+        void *private_data_base = NULL;                                        \
+        if (private_allocator_pointer->allocate) {                             \
+            private_data_base = private_allocator_pointer->allocate(           \
+                (CCC_Allocator_arguments){                                     \
+                    .input = NULL,                                             \
+                    .bytes = sizeof(CCC_private_array_tree_map_storage_for(    \
+                        private_compound_literal                               \
+                    )),                                                        \
+                    .alignment = alignof(struct CCC_Array_tree_map_node)       \
+                                       > alignof(*(private_compound_literal))  \
+                                   ? alignof(struct CCC_Array_tree_map_node)   \
+                                   : alignof(*(private_compound_literal)),     \
+                    .context = private_allocator_pointer->context,             \
+                }                                                              \
+            );                                                                 \
+        }                                                                      \
+        struct CCC_Array_tree_map private_array_tree_map = {};                 \
+        if (private_data_base) {                                               \
+            private_array_tree_map = CCC_private_array_tree_map_for(           \
+                typeof(*(private_compound_literal)),                           \
+                private_key_field,                                             \
+                private_comparator,                                            \
+                CCC_private_array_tree_map_compound_literal_array_capacity(    \
+                    private_compound_literal                                   \
+                ),                                                             \
+                private_data_base                                              \
+            );                                                                 \
+        } else {                                                               \
+            private_array_tree_map = CCC_private_array_tree_map_for(           \
+                typeof(*(private_compound_literal)),                           \
+                private_key_field,                                             \
+                private_comparator,                                            \
+                0,                                                             \
+                NULL                                                           \
+            );                                                                 \
+        }                                                                      \
+        private_array_tree_map;                                                \
+    }))
+
 /*==================     Core Macro Implementations     =====================*/
 
 /** @internal */

--- a/ccc/private/private_array_tree_map.h
+++ b/ccc/private/private_array_tree_map.h
@@ -122,6 +122,15 @@ of the nodes array, a 24 byte sentinel node, a sentinel bit, and the unused bits
 at the end of the parity bit array. This also means it important to consider the
 alignment differences that may occur between the user type and the node type.
 
+The base allocation, the 0th user data element, is required to satisfy
+max(alignof(T), alignof(struct CCC_Array_tree_map_node)), where T is the user
+type. This ensures that both the user data array and the node array begin at
+valid alignment boundaries for their respective element types. Each subsequent
+region is derived via explicit byte-offset computation using aligned rounding,
+guaranteeing that the start of each array is aligned to at least its required
+element alignment. The parity array requires no additional alignment adjustment
+because the node alignment is greater than or equal to parity alignment.
+
 This layout comes at the cost of consulting multiple arrays for many operations.
 However, once user data has been inserted or removed the tree fix up operations
 only need to consult the nodes array and the bit array which means more bits
@@ -218,7 +227,12 @@ metadata. */
             ) > 1,                                                             \
             "fixed size map must have capacity greater than 1"                 \
         );                                                                     \
-        typeof(*(private_type_compound_literal_array))                         \
+        alignas(                                                               \
+            alignof(*(private_type_compound_literal_array))                    \
+                    > alignof(struct CCC_Array_tree_map_node)                  \
+                ? alignof(*(private_type_compound_literal_array))              \
+                : alignof(struct CCC_Array_tree_map_node)                      \
+        ) typeof(*(private_type_compound_literal_array))                       \
             data[CCC_private_array_tree_map_compound_literal_array_capacity(   \
                 private_type_compound_literal_array                            \
             )];                                                                \

--- a/ccc/private/private_doubly_linked_list.h
+++ b/ccc/private/private_doubly_linked_list.h
@@ -70,6 +70,8 @@ struct CCC_Doubly_linked_list {
     struct CCC_Doubly_linked_list_node *tail;
     /** @internal The size in bytes of the type which wraps this handle. */
     size_t sizeof_type;
+    /** @internal The alignment of the type which wraps this handle. */
+    size_t alignof_type;
     /** @internal The offset in bytes of the intrusive element in user type. */
     size_t type_intruder_offset;
 };
@@ -99,6 +101,7 @@ name of the list being on the left hand side of the assignment operator. */
     (struct CCC_Doubly_linked_list) {                                          \
         .head = NULL, .tail = NULL,                                            \
         .sizeof_type = sizeof(private_struct_name),                            \
+        .alignof_type = alignof(private_struct_name),                          \
         .type_intruder_offset                                                  \
             = offsetof(private_struct_name, private_type_intruder_field),      \
     }
@@ -178,6 +181,7 @@ name of the list being on the left hand side of the assignment operator. */
                 ){                                                             \
                     .input = NULL,                                             \
                     .bytes = private_doubly_linked_list->sizeof_type,          \
+                    .alignment = private_doubly_linked_list->alignof_type,     \
                     .context = private_doubly_linked_list_allocator->context,  \
                 });                                                            \
             if (private_doubly_linked_list_res) {                              \
@@ -214,6 +218,7 @@ name of the list being on the left hand side of the assignment operator. */
                 ){                                                             \
                     .input = NULL,                                             \
                     .bytes = private_doubly_linked_list->sizeof_type,          \
+                    .alignment = private_doubly_linked_list->alignof_type,     \
                     .context = private_doubly_linked_list_allocator->context,  \
                 });                                                            \
             if (private_doubly_linked_list_res) {                              \

--- a/ccc/private/private_flat_buffer.h
+++ b/ccc/private/private_flat_buffer.h
@@ -38,12 +38,15 @@ struct CCC_Flat_buffer {
     size_t capacity;
     /** @internal The size of the type the user stores in the buffer. */
     size_t sizeof_type;
+    /** @internal The alignment of the type the user stores in the buffer. */
+    size_t alignof_type;
 };
 
 /* @internal */
 #define CCC_private_flat_buffer_default(private_type_name)                     \
     (struct CCC_Flat_buffer) {                                                 \
         .sizeof_type = sizeof(private_type_name),                              \
+        .alignof_type = alignof(private_type_name),                            \
     }
 
 /** @internal Initializes the Flat_buffer with a default size of 0. However the
@@ -55,7 +58,8 @@ elements are contiguous. */
 )                                                                              \
     (struct CCC_Flat_buffer) {                                                 \
         .data = (private_data), .sizeof_type = sizeof(private_type_name),      \
-        .count = (private_count), .capacity = (private_capacity),              \
+        .alignof_type = alignof(private_type_name), .count = (private_count),  \
+        .capacity = (private_capacity),                                        \
     }
 
 /** @internal For dynamic containers to perform the allocation and
@@ -131,6 +135,7 @@ to the user. GCC is not so forgiving. */
         }){{                                                                   \
                .data = (private_compound_literal_array),                       \
                .sizeof_type = sizeof(*private_compound_literal_array),         \
+               .alignof_type = alignof(*private_compound_literal_array),       \
                .count = private_count,                                         \
                .capacity = sizeof(private_compound_literal_array)              \
                          / sizeof(*private_compound_literal_array),            \
@@ -144,6 +149,7 @@ to the user. GCC is not so forgiving. */
         (struct CCC_Flat_buffer) {                                             \
             .data = (private_compound_literal_array),                          \
             .sizeof_type = sizeof(*private_compound_literal_array),            \
+            .alignof_type = alignof(*private_compound_literal_array),          \
             .count = private_count,                                            \
             .capacity = sizeof(private_compound_literal_array)                 \
                       / sizeof(*private_compound_literal_array),               \

--- a/ccc/private/private_flat_hash_map.h
+++ b/ccc/private/private_flat_hash_map.h
@@ -132,6 +132,17 @@ a fixed or dynamic map, we must assume data starts at the base address and that
 there may be zero or more bytes of padding between the data and tag arrays for
 alignment.
 
+The base address of the struct of arrays, the 0th user data element, is aligned
+to `max(CCC_FLAT_HASH_MAP_GROUP_COUNT, alignof(T))`, where `T` is the user
+type. The tag array base address is then also aligned to
+`CCC_FLAT_HASH_MAP_GROUP_COUNT`. This is done to ensure that user alignment is
+respected and the tag array is always aligned such that aligned group loads are
+possible with SIMD instructions. For fixed size maps generated at compile time,
+this alignment requirement is enforced via the `alignas` compiler directive on
+the generated backing storage. For dynamically allocated maps, this alignment
+requirement is passed to the allocator when requesting the backing storage
+block.
+
 We may lose some of the assembly optimizations in indexing that Rust's table
 gets by adding and subtracting from a shared base address. However, this table
 still needs to use byte offset multiplication because the data is stored as
@@ -139,9 +150,12 @@ still needs to use byte offset multiplication because the data is stored as
 template generic system. Simple 0 based indexing makes the addition and
 multiplication we perform as simple as possible. */
 struct CCC_Flat_hash_map {
-    /** @internal User data type array. */
+    /** @internal User data type array. This address shall always be aligned to
+    the `max(CCC_FLAT_HASH_MAP_GROUP_COUNT, alignof(T))`, where `T` is the user
+    type.*/
     void *data;
-    /** @internal Tag array on byte following data. */
+    /** @internal Tag array following the user data array in a single block.
+    This address shall always be aligned to CCC_FLAT_HASH_MAP_GROUP_COUNT. */
     struct CCC_Flat_hash_map_tag *tag;
     /** @internal The number of user active slots. */
     size_t count;
@@ -226,7 +240,12 @@ be exposed to the user if they wish to know the size in bytes of this object. */
             "fixed size map must be a power of 2 capacity (32, 64, "           \
             "128, 256, etc.)"                                                  \
         );                                                                     \
-        typeof(*(private_type_compound_literal_array)) data                    \
+        alignas(                                                               \
+            CCC_FLAT_HASH_MAP_GROUP_COUNT                                      \
+                    > alignof(*(private_type_compound_literal_array))          \
+                ? CCC_FLAT_HASH_MAP_GROUP_COUNT                                \
+                : alignof(*(private_type_compound_literal_array))              \
+        ) typeof(*(private_type_compound_literal_array)) data                  \
             [CCC_private_flat_hash_map_compound_literal_array_capacity(        \
                  private_type_compound_literal_array                           \
              )                                                                 \

--- a/ccc/private/private_flat_hash_map.h
+++ b/ccc/private/private_flat_hash_map.h
@@ -151,6 +151,8 @@ struct CCC_Flat_hash_map {
     size_t mask;
     /** @internal Size of each user data element being stored. */
     size_t sizeof_type;
+    /** @internal Alignment user data type being stored. */
+    size_t alignof_type;
     /** @internal The location of the key field in user type. */
     size_t key_offset;
     /** @internal The provided hash function, key comparator, and context. */
@@ -243,6 +245,7 @@ be exposed to the user if they wish to know the size in bytes of this object. */
 )                                                                              \
     (struct CCC_Flat_hash_map) {                                               \
         .sizeof_type = sizeof(private_type_name),                              \
+        .alignof_type = alignof(private_type_name),                            \
         .key_offset = offsetof(private_type_name, private_key_field),          \
         .hasher = private_hasher,                                              \
     }
@@ -279,6 +282,7 @@ allocation. */
                    ? ((private_capacity) - (size_t)1)                          \
                    : (size_t)0),                                               \
         .sizeof_type = sizeof(private_type_name),                              \
+        .alignof_type = alignof(private_type_name),                            \
         .key_offset = offsetof(private_type_name, private_key_field),          \
         .hasher = (private_hasher),                                            \
     }
@@ -377,6 +381,7 @@ allocation. */
                 )                                                              \
               - (size_t)1,                                                     \
         .sizeof_type = sizeof(*(private_compound_literal)),                    \
+        .alignof_type = alignof(*(private_compound_literal)),                  \
         .key_offset = offsetof(                                                \
             typeof(*(private_compound_literal)), private_key_field             \
         ),                                                                     \

--- a/ccc/private/private_flat_hash_map.h
+++ b/ccc/private/private_flat_hash_map.h
@@ -407,6 +407,55 @@ allocation. */
         .hasher = (private_hasher),                                            \
     }
 
+/** @internal Helper for allocating a fixed size map dynamically. */
+#define CCC_private_flat_hash_map_with_allocator_storage(                      \
+    private_key_field,                                                         \
+    private_hasher,                                                            \
+    private_allocator,                                                         \
+    private_compound_literal                                                   \
+)                                                                              \
+    (__extension__({                                                           \
+        CCC_Allocator const *const private_allocator_pointer                   \
+            = &(private_allocator);                                            \
+        void *private_data_base = NULL;                                        \
+        if (private_allocator_pointer->allocate) {                             \
+            private_data_base = private_allocator_pointer->allocate(           \
+                (CCC_Allocator_arguments){                                     \
+                    .input = NULL,                                             \
+                    .bytes = sizeof(CCC_private_flat_hash_map_storage_for(     \
+                        private_compound_literal                               \
+                    )),                                                        \
+                    .alignment = CCC_FLAT_HASH_MAP_GROUP_COUNT                 \
+                                       > alignof(*(private_compound_literal))  \
+                                   ? CCC_FLAT_HASH_MAP_GROUP_COUNT             \
+                                   : alignof(*(private_compound_literal)),     \
+                    .context = private_allocator_pointer->context,             \
+                }                                                              \
+            );                                                                 \
+        }                                                                      \
+        struct CCC_Flat_hash_map private_flat_hash_map = {};                   \
+        if (private_data_base) {                                               \
+            private_flat_hash_map = CCC_private_flat_hash_map_for(             \
+                typeof(*(private_compound_literal)),                           \
+                private_key_field,                                             \
+                private_hasher,                                                \
+                CCC_private_flat_hash_map_compound_literal_array_capacity(     \
+                    private_compound_literal                                   \
+                ),                                                             \
+                private_data_base                                              \
+            );                                                                 \
+        } else {                                                               \
+            private_flat_hash_map = CCC_private_flat_hash_map_for(             \
+                typeof(*(private_compound_literal)),                           \
+                private_key_field,                                             \
+                private_hasher,                                                \
+                0,                                                             \
+                NULL                                                           \
+            );                                                                 \
+        }                                                                      \
+        private_flat_hash_map;                                                 \
+    }))
+
 /*========================    Construct In Place    =========================*/
 
 /** @internal A fairly good approximation of closures given C23 capabilities.

--- a/ccc/private/private_priority_queue.h
+++ b/ccc/private/private_priority_queue.h
@@ -91,6 +91,8 @@ struct CCC_Priority_queue {
     size_t type_intruder_offset;
     /** @internal The size of the type we are intruding upon. */
     size_t sizeof_type;
+    /** @internal The alignment of the type we are intruding upon. */
+    size_t alignof_type;
     /** @internal The order of this heap, `CCC_ORDER_LESSER` (min) or
      * `CCC_ORDER_GREATER` (max).*/
     CCC_Order order;
@@ -135,6 +137,7 @@ void CCC_private_priority_queue_decrease_fixup(
         .type_intruder_offset                                                  \
             = offsetof(private_struct_name, private_type_intruder_field),      \
         .sizeof_type = sizeof(private_struct_name),                            \
+        .alignof_type = alignof(private_struct_name),                          \
         .order = (private_priority_queue_order),                               \
         .comparator = (private_comparator),                                    \
     }
@@ -187,6 +190,7 @@ void CCC_private_priority_queue_decrease_fixup(
                     ){                                                         \
                         .input = NULL,                                         \
                         .bytes = private_priority_queue.sizeof_type,           \
+                        .alignment = private_priority_queue.alignof_type,      \
                         .context = private_priority_queue_allocator->context,  \
                     });                                                        \
                 if (!private_new_node) {                                       \
@@ -233,6 +237,7 @@ void CCC_private_priority_queue_decrease_fixup(
                     ){                                                         \
                         .input = NULL,                                         \
                         .bytes = private_priority_queue->sizeof_type,          \
+                        .alignment = private_priority_queue->alignof_type,     \
                         .context = private_priority_queue_allocator->context,  \
                     });                                                        \
                 if (private_priority_queue_res) {                              \

--- a/ccc/private/private_singly_linked_list.h
+++ b/ccc/private/private_singly_linked_list.h
@@ -65,6 +65,8 @@ struct CCC_Singly_linked_list {
     struct CCC_Singly_linked_list_node *head;
     /** @internal The size in bytes of the type which wraps this handle. */
     size_t sizeof_type;
+    /** @internal The alignment of the type which wraps this handle. */
+    size_t alignof_type;
     /** @internal The offset in bytes of the intrusive element in user type. */
     size_t type_intruder_offset;
 };
@@ -88,6 +90,7 @@ struct CCC_Singly_linked_list_node *CCC_private_singly_linked_list_node_in(
 )                                                                              \
     (struct CCC_Singly_linked_list) {                                          \
         .head = NULL, .sizeof_type = sizeof(private_struct_name),              \
+        .alignof_type = alignof(private_struct_name),                          \
         .type_intruder_offset = offsetof(                                      \
             private_struct_name, private_singly_linked_list_node_field         \
         ),                                                                     \

--- a/ccc/private/private_tree_map.h
+++ b/ccc/private/private_tree_map.h
@@ -55,11 +55,12 @@ struct CCC_Tree_map {
     size_t count;
     /** @internal The byte offset of the key in the user struct. */
     size_t key_offset;
-    /** @internal The byte offset of the intrusive element in the user struct.
-     */
+    /** @internal The byte offset of intrusive element in the user struct. */
     size_t type_intruder_offset;
     /** @internal The size of the user struct holding the intruder. */
     size_t sizeof_type;
+    /** @internal The alignment of the user struct holding the intruder. */
+    size_t alignof_type;
     /** @internal The comparator and context pointer. */
     CCC_Key_comparator comparator;
 };
@@ -113,6 +114,7 @@ void *CCC_private_tree_map_insert(
         .type_intruder_offset                                                  \
             = offsetof(private_struct_name, private_node_field),               \
         .sizeof_type = sizeof(private_struct_name),                            \
+        .alignof_type = alignof(private_struct_name),                          \
         .comparator = (private_comparator),                                    \
     }
 
@@ -171,6 +173,7 @@ void *CCC_private_tree_map_insert(
                         ){                                                     \
                             .input = NULL,                                     \
                             .bytes = private_map.sizeof_type,                  \
+                            .alignment = private_map.alignof_type,             \
                             .context = private_tree_map_allocator->context,    \
                         });                                                    \
                     if (!private_new_slot) {                                   \
@@ -224,6 +227,8 @@ void *CCC_private_tree_map_insert(
                       ->allocate((CCC_Allocator_arguments){                    \
                           .input = NULL,                                       \
                           .bytes = (private_tree_map_entry)->map->sizeof_type, \
+                          .alignment                                           \
+                          = (private_tree_map_entry)->map->alignof_type,       \
                           .context = (private_allocator_pointer)->context,     \
                       });                                                      \
         }                                                                      \

--- a/ccc/singly_linked_list.h
+++ b/ccc/singly_linked_list.h
@@ -50,7 +50,7 @@ All types and functions can then be written without the `CCC_` prefix. */
 /** @endcond */
 
 #include "private/private_singly_linked_list.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/sort.h
+++ b/ccc/sort.h
@@ -30,7 +30,7 @@ if it is sorted or insert an element in a sorted position. */
 #include "doubly_linked_list.h"
 #include "flat_buffer.h"
 #include "singly_linked_list.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Sorting Algorithms
 Various sorting algorithms for different containers in the collection. */

--- a/ccc/tree_map.h
+++ b/ccc/tree_map.h
@@ -37,7 +37,7 @@ All types and functions can then be written without the `CCC_` prefix. */
 /** @endcond */
 
 #include "private/private_tree_map.h"
-#include "types.h"
+#include "types.h" /* IWYU pragma: export */
 
 /** @name Container Types
 Types available in the container interface. */

--- a/ccc/types.h
+++ b/ccc/types.h
@@ -329,13 +329,13 @@ For example programs that utilize the context parameter, see the sample
 programs. Using custom arena allocators or container compositions are cases when
 context is needed.
 
-@warning Wrapping `malloc`, `realloc`, and `free` is sufficient if all CCC
-container requested alignments are less than or equal to `max_align_t`. If CCC
-requests alignments that exceed `max_align_t`, a custom alignment-aware
-allocator is required. Some CCC code may request alignments greater than the
-alignment of the user type stored in the container when allocating;
-specifically, the flat hash hash map and array map containers may request
-alignments that are greater then the user type being stored. */
+@warning Alignments are assumed to be powers of 2. Wrapping `malloc`, `realloc`,
+and `free` is sufficient if all CCC container requested alignments are less than
+or equal to `max_align_t`. If CCC requests alignments that exceed `max_align_t`,
+a custom alignment-aware allocator is required. Some CCC code may request
+alignments greater than the alignment of the user type stored in the container
+when allocating; specifically, the flat hash hash map and array map containers
+may request alignments that are greater then the user type being stored. */
 typedef void *CCC_Allocator_interface(CCC_Allocator_arguments);
 
 /** @brief The type passed by reference to any container function that may need

--- a/ccc/types.h
+++ b/ccc/types.h
@@ -292,14 +292,15 @@ user provided allocator function internally.
 
 - If input is NULL and bytes 0, NULL is returned.
 - If input is NULL with non-zero bytes, new memory is allocated and returned
-  with the base address aligned to the alignment argument. If alignment is zero,
-  the default alignment of the allocator is used.
+  with the base address aligned to at least the alignment argument. If alignment
+  is zero, the default alignment of the allocator is used (usually
+  `max_align_t`).
 - If input is non-NULL it has been previously allocated by the allocator.
-- If input is non-NULL with non-zero size, input is resized to at least bytes
-  size. The pointer returned is NULL if resizing fails. Upon success, the
-  pointer returned might not be equal to the pointer provided and is aligned to
-  the provided alignment argument. If alignment is zero, the default alignment
-  of the allocator is used.
+- If input is non-NULL with non-zero bytes, input is resized to at least the
+  bytes argument's capacity. The pointer returned is NULL if resizing fails.
+  Upon success, the pointer returned might not be equal to the pointer provided
+  and is aligned to at least the provided alignment argument. If alignment is
+  zero, the default alignment of the allocator is used (usually `max_align_t`).
 - If input is non-NULL and size is 0, input is freed and NULL is returned.
 
 For example, one allocation interface using the standard library allocator might
@@ -326,7 +327,12 @@ However, the above example is only useful if the standard library allocator
 is used. Any allocator that implements the required behavior is sufficient.
 For example programs that utilize the context parameter, see the sample
 programs. Using custom arena allocators or container compositions are cases when
-context is needed. */
+context is needed.
+
+@warning Wrapping `malloc`, `realloc`, and `free` is sufficient if all CCC
+container requested alignments are less than or equal to `max_align_t`. If CCC
+requests alignments that exceed `max_align_t`, a custom alignment-aware
+allocator is required. */
 typedef void *CCC_Allocator_interface(CCC_Allocator_arguments);
 
 /** @brief The type passed by reference to any container function that may need

--- a/ccc/types.h
+++ b/ccc/types.h
@@ -332,7 +332,10 @@ context is needed.
 @warning Wrapping `malloc`, `realloc`, and `free` is sufficient if all CCC
 container requested alignments are less than or equal to `max_align_t`. If CCC
 requests alignments that exceed `max_align_t`, a custom alignment-aware
-allocator is required. */
+allocator is required. Some CCC code may request alignments greater than the
+alignment of the user type stored in the container when allocating;
+specifically, the flat hash hash map and array map containers may request
+alignments that are greater then the user type being stored. */
 typedef void *CCC_Allocator_interface(CCC_Allocator_arguments);
 
 /** @brief The type passed by reference to any container function that may need

--- a/ccc/types.h
+++ b/ccc/types.h
@@ -279,6 +279,8 @@ typedef struct {
     void *const input;
     /** The bytes being requested from the allocator. 0 is a free request. */
     size_t bytes;
+    /** The alignment for the base address of the returned bytes. */
+    size_t alignment;
     /** Additional state to pass to the allocator to help manage memory. */
     void *const context;
 } CCC_Allocator_arguments;
@@ -289,15 +291,19 @@ The C Container Collection relies on the following behaviors when calling the
 user provided allocator function internally.
 
 - If input is NULL and bytes 0, NULL is returned.
-- If input is NULL with non-zero bytes, new memory is allocated and returned.
+- If input is NULL with non-zero bytes, new memory is allocated and returned
+  with the base address aligned to the alignment argument. If alignment is zero,
+  the default alignment of the allocator is used.
 - If input is non-NULL it has been previously allocated by the allocator.
 - If input is non-NULL with non-zero size, input is resized to at least bytes
   size. The pointer returned is NULL if resizing fails. Upon success, the
-  pointer returned might not be equal to the pointer provided.
+  pointer returned might not be equal to the pointer provided and is aligned to
+  the provided alignment argument. If alignment is zero, the default alignment
+  of the allocator is used.
 - If input is non-NULL and size is 0, input is freed and NULL is returned.
 
 For example, one allocation interface using the standard library allocator might
-be implemented as follows (context is not needed):
+be implemented as follows (alignment and context is not needed):
 
 ```
 void *

--- a/samples/ccczip.c
+++ b/samples/ccczip.c
@@ -1093,6 +1093,7 @@ print_inner_tree(
         str = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = string_length + 1,
+            .alignment = alignof(char),
             .context = allocator->context,
         });
         (void)snprintf(
@@ -1116,6 +1117,7 @@ print_inner_tree(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = str,
         .bytes = 0,
+        .alignment = alignof(char),
         .context = allocator->context,
     });
 }

--- a/source/adaptive_map.c
+++ b/source/adaptive_map.c
@@ -314,6 +314,7 @@ CCC_adaptive_map_remove_key_value(
         allocator->allocate((CCC_Allocator_arguments){
             .input = n,
             .bytes = 0,
+            .alignment = map->alignof_type,
             .context = allocator->context,
         });
         return (CCC_Entry){
@@ -341,6 +342,7 @@ CCC_adaptive_map_remove_entry(
             allocator->allocate((CCC_Allocator_arguments){
                 .input = erased,
                 .bytes = 0,
+                .alignment = e->map->alignof_type,
                 .context = allocator->context,
             });
             return (CCC_Entry){
@@ -509,6 +511,7 @@ CCC_adaptive_map_clear(
             (void)allocator->allocate((CCC_Allocator_arguments){
                 .input = del,
                 .bytes = 0,
+                .alignment = map->alignof_type,
                 .context = allocator->context,
             });
         }
@@ -717,6 +720,7 @@ allocate_insert(
         void *const node = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = t->sizeof_type,
+            .alignment = t->alignof_type,
             .context = allocator->context,
         });
         if (!node) {

--- a/source/array_adaptive_map.c
+++ b/source/array_adaptive_map.c
@@ -52,6 +52,8 @@ start at next aligned byte. */
 enum : size_t {
     /* @internal Test capacity. */
     TCAP = 3,
+    /* @internal Alignment of node type. */
+    NODE_ALIGNMENT = alignof(struct CCC_Array_adaptive_map_node),
 };
 /** @internal This is a static fixed size map exclusive to this translation unit
 used to ensure assumptions about data layout are correct. The following static
@@ -169,7 +171,7 @@ static CCC_Tribool validate(struct CCC_Array_adaptive_map const *);
 static void init_node(struct CCC_Array_adaptive_map const *, size_t);
 static void swap(void *, void *, void *, size_t);
 static void link(struct CCC_Array_adaptive_map *, size_t, enum Branch, size_t);
-static size_t max(size_t, size_t);
+static size_t max_size_t(size_t, size_t);
 static void
 delete_nodes(struct CCC_Array_adaptive_map const *, CCC_Destructor const *);
 
@@ -666,7 +668,7 @@ CCC_array_adaptive_map_clear_and_free(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
-        .alignment = map->alignof_type,
+        .alignment = max_size_t(NODE_ALIGNMENT, map->alignof_type),
         .context = allocator->context,
     });
     map->data = NULL;
@@ -796,7 +798,8 @@ allocate_slot(
     if (!old_count || old_count == old_cap) {
         assert(!map->free_list);
         if (old_count == old_cap) {
-            if (resize(map, max(old_cap * 2, 8), allocator) != CCC_RESULT_OK) {
+            if (resize(map, max_size_t(old_cap * 2, 8), allocator)
+                != CCC_RESULT_OK) {
                 return 0;
             }
         } else {
@@ -811,7 +814,7 @@ allocate_slot(
             node_at(map, i)->next_free = prev;
         }
         map->free_list = prev;
-        map->count = max(old_count, 1);
+        map->count = max_size_t(old_count, 1);
     }
     assert(map->free_list);
     ++map->count;
@@ -832,7 +835,7 @@ resize(
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
         .bytes = total_bytes(map->sizeof_type, new_capacity),
-        .alignment = map->alignof_type,
+        .alignment = max_size_t(NODE_ALIGNMENT, map->alignof_type),
         .context = allocator->context,
     });
     if (!new_data) {
@@ -843,7 +846,7 @@ resize(
     allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
-        .alignment = map->alignof_type,
+        .alignment = max_size_t(NODE_ALIGNMENT, map->alignof_type),
         .context = allocator->context,
     });
     map->data = new_data;
@@ -1216,7 +1219,7 @@ key_in_slot(
 }
 
 static inline size_t
-max(size_t const a, size_t const b) {
+max_size_t(size_t const a, size_t const b) {
     return a > b ? a : b;
 }
 

--- a/source/array_adaptive_map.c
+++ b/source/array_adaptive_map.c
@@ -666,6 +666,7 @@ CCC_array_adaptive_map_clear_and_free(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
+        .alignment = map->alignof_type,
         .context = allocator->context,
     });
     map->data = NULL;
@@ -831,6 +832,7 @@ resize(
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
         .bytes = total_bytes(map->sizeof_type, new_capacity),
+        .alignment = map->alignof_type,
         .context = allocator->context,
     });
     if (!new_data) {
@@ -841,6 +843,7 @@ resize(
     allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
+        .alignment = map->alignof_type,
         .context = allocator->context,
     });
     map->data = new_data;

--- a/source/array_tree_map.c
+++ b/source/array_tree_map.c
@@ -77,6 +77,8 @@ two alignments in C. */
 enum : size_t {
     /* @internal Test capacity. */
     TCAP = 3,
+    /* @internal Alignment of node type. */
+    NODE_ALIGNMENT = alignof(struct CCC_Array_tree_map_node),
 };
 /** @internal This is a static fixed size map exclusive to this translation unit
 used to ensure assumptions about data layout are correct. The following static
@@ -157,6 +159,11 @@ static_assert(
             )),
     "The start of the parity array must begin at the next aligned byte given "
     "alignment of both the data and nodes array."
+);
+static_assert(
+    NODE_ALIGNMENT >= alignof(*static_data_nodes_parity_layout_test.parity),
+    "Parity bit array is always aligned after node array without any special "
+    "alignment or padding considerations."
 );
 
 /*==========================  Type Declarations   ===========================*/
@@ -287,7 +294,7 @@ rotate(struct CCC_Array_tree_map *, size_t, size_t, size_t, enum Link);
 static void
 double_rotate(struct CCC_Array_tree_map *, size_t, size_t, size_t, enum Link);
 static void swap(void *, void *, void *, size_t);
-static size_t max(size_t, size_t);
+static size_t max_size_t(size_t, size_t);
 
 /*==============================  Interface    ==============================*/
 
@@ -782,7 +789,7 @@ CCC_array_tree_map_clear_and_free(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
-        .alignment = map->alignof_type,
+        .alignment = max_size_t(NODE_ALIGNMENT, map->alignof_type),
         .context = allocator->context,
     });
     map->data = NULL;
@@ -869,7 +876,9 @@ allocate_slot(
     if (!old_count || old_count == old_cap) {
         assert(!map->free_list);
         if (old_count == old_cap) {
-            if (resize(map, max(old_cap * 2, PARITY_BLOCK_BITS), allocator)
+            if (resize(
+                    map, max_size_t(old_cap * 2, PARITY_BLOCK_BITS), allocator
+                )
                 != CCC_RESULT_OK) {
                 return 0;
             }
@@ -888,7 +897,7 @@ allocate_slot(
             node_at(map, i)->next_free = prev;
         }
         map->free_list = prev;
-        map->count = max(old_count, 1);
+        map->count = max_size_t(old_count, 1);
         set_parity(map, 0, CCC_TRUE);
     }
     assert(map->free_list);
@@ -910,7 +919,7 @@ resize(
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
         .bytes = total_bytes(map->sizeof_type, new_capacity),
-        .alignment = map->alignof_type,
+        .alignment = max_size_t(NODE_ALIGNMENT, map->alignof_type),
         .context = allocator->context,
     });
     if (!new_data) {
@@ -923,7 +932,7 @@ resize(
     allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
-        .alignment = map->alignof_type,
+        .alignment = max_size_t(NODE_ALIGNMENT, map->alignof_type),
         .context = allocator->context,
     });
     map->data = new_data;
@@ -1751,7 +1760,7 @@ sibling_of(struct CCC_Array_tree_map const *const map, size_t const x) {
 }
 
 static inline size_t
-max(size_t const a, size_t const b) {
+max_size_t(size_t const a, size_t const b) {
     return a > b ? a : b;
 }
 

--- a/source/array_tree_map.c
+++ b/source/array_tree_map.c
@@ -782,6 +782,7 @@ CCC_array_tree_map_clear_and_free(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
+        .alignment = map->alignof_type,
         .context = allocator->context,
     });
     map->data = NULL;
@@ -909,6 +910,7 @@ resize(
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
         .bytes = total_bytes(map->sizeof_type, new_capacity),
+        .alignment = map->alignof_type,
         .context = allocator->context,
     });
     if (!new_data) {
@@ -921,6 +923,7 @@ resize(
     allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
+        .alignment = map->alignof_type,
         .context = allocator->context,
     });
     map->data = new_data;

--- a/source/doubly_linked_list.c
+++ b/source/doubly_linked_list.c
@@ -93,6 +93,7 @@ CCC_doubly_linked_list_push_front(
         void *const copy = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = list->sizeof_type,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
         if (!copy) {
@@ -119,6 +120,7 @@ CCC_doubly_linked_list_push_back(
         void *const node = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = list->sizeof_type,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
         if (!node) {
@@ -161,6 +163,7 @@ CCC_doubly_linked_list_pop_front(
         (void)allocator->allocate((CCC_Allocator_arguments){
             .input = struct_base(list, r),
             .bytes = 0,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
     }
@@ -180,6 +183,7 @@ CCC_doubly_linked_list_pop_back(
         (void)allocator->allocate((CCC_Allocator_arguments){
             .input = struct_base(list, r),
             .bytes = 0,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
     }
@@ -200,6 +204,7 @@ CCC_doubly_linked_list_insert(
         void *const node = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = list->sizeof_type,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
         if (!node) {
@@ -227,6 +232,7 @@ CCC_doubly_linked_list_erase(
         (void)allocator->allocate((CCC_Allocator_arguments){
             .input = struct_base(list, type_intruder),
             .bytes = 0,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
     }
@@ -513,6 +519,7 @@ CCC_doubly_linked_list_clear(
             (void)allocator->allocate((CCC_Allocator_arguments){
                 .input = node,
                 .bytes = 0,
+                .alignment = list->alignof_type,
                 .context = allocator->context,
             });
         }
@@ -599,6 +606,7 @@ CCC_doubly_linked_list_insert_sorted(
         void *const node = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = list->sizeof_type,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
         if (!node) {
@@ -860,6 +868,7 @@ erase_inclusive_range(
         allocator->allocate((CCC_Allocator_arguments){
             .input = struct_base(list, begin),
             .bytes = 0,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
         if (begin == inclusive_end) {

--- a/source/flat_bitset.c
+++ b/source/flat_bitset.c
@@ -907,6 +907,7 @@ CCC_flat_bitset_clear_and_free(
         (void)allocator->allocate((CCC_Allocator_arguments){
             .input = bitset->blocks,
             .bytes = 0,
+            .alignment = alignof(*bitset->blocks),
             .context = allocator->context,
         });
     }
@@ -947,6 +948,7 @@ CCC_flat_bitset_copy(
             = allocator->allocate((CCC_Allocator_arguments){
                 .input = destination->blocks,
                 .bytes = block_count(source->capacity) * SIZEOF_BLOCK,
+                .alignment = alignof((*destination->blocks)),
                 .context = allocator->context,
             });
         if (!new_data) {
@@ -1067,6 +1069,7 @@ maybe_resize(
     Bit_block *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = bitset->blocks,
         .bytes = block_count(new_capacity) * SIZEOF_BLOCK,
+        .alignment = alignof(*bitset->blocks),
         .context = allocator->context,
     });
     if (!new_data) {

--- a/source/flat_buffer.c
+++ b/source/flat_buffer.c
@@ -46,6 +46,7 @@ CCC_flat_buffer_allocate(
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = buffer->data,
         .bytes = buffer->sizeof_type * capacity,
+        .alignment = buffer->alignof_type,
         .context = allocator->context,
     });
     if (capacity && !new_data) {
@@ -75,6 +76,7 @@ CCC_flat_buffer_reserve(
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = buffer->data,
         .bytes = buffer->sizeof_type * needed,
+        .alignment = buffer->alignof_type,
         .context = allocator->context,
     });
     if (!new_data) {
@@ -130,6 +132,7 @@ CCC_flat_buffer_clear_and_free(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = buffer->data,
         .bytes = 0,
+        .alignment = buffer->alignof_type,
         .context = allocator->context,
     });
     buffer->data = NULL;

--- a/source/flat_double_ended_queue.c
+++ b/source/flat_double_ended_queue.c
@@ -704,6 +704,7 @@ maybe_resize(
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
         .bytes = sizeof_type * required,
+        .alignment = queue->buffer.alignof_type,
         .context = allocator->context,
     });
     if (!new_data) {

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -320,7 +320,7 @@ static void set_insert_tag(
     struct CCC_Flat_hash_map *, struct CCC_Flat_hash_map_tag, size_t
 );
 static size_t mask_to_capacity_with_load_factor(size_t);
-static size_t max(size_t, size_t);
+static size_t max_size_t(size_t, size_t);
 static void
 tag_set(struct CCC_Flat_hash_map *, struct CCC_Flat_hash_map_tag, size_t);
 static CCC_Tribool match_has_one(struct Match_mask);
@@ -685,7 +685,7 @@ CCC_flat_hash_map_clear_and_free(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
-        .alignment = map->alignof_type,
+        .alignment = max_size_t(GROUP_COUNT, map->alignof_type),
         .context = allocator->context,
     });
     map->data = NULL;
@@ -742,7 +742,7 @@ CCC_flat_hash_map_copy(
         void *const new_data = allocator->allocate((CCC_Allocator_arguments){
             .input = destination->data,
             .bytes = source_bytes,
-            .alignment = destination->alignof_type,
+            .alignment = max_size_t(GROUP_COUNT, destination->alignof_type),
             .context = allocator->context,
         });
         if (!new_data) {
@@ -1359,7 +1359,7 @@ rehash_resize(
     void *const new_buf = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
         .bytes = total_bytes,
-        .alignment = map->alignof_type,
+        .alignment = max_size_t(GROUP_COUNT, map->alignof_type),
         .context = allocator->context,
     });
     if (!new_buf) {
@@ -1372,6 +1372,11 @@ rehash_resize(
     new_map.data = new_buf;
     /* Our static assertions at start of file guarantee this is correct. */
     new_map.tag = tags_base_address(new_map.sizeof_type, new_buf, new_map.mask);
+    assert(
+        (uintptr_t)new_map.tag % GROUP_COUNT == 0
+        && "Tag array is at correctly aligned offset from base address of "
+           "struct of arrays."
+    );
     (void)memset(new_map.tag, TAG_EMPTY, mask_to_tag_bytes(new_map.mask));
     {
         size_t group_start = 0;
@@ -1398,7 +1403,7 @@ rehash_resize(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
-        .alignment = map->alignof_type,
+        .alignment = max_size_t(GROUP_COUNT, map->alignof_type),
         .context = allocator->context,
     });
     map->data = new_map.data;
@@ -1431,13 +1436,13 @@ lazy_initialize(
         (void)memset(map->tag, TAG_EMPTY, mask_to_tag_bytes(map->mask));
     } else {
         /* A dynamic map we can re-size as needed. */
-        required_capacity = max(required_capacity, GROUP_COUNT);
+        required_capacity = max_size_t(required_capacity, GROUP_COUNT);
         size_t const total_bytes
             = mask_to_total_bytes(map->sizeof_type, required_capacity - 1);
         map->data = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = total_bytes,
-            .alignment = map->alignof_type,
+            .alignment = max_size_t(GROUP_COUNT, map->alignof_type),
             .context = allocator->context,
         });
         if (!map->data) {
@@ -1636,7 +1641,7 @@ tags_base_address(
 }
 
 static inline size_t
-max(size_t const a, size_t const b) {
+max_size_t(size_t const a, size_t const b) {
     return a > b ? a : b;
 }
 

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -685,6 +685,7 @@ CCC_flat_hash_map_clear_and_free(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
+        .alignment = map->alignof_type,
         .context = allocator->context,
     });
     map->data = NULL;
@@ -741,6 +742,7 @@ CCC_flat_hash_map_copy(
         void *const new_data = allocator->allocate((CCC_Allocator_arguments){
             .input = destination->data,
             .bytes = source_bytes,
+            .alignment = destination->alignof_type,
             .context = allocator->context,
         });
         if (!new_data) {
@@ -1357,6 +1359,7 @@ rehash_resize(
     void *const new_buf = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
         .bytes = total_bytes,
+        .alignment = map->alignof_type,
         .context = allocator->context,
     });
     if (!new_buf) {
@@ -1395,6 +1398,7 @@ rehash_resize(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = map->data,
         .bytes = 0,
+        .alignment = map->alignof_type,
         .context = allocator->context,
     });
     map->data = new_map.data;
@@ -1433,6 +1437,7 @@ lazy_initialize(
         map->data = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = total_bytes,
+            .alignment = map->alignof_type,
             .context = allocator->context,
         });
         if (!map->data) {

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -672,11 +672,11 @@ CCC_flat_hash_map_clear_and_free(
 ) {
     if (unlikely(
             !map || !map->data || !destructor || !allocator
-            || !allocator->allocate || !map->mask || is_uninitialized(map)
+            || !allocator->allocate || !map->mask
         )) {
         return CCC_RESULT_ARGUMENT_ERROR;
     }
-    if (destructor->destroy) {
+    if (destructor->destroy && !is_uninitialized(map)) {
         destory_each(map, destructor);
     }
     map->remain = 0;

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -185,7 +185,7 @@ and pointer arithmetic tests. One behavior we want to ensure is that our manual
 pointer arithmetic at runtime matches the group size aligned position of the tag
 metadata array. */
 static __auto_type const data_tag_layout_test = (struct {
-    int const data[2 + 1];
+    alignas(GROUP_COUNT) int const data[2 + 1];
     alignas(GROUP_COUNT) struct CCC_Flat_hash_map_tag const tag[2];
 }){};
 static_assert(
@@ -193,8 +193,8 @@ static_assert(
             - (char const *)&data_tag_layout_test.data[0]
         == (comptime_roundup((sizeof(data_tag_layout_test.data)))
             + (sizeof(struct CCC_Flat_hash_map_tag) * 2)),
-    "Calculating the size in bytes of the struct manually must match the bytes "
-    "added by a compiler alignas directive."
+    "The manually computed offset of the tag array from the start of the data "
+    "array must match the offset chosen by compiler alignment rules."
 );
 static_assert(
     (char const *)&data_tag_layout_test.data

--- a/source/priority_queue.c
+++ b/source/priority_queue.c
@@ -85,6 +85,7 @@ CCC_priority_queue_push(
         void *const node = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = priority_queue->sizeof_type,
+            .alignment = priority_queue->alignof_type,
             .context = allocator->context,
         });
         if (!node) {
@@ -117,6 +118,7 @@ CCC_priority_queue_pop(
         (void)allocator->allocate((CCC_Allocator_arguments){
             .input = struct_base(priority_queue, popped),
             .bytes = 0,
+            .alignment = priority_queue->alignof_type,
             .context = allocator->context,
         });
     }
@@ -154,6 +156,7 @@ CCC_priority_queue_erase(
         (void)allocator->allocate((CCC_Allocator_arguments){
             .input = struct_base(priority_queue, type_intruder),
             .bytes = 0,
+            .alignment = priority_queue->alignof_type,
             .context = allocator->context,
         });
     }
@@ -210,6 +213,7 @@ CCC_priority_queue_clear(
             (void)allocator->allocate((CCC_Allocator_arguments){
                 .input = destroy_this,
                 .bytes = 0,
+                .alignment = priority_queue->alignof_type,
                 .context = allocator->context,
             });
         }

--- a/source/singly_linked_list.c
+++ b/source/singly_linked_list.c
@@ -103,6 +103,7 @@ CCC_singly_linked_list_push_front(
         void *const node = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = list->sizeof_type,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
         if (!node) {
@@ -136,6 +137,7 @@ CCC_singly_linked_list_pop_front(
         (void)allocator->allocate((CCC_Allocator_arguments){
             .input = struct_base(list, remove),
             .bytes = 0,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
     }
@@ -228,6 +230,7 @@ CCC_singly_linked_list_erase(
         (void)allocator->allocate((CCC_Allocator_arguments){
             .input = struct_base(list, type_intruder),
             .bytes = 0,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
     }
@@ -352,6 +355,7 @@ CCC_singly_linked_list_clear(
             (void)allocator->allocate((CCC_Allocator_arguments){
                 .input = data,
                 .bytes = 0,
+                .alignment = list->alignof_type,
                 .context = allocator->context,
             });
         }
@@ -443,6 +447,7 @@ CCC_singly_linked_list_insert_sorted(
         void *const node = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = list->sizeof_type,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
         if (!node) {
@@ -691,6 +696,7 @@ erase_range(
         (void)allocator->allocate((CCC_Allocator_arguments){
             .input = struct_base(list, begin),
             .bytes = 0,
+            .alignment = list->alignof_type,
             .context = allocator->context,
         });
         if (begin == end) {

--- a/source/tree_map.c
+++ b/source/tree_map.c
@@ -379,6 +379,7 @@ CCC_tree_map_remove_entry(
             allocator->allocate((CCC_Allocator_arguments){
                 .input = erased,
                 .bytes = 0,
+                .alignment = entry->map->alignof_type,
                 .context = allocator->context,
             });
             return (CCC_Entry){
@@ -420,6 +421,7 @@ CCC_tree_map_remove_key_value(
         allocator->allocate((CCC_Allocator_arguments){
             .input = removed,
             .bytes = 0,
+            .alignment = map->alignof_type,
             .context = allocator->context,
         });
         return (CCC_Entry){
@@ -623,6 +625,7 @@ CCC_tree_map_clear(
             (void)allocator->allocate((CCC_Allocator_arguments){
                 .input = type,
                 .bytes = 0,
+                .alignment = map->alignof_type,
                 .context = allocator->context,
             });
         }
@@ -712,6 +715,7 @@ maybe_allocate_insert(
         void *const new = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = map->sizeof_type,
+            .alignment = map->alignof_type,
             .context = allocator->context,
         });
         if (!new) {

--- a/tests/array_adaptive_map/test_array_adaptive_map_construct.c
+++ b/tests/array_adaptive_map/test_array_adaptive_map_construct.c
@@ -77,6 +77,13 @@ check_static_begin(array_adaptive_map_construct_allocator_fixed) {
     check(is_empty(&allocated), CCC_TRUE);
     check(validate(&allocated), CCC_TRUE);
     check(capacity(&allocated).count > 0, CCC_TRUE);
+    CCC_Handle const inserted = array_adaptive_map_insert_or_assign(
+        &allocated, &(struct Val){.id = 1, .val = 1}, &(CCC_Allocator){}
+    );
+    struct Val const *const v
+        = array_adaptive_map_at(&allocated, unwrap(&inserted));
+    check(insert_error(&inserted), CCC_FALSE);
+    check(v != NULL, CCC_TRUE);
     check_end(array_adaptive_map_clear_and_free(
                   &allocated, &(CCC_Destructor){}, &std_allocator
     ););

--- a/tests/array_adaptive_map/test_array_adaptive_map_construct.c
+++ b/tests/array_adaptive_map/test_array_adaptive_map_construct.c
@@ -67,6 +67,36 @@ check_static_begin(array_adaptive_map_test_empty) {
     check_end();
 }
 
+check_static_begin(array_adaptive_map_construct_allocator_fixed) {
+    Array_adaptive_map allocated = array_adaptive_map_with_allocator_storage(
+        id,
+        (CCC_Key_comparator){.compare = id_order},
+        std_allocator,
+        (struct Val[SMALL_FIXED_CAP]){}
+    );
+    check(is_empty(&allocated), CCC_TRUE);
+    check(validate(&allocated), CCC_TRUE);
+    check(capacity(&allocated).count > 0, CCC_TRUE);
+    check_end(array_adaptive_map_clear_and_free(
+                  &allocated, &(CCC_Destructor){}, &std_allocator
+    ););
+}
+
+check_static_begin(array_adaptive_map_construct_allocator_fixed_fail) {
+    Array_adaptive_map allocated = array_adaptive_map_with_allocator_storage(
+        id,
+        (CCC_Key_comparator){.compare = id_order},
+        (CCC_Allocator){},
+        (struct Val[SMALL_FIXED_CAP]){}
+    );
+    check(is_empty(&allocated), CCC_TRUE);
+    check(validate(&allocated), CCC_TRUE);
+    check(capacity(&allocated).count, 0);
+    check_end(array_adaptive_map_clear_and_free(
+                  &allocated, &(CCC_Destructor){}, &std_allocator
+    ););
+}
+
 check_static_begin(array_adaptive_map_test_with_literal) {
     Array_adaptive_map s = array_adaptive_map_with_storage(
         id,
@@ -501,6 +531,8 @@ main(void) {
         array_adaptive_map_construct_empty(),
         array_adaptive_map_test_static(),
         array_adaptive_map_test_empty(),
+        array_adaptive_map_construct_allocator_fixed(),
+        array_adaptive_map_construct_allocator_fixed_fail(),
         array_adaptive_map_test_with_literal(),
         array_adaptive_map_test_copy_no_allocate(),
         array_adaptive_map_test_copy_no_allocate_fail(),

--- a/tests/array_tree_map/test_array_tree_map_construct.c
+++ b/tests/array_tree_map/test_array_tree_map_construct.c
@@ -71,6 +71,36 @@ check_static_begin(array_tree_map_construct_empty) {
     check_end();
 }
 
+check_static_begin(array_tree_map_construct_allocator_fixed) {
+    Array_tree_map allocated = array_tree_map_with_allocator_storage(
+        id,
+        (CCC_Key_comparator){.compare = id_order},
+        std_allocator,
+        (struct Val[SMALL_FIXED_CAP]){}
+    );
+    check(is_empty(&allocated), CCC_TRUE);
+    check(validate(&allocated), CCC_TRUE);
+    check(capacity(&allocated).count > 0, CCC_TRUE);
+    check_end(array_tree_map_clear_and_free(
+                  &allocated, &(CCC_Destructor){}, &std_allocator
+    ););
+}
+
+check_static_begin(array_tree_map_construct_allocator_fixed_fail) {
+    Array_tree_map allocated = array_tree_map_with_allocator_storage(
+        id,
+        (CCC_Key_comparator){.compare = id_order},
+        (CCC_Allocator){},
+        (struct Val[SMALL_FIXED_CAP]){}
+    );
+    check(is_empty(&allocated), CCC_TRUE);
+    check(validate(&allocated), CCC_TRUE);
+    check(capacity(&allocated).count, 0);
+    check_end(array_tree_map_clear_and_free(
+                  &allocated, &(CCC_Destructor){}, &std_allocator
+    ););
+}
+
 check_static_begin(array_tree_map_test_static) {
     check(array_tree_map_capacity(&static_map).count, SMALL_FIXED_CAP);
     check(array_tree_map_count(&static_map).count, 0);
@@ -569,6 +599,8 @@ main(void) {
         array_tree_map_test_handle_status_input(),
         array_tree_map_construct_empty(),
         array_tree_map_test_static(),
+        array_tree_map_construct_allocator_fixed(),
+        array_tree_map_construct_allocator_fixed_fail(),
         array_tree_map_test_empty(),
         array_tree_map_test_with_literal(),
         array_tree_map_test_copy_no_allocate(),

--- a/tests/array_tree_map/test_array_tree_map_construct.c
+++ b/tests/array_tree_map/test_array_tree_map_construct.c
@@ -81,6 +81,13 @@ check_static_begin(array_tree_map_construct_allocator_fixed) {
     check(is_empty(&allocated), CCC_TRUE);
     check(validate(&allocated), CCC_TRUE);
     check(capacity(&allocated).count > 0, CCC_TRUE);
+    CCC_Handle const inserted = array_tree_map_insert_or_assign(
+        &allocated, &(struct Val){.id = 1, .val = 1}, &(CCC_Allocator){}
+    );
+    struct Val const *const v
+        = array_tree_map_at(&allocated, unwrap(&inserted));
+    check(insert_error(&inserted), CCC_FALSE);
+    check(v != NULL, CCC_TRUE);
     check_end(array_tree_map_clear_and_free(
                   &allocated, &(CCC_Destructor){}, &std_allocator
     ););

--- a/tests/flat_hash_map/test_flat_hash_map_construct.c
+++ b/tests/flat_hash_map/test_flat_hash_map_construct.c
@@ -64,6 +64,11 @@ check_static_begin(flat_hash_map_construct_allocator_fixed) {
     check(is_empty(&allocated), CCC_TRUE);
     check(validate(&allocated), CCC_TRUE);
     check(capacity(&allocated).count > 0, CCC_TRUE);
+    CCC_Entry const e = insert_or_assign(
+        &allocated, &(struct Val){.key = 1, .val = 1}, &(CCC_Allocator){}
+    );
+    check(insert_error(&e), CCC_FALSE);
+    check(unwrap(&e) != NULL, CCC_TRUE);
     check_end(flat_hash_map_clear_and_free(
                   &allocated, &(CCC_Destructor){}, &std_allocator
     ););

--- a/tests/flat_hash_map/test_flat_hash_map_construct.c
+++ b/tests/flat_hash_map/test_flat_hash_map_construct.c
@@ -51,6 +51,42 @@ check_static_begin(flat_hash_map_construct_empty) {
     check_end();
 }
 
+check_static_begin(flat_hash_map_construct_allocator_fixed) {
+    Flat_hash_map allocated = flat_hash_map_with_allocator_storage(
+        key,
+        ((CCC_Hasher){
+            .hash = flat_hash_map_int_to_u64,
+            .compare = flat_hash_map_id_order,
+        }),
+        std_allocator,
+        (struct Val[SMALL_FIXED_CAP]){}
+    );
+    check(is_empty(&allocated), CCC_TRUE);
+    check(validate(&allocated), CCC_TRUE);
+    check(capacity(&allocated).count > 0, CCC_TRUE);
+    check_end(flat_hash_map_clear_and_free(
+                  &allocated, &(CCC_Destructor){}, &std_allocator
+    ););
+}
+
+check_static_begin(flat_hash_map_construct_allocator_fixed_fail) {
+    Flat_hash_map allocated = flat_hash_map_with_allocator_storage(
+        key,
+        ((CCC_Hasher){
+            .hash = flat_hash_map_int_to_u64,
+            .compare = flat_hash_map_id_order,
+        }),
+        (CCC_Allocator){},
+        (struct Val[SMALL_FIXED_CAP]){}
+    );
+    check(is_empty(&allocated), CCC_TRUE);
+    check(validate(&allocated), CCC_TRUE);
+    check(capacity(&allocated).count, 0);
+    check_end(flat_hash_map_clear_and_free(
+                  &allocated, &(CCC_Destructor){}, &std_allocator
+    ););
+}
+
 check_static_begin(flat_hash_map_test_static_initialize) {
     check(flat_hash_map_capacity(&static_fh).count, SMALL_FIXED_CAP);
     check(flat_hash_map_count(&static_fh).count, 0);
@@ -552,6 +588,8 @@ int
 main(void) {
     return check_run(
         flat_hash_map_construct_empty(),
+        flat_hash_map_construct_allocator_fixed(),
+        flat_hash_map_construct_allocator_fixed_fail(),
         flat_hash_map_test_static_initialize(),
         flat_hash_map_test_with_literal(),
         flat_hash_map_test_copy_no_allocate(),

--- a/tests/flat_hash_map/test_flat_hash_map_erase.c
+++ b/tests/flat_hash_map/test_flat_hash_map_erase.c
@@ -163,7 +163,7 @@ check_static_begin(flat_hash_map_test_shuffle_erase_fixed) {
     iota(to_insert, STANDARD_FIXED_CAP, 0);
     rand_shuffle(sizeof(int), to_insert, STANDARD_FIXED_CAP, &(int){});
     int i = 0;
-    do {
+    for (;;) {
         int const cur = to_insert[i];
         struct Val const *const v = unwrap(flat_hash_map_insert_or_assign_with(
             &h, cur, &(CCC_Allocator){}, (struct Val){.val = i}
@@ -175,7 +175,7 @@ check_static_begin(flat_hash_map_test_shuffle_erase_fixed) {
         check(v->val, i);
         check(validate(&h), true);
         ++i;
-    } while (1);
+    }
     size_t const full_size = count(&h).count;
     size_t cur_size = count(&h).count;
     i = 0;
@@ -239,7 +239,7 @@ check_static_begin(flat_hash_map_test_shuffle_erase_fixed_aligned) {
     iota(to_insert, STANDARD_FIXED_CAP, 0);
     rand_shuffle(sizeof(int), to_insert, STANDARD_FIXED_CAP, &(int){});
     int i = 0;
-    do {
+    for (;;) {
         int const cur = to_insert[i];
         struct Aligned_type const *const v
             = unwrap(flat_hash_map_insert_or_assign_with(
@@ -251,7 +251,12 @@ check_static_begin(flat_hash_map_test_shuffle_erase_fixed_aligned) {
         check(v->i, to_insert[i]);
         check(validate(&h), true);
         ++i;
-    } while (1);
+    }
+    for (struct Aligned_type const *iter = begin(&h); iter != end(&h);
+         iter = next(&h, iter)) {
+        check(iter != NULL, CCC_TRUE);
+        check(iter->i >= 0 && iter->i <= (int)STANDARD_FIXED_CAP, CCC_TRUE);
+    }
     size_t const full_size = count(&h).count;
     size_t cur_size = count(&h).count;
     i = 0;
@@ -317,7 +322,7 @@ check_static_begin(flat_hash_map_test_shuffle_erase_fixed_collisions) {
     iota(to_insert, STANDARD_FIXED_CAP, 0);
     rand_shuffle(sizeof(int), to_insert, STANDARD_FIXED_CAP, &(int){});
     int i = 0;
-    do {
+    for (;;) {
         int const cur = to_insert[i];
         struct Val const *const v = unwrap(flat_hash_map_insert_or_assign_with(
             &h, cur, &(CCC_Allocator){}, (struct Val){.val = i}
@@ -329,7 +334,7 @@ check_static_begin(flat_hash_map_test_shuffle_erase_fixed_collisions) {
         check(v->val, i);
         check(validate(&h), true);
         ++i;
-    } while (1);
+    }
     size_t const full_size = count(&h).count;
     size_t cur_size = count(&h).count;
     i = 0;
@@ -402,7 +407,7 @@ check_static_begin(flat_hash_map_test_shuffle_erase_reserved) {
     iota(to_insert, 1024, 0);
     rand_shuffle(sizeof(int), to_insert, 1024, &(int){});
     int i = 0;
-    do {
+    for (;;) {
         int const cur = to_insert[i];
         struct Val const *const v = unwrap(flat_hash_map_insert_or_assign_with(
             &h, cur, &(CCC_Allocator){}, (struct Val){.val = i}
@@ -414,7 +419,7 @@ check_static_begin(flat_hash_map_test_shuffle_erase_reserved) {
         check(v->val, i);
         check(validate(&h), true);
         ++i;
-    } while (1);
+    }
     size_t const full_size = count(&h).count;
     size_t cur_size = count(&h).count;
     i = 0;
@@ -492,7 +497,7 @@ check_static_begin(flat_hash_map_test_shuffle_erase_reserved_aligned) {
     iota(to_insert, 1024, 0);
     rand_shuffle(sizeof(int), to_insert, 1024, &(int){});
     int i = 0;
-    do {
+    for (;;) {
         int const cur = to_insert[i];
         struct Aligned_type const *const v
             = unwrap(flat_hash_map_insert_or_assign_with(
@@ -504,7 +509,12 @@ check_static_begin(flat_hash_map_test_shuffle_erase_reserved_aligned) {
         check(v->i, cur);
         check(validate(&h), true);
         ++i;
-    } while (1);
+    }
+    for (struct Aligned_type const *iter = begin(&h); iter != end(&h);
+         iter = next(&h, iter)) {
+        check(iter != NULL, CCC_TRUE);
+        check(iter->i >= 0 && iter->i <= 1024, CCC_TRUE);
+    }
     size_t const full_size = count(&h).count;
     size_t cur_size = count(&h).count;
     i = 0;

--- a/tests/flat_hash_map/test_flat_hash_map_erase.c
+++ b/tests/flat_hash_map/test_flat_hash_map_erase.c
@@ -1,4 +1,6 @@
+#include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
 
@@ -12,6 +14,45 @@
 #include "types.h"
 #include "utility/random.h"
 #include "utility/std_allocator.h"
+
+/** Test constructing a user type that has an alignment constraint with an
+allocator that respects it. We know that the flat hash map must align the
+metadata array to group size for SIMD performance. So, we want to ensure that
+using an aligned allocation for this type*/
+struct Aligned_type {
+    int i;
+    uint64_t d;
+};
+static_assert(
+    alignof(struct Aligned_type) != sizeof(struct Aligned_type),
+    "Tested type alignment and size must differ."
+);
+
+/** This is a limited test to ensure behavior of aligned allocation works. A
+real user allocator would gracefully implement an aligned reallocation function.
+We will not. Only use this for single allocation or reserve. No reallocation
+is available. Aligned allocate and free are available behaviors. */
+static void *
+my_aligned_alloc_no_realloc(CCC_Allocator_arguments const arguments) {
+    if (!arguments.input && !arguments.bytes) {
+        return NULL;
+    }
+    if (!arguments.input) {
+        return aligned_alloc(arguments.alignment, arguments.bytes);
+    }
+    if (!arguments.bytes) {
+        free(arguments.input);
+        return NULL;
+    }
+    return NULL;
+}
+
+static CCC_Order
+flat_hash_map_aligned_int_order(CCC_Key_comparator_arguments const order) {
+    struct Aligned_type const *const right = order.type_right;
+    int const left = *((int *)order.key_left);
+    return (left > right->i) - (left < right->i);
+}
 
 check_static_begin(flat_hash_map_test_erase) {
     CCC_Flat_hash_map fh = flat_hash_map_with_storage(
@@ -350,6 +391,98 @@ check_static_begin(flat_hash_map_test_shuffle_erase_reserved) {
     ););
 }
 
+check_static_begin(flat_hash_map_test_shuffle_erase_reserved_aligned) {
+    /* The map will be given dynamically reserved space but no ability to
+       resize. All algorithms should function normally and in place rehashing
+       should take effect. */
+    CCC_Flat_hash_map h = flat_hash_map_default(
+        struct Aligned_type,
+        i,
+        ((CCC_Hasher){
+            .hash = flat_hash_map_int_to_u64,
+            .compare = flat_hash_map_aligned_int_order,
+        })
+    );
+    int const test_amount = 896;
+    CCC_Result const res_check = CCC_flat_hash_map_reserve(
+        &h,
+        (size_t)test_amount,
+        &(CCC_Allocator){.allocate = my_aligned_alloc_no_realloc}
+    );
+    check(res_check, CCC_RESULT_OK);
+
+    /* Give ourselves plenty more to insert so we don't run out before cap. */
+    int to_insert[1024];
+    iota(to_insert, 1024, 0);
+    rand_shuffle(sizeof(int), to_insert, 1024, &(int){});
+    int i = 0;
+    do {
+        int const cur = to_insert[i];
+        struct Aligned_type const *const v
+            = unwrap(flat_hash_map_insert_or_assign_with(
+                &h, cur, &(CCC_Allocator){}, (struct Aligned_type){.i = i}
+            ));
+        if (!v) {
+            break;
+        }
+        check(v->i, cur);
+        check(validate(&h), true);
+        ++i;
+    } while (1);
+    size_t const full_size = count(&h).count;
+    size_t cur_size = count(&h).count;
+    i = 0;
+    for (; i < (int)(full_size / 2); ++i) {
+        int const cur = to_insert[i];
+        CCC_Tribool const check = contains(&h, &cur);
+        check(check, true);
+        CCC_Entry const removed = remove_entry(
+            flat_hash_map_entry_wrap(&h, &cur, &(CCC_Allocator){})
+        );
+        check(occupied(&removed), true);
+        check(validate(&h), true);
+    }
+    i = 0;
+    for (; i < (int)(full_size / 2); ++i) {
+        int const cur = to_insert[i];
+        CCC_Entry const *const e = flat_hash_map_insert_or_assign_with(
+            &h, cur, &(CCC_Allocator){}, (struct Aligned_type){.i = cur}
+        );
+        check(occupied(e), false);
+        check(validate(&h), true);
+    }
+    check(full_size, cur_size);
+    i = 0;
+    while (!is_empty(&h) && cur_size) {
+        int const cur = to_insert[i];
+        CCC_Tribool const check = contains(&h, &cur);
+        check(check, true);
+        if (i % 2) {
+            struct Aligned_type const *const old_val
+                = unwrap(flat_hash_map_remove_key_value_wrap(
+                    &h, &(struct Aligned_type){.i = cur}
+                ));
+            check(old_val != NULL, true);
+            check(old_val->i, to_insert[i]);
+        } else {
+            CCC_Entry removed = remove_entry(
+                flat_hash_map_entry_wrap(&h, &cur, &(CCC_Allocator){})
+            );
+            check(occupied(&removed), true);
+        }
+        --cur_size;
+        ++i;
+        check(count(&h).count, cur_size);
+        check(validate(&h), true);
+    }
+    check(count(&h).count, 0);
+    check_end((void)CCC_flat_hash_map_clear_and_free(
+                  &h,
+                  &(CCC_Destructor){},
+                  &(CCC_Allocator){.allocate = my_aligned_alloc_no_realloc}
+    ););
+}
+
 check_static_begin(flat_hash_map_test_shuffle_erase_dynamic) {
     CCC_Flat_hash_map h = flat_hash_map_default(
         struct Val,
@@ -432,6 +565,7 @@ main(void) {
         flat_hash_map_test_shuffle_erase_fixed(),
         flat_hash_map_test_shuffle_erase_fixed_collisions(),
         flat_hash_map_test_shuffle_erase_reserved(),
+        flat_hash_map_test_shuffle_erase_reserved_aligned(),
         flat_hash_map_test_shuffle_erase_dynamic(),
     );
 }

--- a/tests/flat_hash_map/test_flat_hash_map_erase.c
+++ b/tests/flat_hash_map/test_flat_hash_map_erase.c
@@ -48,7 +48,7 @@ my_aligned_alloc_no_realloc(CCC_Allocator_arguments const arguments) {
 }
 
 static CCC_Order
-flat_hash_map_aligned_int_order(CCC_Key_comparator_arguments const order) {
+flat_hash_map_aligned_type_order(CCC_Key_comparator_arguments const order) {
     struct Aligned_type const *const right = order.type_right;
     int const left = *((int *)order.key_left);
     return (left > right->i) - (left < right->i);
@@ -211,6 +211,82 @@ check_static_begin(flat_hash_map_test_shuffle_erase_fixed) {
                 ));
             check(old_val != NULL, true);
             check(old_val->key, to_insert[i]);
+        } else {
+            CCC_Entry removed = remove_entry(
+                flat_hash_map_entry_wrap(&h, &cur, &(CCC_Allocator){})
+            );
+            check(occupied(&removed), true);
+        }
+        --cur_size;
+        ++i;
+        check(count(&h).count, cur_size);
+        check(validate(&h), true);
+    }
+    check(count(&h).count, 0);
+    check_end();
+}
+
+check_static_begin(flat_hash_map_test_shuffle_erase_fixed_aligned) {
+    CCC_Flat_hash_map h = flat_hash_map_with_storage(
+        i,
+        ((CCC_Hasher){
+            .hash = flat_hash_map_int_to_u64,
+            .compare = flat_hash_map_aligned_type_order,
+        }),
+        (struct Aligned_type[STANDARD_FIXED_CAP]){}
+    );
+    int to_insert[STANDARD_FIXED_CAP];
+    iota(to_insert, STANDARD_FIXED_CAP, 0);
+    rand_shuffle(sizeof(int), to_insert, STANDARD_FIXED_CAP, &(int){});
+    int i = 0;
+    do {
+        int const cur = to_insert[i];
+        struct Aligned_type const *const v
+            = unwrap(flat_hash_map_insert_or_assign_with(
+                &h, cur, &(CCC_Allocator){}, (struct Aligned_type){.i = i}
+            ));
+        if (!v) {
+            break;
+        }
+        check(v->i, to_insert[i]);
+        check(validate(&h), true);
+        ++i;
+    } while (1);
+    size_t const full_size = count(&h).count;
+    size_t cur_size = count(&h).count;
+    i = 0;
+    for (; i < (int)(full_size / 2); ++i) {
+        int const cur = to_insert[i];
+        CCC_Tribool const check = contains(&h, &cur);
+        check(check, true);
+        CCC_Entry removed = remove_entry(
+            flat_hash_map_entry_wrap(&h, &cur, &(CCC_Allocator){})
+        );
+        check(occupied(&removed), true);
+        check(validate(&h), true);
+    }
+    i = 0;
+    for (; i < (int)(full_size / 2); ++i) {
+        int const cur = to_insert[i];
+        CCC_Entry const *const e = flat_hash_map_insert_or_assign_with(
+            &h, cur, &(CCC_Allocator){}, (struct Aligned_type){}
+        );
+        check(occupied(e), false);
+        check(validate(&h), true);
+    }
+    check(full_size, cur_size);
+    i = 0;
+    while (!is_empty(&h) && cur_size) {
+        int const cur = to_insert[i];
+        CCC_Tribool const check = contains(&h, &cur);
+        check(check, true);
+        if (i % 2) {
+            struct Aligned_type const *const old_val
+                = unwrap(flat_hash_map_remove_key_value_wrap(
+                    &h, &(struct Aligned_type){.i = cur}
+                ));
+            check(old_val != NULL, true);
+            check(old_val->i, to_insert[i]);
         } else {
             CCC_Entry removed = remove_entry(
                 flat_hash_map_entry_wrap(&h, &cur, &(CCC_Allocator){})
@@ -400,7 +476,7 @@ check_static_begin(flat_hash_map_test_shuffle_erase_reserved_aligned) {
         i,
         ((CCC_Hasher){
             .hash = flat_hash_map_int_to_u64,
-            .compare = flat_hash_map_aligned_int_order,
+            .compare = flat_hash_map_aligned_type_order,
         })
     );
     int const test_amount = 896;
@@ -563,6 +639,7 @@ main(void) {
         flat_hash_map_test_erase(),
         flat_hash_map_test_shuffle_insert_erase(),
         flat_hash_map_test_shuffle_erase_fixed(),
+        flat_hash_map_test_shuffle_erase_fixed_aligned(),
         flat_hash_map_test_shuffle_erase_fixed_collisions(),
         flat_hash_map_test_shuffle_erase_reserved(),
         flat_hash_map_test_shuffle_erase_reserved_aligned(),

--- a/utility/std_allocator.c
+++ b/utility/std_allocator.c
@@ -2,7 +2,15 @@
 #include <stdlib.h>
 
 #include "std_allocator.h"
-#include "types.h"
+
+#include "ccc/types.h"
+
+#include "ccc/flat_hash_map.h" /* IWYU pragma: keep */
+static_assert(
+    alignof(max_align_t) >= CCC_FLAT_HASH_MAP_GROUP_COUNT,
+    "Standard library malloc and realloc default maximum alignment is "
+    "sufficient for flat hash map SIMD group loads."
+);
 
 /** Defined extern in allocate.h */
 CCC_Allocator const std_allocator = {

--- a/utility/std_allocator.c
+++ b/utility/std_allocator.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stddef.h>
 #include <stdlib.h>
 
@@ -19,6 +20,14 @@ CCC_Allocator const std_allocator = {
 
 void *
 std_allocate(CCC_Allocator_arguments const arguments) {
+    if (arguments.alignment && arguments.alignment > alignof(max_align_t)) {
+        assert(
+            arguments.alignment <= alignof(max_align_t)
+            && "Any type provided to this allocator has alignment less than or "
+               "equal to default malloc/realloc max alignment."
+        );
+        return NULL;
+    }
     if (!arguments.input && !arguments.bytes) {
         return NULL;
     }

--- a/utility/string_arena.c
+++ b/utility/string_arena.c
@@ -20,6 +20,7 @@ string_arena_create(size_t const cap, CCC_Allocator const *const allocator) {
     a.arena = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
         .bytes = cap,
+        .alignment = alignof(char),
         .context = allocator->context,
     });
     if (!a.arena) {
@@ -103,6 +104,7 @@ string_arena_maybe_resize_pos(
         void *const moved_arena = allocator->allocate((CCC_Allocator_arguments){
             .input = a->arena,
             .bytes = new_cap,
+            .alignment = alignof(char),
             .context = allocator->context,
         });
         if (!moved_arena) {
@@ -158,6 +160,7 @@ string_arena_free(
     (void)allocator->allocate((CCC_Allocator_arguments){
         .input = a->arena,
         .bytes = 0,
+        .alignment = alignof(char),
         .context = allocator->context,
     });
     a->arena = NULL;


### PR DESCRIPTION
The allocator interface should make alignment explicit. This allows the user to implement more optimal and correct allocators that respect alignment for their types.