### PR TITLE
More portable `size_t` msb constant

### DIFF
--- a/source/flat_bitset.c
+++ b/source/flat_bitset.c
@@ -62,9 +62,9 @@ enum : size_t {
 /** @internal Various constants to support bit block size bit ops. */
 enum : Bit_block {
     /** @internal A mask of a bit block with all bits on. */
-    BLOCK_ON = ((Bit_block)~0),
+    BLOCK_ON = (Bit_block)~0,
     /** @internal The Most Significant Bit of a bit block turned on to 1. */
-    BLOCK_MSB = (((Bit_block)1) << (((SIZEOF_BLOCK * CHAR_BIT)) - 1)),
+    BLOCK_MSB = (Bit_block)1 << ((SIZEOF_BLOCK * CHAR_BIT) - 1),
 };
 
 /** @internal An index into the block array or count of bit blocks. The block
@@ -89,7 +89,7 @@ typedef uint8_t Bit_count;
 
 enum : Bit_count {
     /** @internal How many total bits that fit in a bit block. */
-    BLOCK_BITS = (SIZEOF_BLOCK * CHAR_BIT),
+    BLOCK_BITS = SIZEOF_BLOCK * CHAR_BIT,
     /** @internal Used for static assert clarity. */
     U8_BLOCK_MAX = UINT8_MAX,
     /** @internal Hand coded log2 of block bits to avoid division. */

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -2329,7 +2329,7 @@ count_leading_zeros_size_t(size_t const n) {
 
 enum : size_t {
     /** @internal Most significant bit of size_t for bit counting. */
-    SIZE_T_MSB = 0x8000000000000000,
+    SIZE_T_MSB = (size_t)1 << ((sizeof(size_t) * CHAR_BIT) - 1),
 };
 
 static inline unsigned
@@ -2411,7 +2411,7 @@ count_leading_zeros_size_t(size_t const n) {
 
 enum : size_t {
     /** @internal Most significant bit of size_t for bit counting. */
-    SIZE_T_MSB = 0x8000000000000000,
+    SIZE_T_MSB = (size_t)1 << ((sizeof(size_t) * CHAR_BIT) - 1),
 };
 
 static inline unsigned

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -798,7 +798,7 @@ static inline unsigned
 count_leading_zeros_size_t(size_t n) {
     enum : size_t {
         /** @internal Most significant bit of size_t for bit counting. */
-        SIZE_T_MSB = 0x8000000000000000,
+        SIZE_T_MSB = (size_t)1 << ((sizeof(size_t) * CHAR_BIT) - 1),
     };
     if (!n) {
         return sizeof(size_t) * CHAR_BIT;


### PR DESCRIPTION
Ensure bit counting does not depend on 64 or 32 bit for size_t.