### PR TITLE
Use shift trick to reduce memcpy bottom-up-reheap.

### DIFF
--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -604,13 +604,13 @@ bottom_up_reheap(
            height` to `height + 2` which is significant for data sizes that can
            vary significantly in this type of generic container. */
         (void)memcpy(temp, at(buffer, root), buffer->sizeof_type);
-        size_t lineage = count_leading_zeros_size_t(root + 1)
-                       - count_leading_zeros_size_t(leaf + 1);
-        while (lineage--) {
+        size_t tree_levels = count_leading_zeros_size_t(root + 1)
+                           - count_leading_zeros_size_t(leaf + 1);
+        while (tree_levels--) {
             size_t const vacant_ancestor_index
-                = ((leaf + 1) >> (lineage + 1)) - 1;
+                = ((leaf + 1) >> (tree_levels + 1)) - 1;
             size_t const occupied_ancestor_child_index
-                = ((leaf + 1) >> lineage) - 1;
+                = ((leaf + 1) >> tree_levels) - 1;
             memcpy(
                 at(buffer, vacant_ancestor_index),
                 at(buffer, occupied_ancestor_child_index),

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -609,11 +609,11 @@ bottom_up_reheap(
         while (lineage--) {
             size_t const vacant_ancestor_index
                 = ((leaf + 1) >> (lineage + 1)) - 1;
-            size_t const occupied_child_of_ancestor_index
+            size_t const occupied_ancestor_child_index
                 = ((leaf + 1) >> lineage) - 1;
             memcpy(
                 at(buffer, vacant_ancestor_index),
-                at(buffer, occupied_child_of_ancestor_index),
+                at(buffer, occupied_ancestor_child_index),
                 buffer->sizeof_type
             );
         }

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -617,7 +617,8 @@ bottom_up_reheap(
            special path we can just save the root in temp and shift all other
            nodes up the special path with overwrites. This is a 3x reduction
            in memcpy calls and thus reduces memory writes significantly in our
-           hot path for heapifying and sorting. */
+           hot path for heapifying and sorting. The traditional implementation
+           has us */
         (void)memcpy(temp, at(buffer, root), buffer->sizeof_type);
         size_t special_bit_path_index = 0;
         size_t node = root;

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -62,6 +62,7 @@ static void
 destroy_each(struct CCC_Flat_priority_queue *, CCC_Destructor const *);
 static void swap(void *, size_t, void *, void *);
 static void *at(CCC_Flat_buffer const *buffer, size_t i);
+static unsigned count_leading_zeros_size_t(size_t n);
 
 /*=====================       Interface      ================================*/
 
@@ -604,8 +605,8 @@ bottom_up_reheap(
            hot path for heapifying and sorting. The traditional implementation
            has us */
         (void)memcpy(temp, at(buffer, root), buffer->sizeof_type);
-        size_t levels = (size_t)__builtin_clzl(root + 1)
-                      - (size_t)__builtin_clzl(leaf + 1);
+        size_t levels = count_leading_zeros_size_t(root + 1)
+                      - count_leading_zeros_size_t(leaf + 1);
         while (levels--) {
             size_t const ancestor_of_leaf = ((leaf + 1) >> (levels + 1)) - 1;
             size_t const child_of_ancestor = ((leaf + 1) >> levels) - 1;
@@ -763,3 +764,33 @@ destroy_each(
         });
     }
 }
+
+#if defined(__has_builtin) && __has_builtin(__builtin_clzl)
+
+static inline unsigned
+count_leading_zeros_size_t(size_t const n) {
+    static_assert(
+        sizeof(size_t) == sizeof(unsigned long),
+        "Ensure the available builtin works for the platform defined "
+        "size of a size_t."
+    );
+    return n ? (unsigned)__builtin_clzl(n) : sizeof(size_t) * CHAR_BIT;
+}
+
+#else /* !defined(__has_builtin) || !__has_builtin(__builtin_clzl) */
+
+static inline unsigned
+count_leading_zeros_size_t(size_t n) {
+    enum : size_t {
+        /** @internal Most significant bit of size_t for bit counting. */
+        SIZE_T_MSB = 0x8000000000000000,
+    };
+    if (!n) {
+        return sizeof(size_t) * CHAR_BIT;
+    }
+    unsigned cnt = 0;
+    for (; !(n & SIZE_T_MSB); ++cnt, n <<= 1U) {}
+    return cnt;
+}
+
+#endif /* defined(__has_builtin) && __has_builtin(__builtin_clzl) */

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -566,34 +566,20 @@ bottom_up_reheap(
     CCC_Comparator const *const comparator
 ) {
     size_t leaf = root;
-    /* We are adjusting the implementation to reduce calls to memcpy later in
-       the final loop from 3 * height of special path, which happens if we swap,
-       to just height of special path + 2. */
-    size_t special_bit_path = 0;
-    size_t special_bit_path_count = 0;
     {
         /* Procedure leaf-search(count, root) */
         size_t left = (2 * leaf) + 1;
-        size_t went_right = 1;
         while (left + 1 < count) {
             size_t const right = left + 1;
             if (wins(at(buffer, left), at(buffer, right), order, comparator)) {
                 leaf = left;
             } else {
                 leaf = right;
-                special_bit_path |= went_right;
             }
             left = (2 * leaf) + 1;
-            went_right <<= 1;
-            ++special_bit_path_count;
-            assert(
-                (special_bit_path_count < sizeof(size_t) * CHAR_BIT)
-                && "heap height remains indexible by size_t"
-            );
         }
         if (left < count) {
             leaf = left;
-            ++special_bit_path_count;
         }
     }
     {
@@ -607,10 +593,8 @@ bottom_up_reheap(
         void const *const node = at(buffer, root);
         while (leaf > root && wins(node, at(buffer, leaf), order, comparator)) {
             leaf = (leaf - 1) / 2;
-            --special_bit_path_count;
         }
     }
-    size_t const reheaped_root_index = leaf;
     {
         /* Procedure interchange-2(root, leaf). Here we want to reduce the calls
            to memcpy by not using a swap operation. Because we remember the
@@ -620,23 +604,20 @@ bottom_up_reheap(
            hot path for heapifying and sorting. The traditional implementation
            has us */
         (void)memcpy(temp, at(buffer, root), buffer->sizeof_type);
-        size_t special_bit_path_index = 0;
-        size_t node = root;
-        while (special_bit_path_index < special_bit_path_count) {
-            size_t const child
-                = (special_bit_path & 1) ? (node * 2) + 2 : (node * 2) + 1;
-            (void)memcpy(
-                at(buffer, node), at(buffer, child), buffer->sizeof_type
+        size_t levels = (size_t)__builtin_clzl(root + 1)
+                      - (size_t)__builtin_clzl(leaf + 1);
+        while (levels--) {
+            size_t const ancestor_of_leaf = ((leaf + 1) >> (levels + 1)) - 1;
+            size_t const child_of_ancestor = ((leaf + 1) >> levels) - 1;
+            memcpy(
+                at(buffer, ancestor_of_leaf),
+                at(buffer, child_of_ancestor),
+                buffer->sizeof_type
             );
-            node = child;
-            special_bit_path >>= 1;
-            ++special_bit_path_index;
         }
-        (void)memcpy(
-            at(buffer, reheaped_root_index), temp, buffer->sizeof_type
-        );
+        (void)memcpy(at(buffer, leaf), temp, buffer->sizeof_type);
     }
-    return reheaped_root_index;
+    return leaf;
 }
 
 /* Returns the sorted position of the element starting at position i. */

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -543,7 +543,7 @@ heapify(
     }
 }
 
-/** The Bottom-Up-Heapsort procedures from the research paper but all in one
+/** The Bottom-Up-Reheap procedures from the research paper but all in one
 function. No need to break out into tiny functions because they are only used
 here and this makes the logic easy to track in one short function. Such an
 operation also replaces the traditional bubble-down of a standard heap. The
@@ -566,20 +566,34 @@ bottom_up_reheap(
     CCC_Comparator const *const comparator
 ) {
     size_t leaf = root;
+    /* We are adjusting the implementation to reduce calls to memcpy later in
+       the final loop from 3 * height of special path, which happens if we swap,
+       to just height of special path + 2. */
+    size_t special_bit_path = 0;
+    size_t special_bit_path_count = 0;
     {
         /* Procedure leaf-search(count, root) */
         size_t left = (2 * leaf) + 1;
+        size_t went_right = 1;
         while (left + 1 < count) {
             size_t const right = left + 1;
             if (wins(at(buffer, left), at(buffer, right), order, comparator)) {
                 leaf = left;
             } else {
                 leaf = right;
+                special_bit_path |= went_right;
             }
             left = (2 * leaf) + 1;
+            went_right <<= 1;
+            ++special_bit_path_count;
+            assert(
+                (special_bit_path_count < sizeof(size_t) * CHAR_BIT)
+                && "heap height remains indexible by size_t"
+            );
         }
         if (left < count) {
             leaf = left;
+            ++special_bit_path_count;
         }
     }
     {
@@ -593,18 +607,33 @@ bottom_up_reheap(
         void const *const node = at(buffer, root);
         while (leaf > root && wins(node, at(buffer, leaf), order, comparator)) {
             leaf = (leaf - 1) / 2;
+            --special_bit_path_count;
         }
     }
     size_t const reheaped_root_index = leaf;
     {
-        /* Procedure interchange-2(root, leaf). We only have one available swap
-           slot in temp provided to us by the user. Therefore, we cannot save
-           our root element of interest on the stack. We will use a swap chain
-           to slide everything up to fill the vacated root slot. */
-        while (leaf > root) {
-            swap(temp, buffer->sizeof_type, at(buffer, leaf), at(buffer, root));
-            leaf = (leaf - 1) / 2;
+        /* Procedure interchange-2(root, leaf). Here we want to reduce the calls
+           to memcpy by not using a swap operation. Because we remember the
+           special path we can just save the root in temp and shift all other
+           nodes up the special path with overwrites. This is a 3x reduction
+           in memcpy calls and thus reduces memory writes significantly in our
+           hot path for heapifying and sorting. */
+        (void)memcpy(temp, at(buffer, root), buffer->sizeof_type);
+        size_t special_bit_path_index = 0;
+        size_t node = root;
+        while (special_bit_path_index < special_bit_path_count) {
+            size_t const child
+                = (special_bit_path & 1) ? (node * 2) + 2 : (node * 2) + 1;
+            (void)memcpy(
+                at(buffer, node), at(buffer, child), buffer->sizeof_type
+            );
+            node = child;
+            special_bit_path >>= 1;
+            ++special_bit_path_index;
         }
+        (void)memcpy(
+            at(buffer, reheaped_root_index), temp, buffer->sizeof_type
+        );
     }
     return reheaped_root_index;
 }

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -601,17 +601,19 @@ bottom_up_reheap(
            memcpy by avoiding the traditional swap with our temp position. We
            can figure out the ancestry of the special path leaf position we have
            found using bitwise checks. This cuts the calls to memcpy from `3 *
-           height` to `height + 2` which is significant for unknown data sizes
-           being copied with memcpy for this container. */
+           height` to `height + 2` which is significant for data sizes that can
+           vary significantly in this type of generic container. */
         (void)memcpy(temp, at(buffer, root), buffer->sizeof_type);
-        size_t levels = count_leading_zeros_size_t(root + 1)
-                      - count_leading_zeros_size_t(leaf + 1);
-        while (levels--) {
-            size_t const ancestor_of_leaf = ((leaf + 1) >> (levels + 1)) - 1;
-            size_t const child_of_ancestor = ((leaf + 1) >> levels) - 1;
+        size_t lineage = count_leading_zeros_size_t(root + 1)
+                       - count_leading_zeros_size_t(leaf + 1);
+        while (lineage--) {
+            size_t const vacant_ancestor_index
+                = ((leaf + 1) >> (lineage + 1)) - 1;
+            size_t const occupied_child_of_ancestor_index
+                = ((leaf + 1) >> lineage) - 1;
             memcpy(
-                at(buffer, ancestor_of_leaf),
-                at(buffer, child_of_ancestor),
+                at(buffer, vacant_ancestor_index),
+                at(buffer, occupied_child_of_ancestor_index),
                 buffer->sizeof_type
             );
         }

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -597,13 +597,12 @@ bottom_up_reheap(
         }
     }
     {
-        /* Procedure interchange-2(root, leaf). Here we want to reduce the calls
-           to memcpy by not using a swap operation. Because we remember the
-           special path we can just save the root in temp and shift all other
-           nodes up the special path with overwrites. This is a 3x reduction
-           in memcpy calls and thus reduces memory writes significantly in our
-           hot path for heapifying and sorting. The traditional implementation
-           has us */
+        /* Procedure interchange-2(root, leaf). We can reduce the calls to
+           memcpy by avoiding the traditional swap with our temp position. We
+           can figure out the ancestry of the special path leaf position we have
+           found using bitwise checks. This cuts the calls to memcpy from `3 *
+           height` to `height + 2` which is significant for unknown data sizes
+           being copied with memcpy for this container. */
         (void)memcpy(temp, at(buffer, root), buffer->sizeof_type);
         size_t levels = count_leading_zeros_size_t(root + 1)
                       - count_leading_zeros_size_t(leaf + 1);

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -597,7 +597,7 @@ bottom_up_reheap(
         }
     }
     {
-        /* Procedure interchange-2(root, leaf). We can reduce the calls to
+        /* Procedure interchange-1(root, leaf). We can reduce the calls to
            memcpy by avoiding the traditional swap with our temp position. We
            can figure out the ancestry of the special path leaf position we have
            found using bitwise checks. This cuts the calls to memcpy from `3 *

--- a/tests/flat_priority_queue/test_flat_priority_queue_construct.c
+++ b/tests/flat_priority_queue/test_flat_priority_queue_construct.c
@@ -373,6 +373,26 @@ check_static_begin(flat_priority_queue_test_heapsort_one) {
     check_end();
 }
 
+check_static_begin(flat_priority_queue_test_heapsort_two) {
+    Flat_buffer storage = flat_buffer_with_storage(2, (int[2]){1, 2});
+    check(
+        CCC_sort_heapsort(
+            &storage,
+            &(int){},
+            CCC_ORDER_GREATER,
+            &(CCC_Comparator){.compare = int_order}
+        ),
+        CCC_RESULT_OK
+    );
+    check(
+        flat_int_buffers_are_equal(
+            &storage, &flat_buffer_with_storage(2, (int[2]){2, 1})
+        ),
+        CCC_TRUE
+    );
+    check_end();
+}
+
 check_static_begin(flat_priority_queue_test_heapsort_reversed_lesser) {
     enum : int {
         CAP = 10,
@@ -725,6 +745,7 @@ main(void) {
         flat_priority_queue_test_copy_allocate_fail(),
         flat_priority_queue_test_heapsort_empty(),
         flat_priority_queue_test_heapsort_one(),
+        flat_priority_queue_test_heapsort_two(),
         flat_priority_queue_test_heapsort_reversed_lesser(),
         flat_priority_queue_test_heapsort_reversed_greater(),
         flat_priority_queue_test_heapsort_merge(),

--- a/tests/flat_priority_queue/test_flat_priority_queue_construct.c
+++ b/tests/flat_priority_queue/test_flat_priority_queue_construct.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #define TRAITS_USING_NAMESPACE_CCC
@@ -22,6 +23,49 @@ static Flat_priority_queue const static_priority_queue
     = flat_priority_queue_with_storage(
         CCC_ORDER_LESSER, (CCC_Comparator){.compare = val_order}, (int[16]){}
     );
+
+static inline CCC_Tribool
+ints_are_sorted(Flat_buffer const *const ints, CCC_Order const order) {
+    int const *prev = begin(ints);
+    if (prev == end(ints)) {
+        return CCC_TRUE;
+    }
+    for (int const *current = next(ints, prev); current != end(ints);
+         current = next(ints, current)) {
+        if (*current > *prev && order == CCC_ORDER_GREATER) {
+            return CCC_FALSE;
+        }
+        if (*current < *prev && order == CCC_ORDER_LESSER) {
+            return CCC_FALSE;
+        }
+    }
+    return CCC_TRUE;
+}
+
+static inline CCC_Tribool
+flat_int_buffers_are_equal(
+    Flat_buffer const *const a, Flat_buffer const *const b
+) {
+    if (count(a).count != count(b).count) {
+        return CCC_FALSE;
+    }
+    if (flat_buffer_sizeof_type(a).count != flat_buffer_sizeof_type(b).count) {
+        return CCC_FALSE;
+    }
+    for (int const *iter_a = begin(a), *iter_b = begin(b);
+         iter_a != end(a) && iter_b != end(b);
+         iter_a = next(a, iter_a), iter_b = next(b, iter_b)) {
+        if (*iter_a != *iter_b) {
+            return CCC_FALSE;
+        }
+    }
+    return memcmp(
+               flat_buffer_data(a),
+               flat_buffer_data(b),
+               flat_buffer_sizeof_type(a).count * flat_buffer_count(a).count
+           )
+        == 0;
+}
 
 check_static_begin(flat_priority_queue_test_static_const) {
     check(is_empty(&static_priority_queue), true);
@@ -279,19 +323,10 @@ check_static_begin(flat_priority_queue_test_heapify_copy_fail) {
     check_end();
 }
 
-check_static_begin(flat_priority_queue_test_heapsort) {
-    enum : int {
-        HPSORTCAP = 100,
-    };
-    Flat_buffer storage
-        = flat_buffer_with_storage(HPSORTCAP, (int[HPSORTCAP]){});
-    for (int *i = flat_buffer_begin(&storage); i != flat_buffer_end(&storage);
-         i = flat_buffer_next(&storage, i)) {
-        *i = (int)rand_range(0, HPSORTCAP);
-    }
+check_static_begin(flat_priority_queue_test_heapsort_empty) {
     check(
         CCC_sort_heapsort(
-            &storage,
+            &flat_buffer_default(int),
             NULL,
             CCC_ORDER_GREATER,
             &(CCC_Comparator){.compare = int_order}
@@ -299,17 +334,77 @@ check_static_begin(flat_priority_queue_test_heapsort) {
         CCC_RESULT_ARGUMENT_ERROR
     );
     check(
-        CCC_sort_heapsort(&storage, &(int){}, CCC_ORDER_GREATER, NULL),
+        CCC_sort_heapsort(
+            &flat_buffer_default(int), &(int){}, CCC_ORDER_GREATER, NULL
+        ),
         CCC_RESULT_ARGUMENT_ERROR
     );
     check(
         CCC_sort_heapsort(
-            &storage,
+            &flat_buffer_default(int),
             &(int){},
             CCC_ORDER_EQUAL,
             &(CCC_Comparator){.compare = int_order}
         ),
         CCC_RESULT_ARGUMENT_ERROR
+    );
+    check(
+        CCC_sort_heapsort(
+            &flat_buffer_default(int),
+            &(int){},
+            CCC_ORDER_GREATER,
+            &(CCC_Comparator){.compare = int_order}
+        ),
+        CCC_RESULT_OK
+    );
+    check_end();
+}
+
+check_static_begin(flat_priority_queue_test_heapsort_one) {
+    check(
+        CCC_sort_heapsort(
+            &flat_buffer_with_storage(1, (int[1]){1}),
+            &(int){},
+            CCC_ORDER_GREATER,
+            &(CCC_Comparator){.compare = int_order}
+        ),
+        CCC_RESULT_OK
+    );
+    check_end();
+}
+
+check_static_begin(flat_priority_queue_test_heapsort_reversed_lesser) {
+    enum : int {
+        CAP = 10,
+    };
+    Flat_buffer storage = flat_buffer_with_storage(
+        CAP, (int[CAP]){9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+    );
+    CCC_Result const result = CCC_sort_heapsort(
+        &storage,
+        &(int){},
+        CCC_ORDER_LESSER,
+        &(CCC_Comparator){.compare = int_order}
+    );
+    check(result, CCC_RESULT_OK);
+    check(
+        flat_int_buffers_are_equal(
+            &storage,
+            &flat_buffer_with_storage(
+                CAP, (int[CAP]){0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+            )
+        ),
+        CCC_TRUE
+    );
+    check_end();
+}
+
+check_static_begin(flat_priority_queue_test_heapsort_reversed_greater) {
+    enum : int {
+        CAP = 10,
+    };
+    Flat_buffer storage = flat_buffer_with_storage(
+        CAP, (int[CAP]){9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
     );
     CCC_Result const result = CCC_sort_heapsort(
         &storage,
@@ -318,17 +413,61 @@ check_static_begin(flat_priority_queue_test_heapsort) {
         &(CCC_Comparator){.compare = int_order}
     );
     check(result, CCC_RESULT_OK);
-    int const *prev = begin(&storage);
-    check(prev != NULL, true);
-    check(CCC_flat_buffer_count(&storage).count, HPSORTCAP);
-    size_t count = 1;
-    for (int const *cur = next(&storage, prev); cur != end(&storage);
-         cur = next(&storage, cur)) {
-        check(*prev >= *cur, true);
-        prev = cur;
-        ++count;
+    check(
+        flat_int_buffers_are_equal(
+            &storage,
+            &flat_buffer_with_storage(
+                CAP, (int[CAP]){9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+            )
+        ),
+        CCC_TRUE
+    );
+    check_end();
+}
+
+check_static_begin(flat_priority_queue_test_heapsort_merge) {
+    enum : int {
+        CAP = 10,
+    };
+    Flat_buffer storage = flat_buffer_with_storage(
+        CAP, (int[CAP]){1, 3, 5, 7, 9, 0, 2, 4, 6, 8}
+    );
+    CCC_Result const result = CCC_sort_heapsort(
+        &storage,
+        &(int){},
+        CCC_ORDER_LESSER,
+        &(CCC_Comparator){.compare = int_order}
+    );
+    check(result, CCC_RESULT_OK);
+    check(
+        flat_int_buffers_are_equal(
+            &storage,
+            &flat_buffer_with_storage(
+                CAP, (int[CAP]){0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+            )
+        ),
+        CCC_TRUE
+    );
+    check_end();
+}
+
+check_static_begin(flat_priority_queue_test_heapsort) {
+    enum : int {
+        CAP = 100,
+    };
+    Flat_buffer storage = flat_buffer_with_storage(CAP, (int[CAP]){});
+    for (int *i = flat_buffer_begin(&storage); i != flat_buffer_end(&storage);
+         i = flat_buffer_next(&storage, i)) {
+        *i = (int)rand_range(0, CAP);
     }
-    check(count, HPSORTCAP);
+    CCC_Result const result = CCC_sort_heapsort(
+        &storage,
+        &(int){},
+        CCC_ORDER_GREATER,
+        &(CCC_Comparator){.compare = int_order}
+    );
+    check(result, CCC_RESULT_OK);
+    check(ints_are_sorted(&storage, CCC_ORDER_GREATER), CCC_TRUE);
     check_end();
 }
 
@@ -584,6 +723,11 @@ main(void) {
         flat_priority_queue_test_copy_no_allocate_fail(),
         flat_priority_queue_test_copy_allocate(),
         flat_priority_queue_test_copy_allocate_fail(),
+        flat_priority_queue_test_heapsort_empty(),
+        flat_priority_queue_test_heapsort_one(),
+        flat_priority_queue_test_heapsort_reversed_lesser(),
+        flat_priority_queue_test_heapsort_reversed_greater(),
+        flat_priority_queue_test_heapsort_merge(),
         flat_priority_queue_test_heapsort(),
         flat_priority_queue_test_init_from(),
         flat_priority_queue_test_init_from_fail(),


### PR DESCRIPTION
Shifting to determine lineage of the leaf on the special path reduces memcpy calls to 3xheight of tree to height of tree + 2.