### PR TITLE
Add thin wrapper type safety to samples

### DIFF
--- a/samples/ccczip.c
+++ b/samples/ccczip.c
@@ -63,6 +63,11 @@ struct Character_frequency {
     size_t freq;
 };
 
+/** Type safe wrapper for mapping character frequencies. */
+struct Character_frequency_map {
+    CCC_Flat_hash_map map;
+};
+
 enum : uint8_t {
     /** Caching for iterative traversals uses this position as end sentinel. */
     MAX_CHILD_COUNT = 2,
@@ -86,6 +91,11 @@ struct Huffman_node {
     uint8_t child_index;
 };
 
+/** Type safe wrapper for buffering Huffman nodes. */
+struct Huffman_node_buffer {
+    CCC_Flat_buffer buffer;
+};
+
 /** Element intended for the flat priority queue during the tree building phase.
 Pair nodes are paired in twos as they are popped from the priority queue and
 pushed back as the sum of their frequencies. This is how the tree is built.
@@ -97,10 +107,15 @@ struct Pair_node {
     size_t node_index;
 };
 
+/** Type safe wrapper for tracking Pair nodes in a queue. */
+struct Pair_node_priority_queue {
+    CCC_Flat_priority_queue priority_queue;
+};
+
 /** It is helpful to know how many leaves and total nodes there are for
 reserving the appropriate space for helper data structures. */
 struct Huffman_tree {
-    CCC_Flat_buffer tree_storage;
+    struct Huffman_node_buffer tree_storage;
     size_t root;
     size_t num_nodes;
     size_t num_leaves;
@@ -118,6 +133,11 @@ struct Path_memo {
     size_t bitq_start_index;
     /** The length of the known path we have already pushed to the queue. */
     size_t path_len;
+};
+
+/** Type safe wrapper for mapping paths. */
+struct Path_memo_map {
+    CCC_Flat_hash_map map;
 };
 
 enum : size_t {
@@ -173,7 +193,7 @@ static SV_Str_view const cccz_suffix = SV_from(".cccz");
 /*===========================      Prototypes      ==========================*/
 
 static void zip_file(SV_Str_view, CCC_Allocator const *);
-static Flat_priority_queue build_encoding_priority_queue(
+static struct Pair_node_priority_queue build_encoding_priority_queue(
     FILE *, struct Huffman_tree *, CCC_Allocator const *
 );
 static CCC_Tribool bitq_is_empty(struct Bit_queue const *);
@@ -232,6 +252,17 @@ static void
 fill_bitq(FILE *, struct Bit_queue *, size_t, CCC_Allocator const *);
 static size_t file_size(FILE *);
 static size_t min(size_t, size_t);
+static size_t huffman_node_buffer_index(
+    struct Huffman_node_buffer const *, struct Huffman_node const *
+);
+static struct Pair_node *pair_priority_queue_push(
+    struct Pair_node_priority_queue *,
+    struct Pair_node const *,
+    CCC_Allocator const *
+);
+static CCC_Result pair_priority_queue_pop(struct Pair_node_priority_queue *);
+static struct Pair_node *
+pair_priority_queue_front(struct Pair_node_priority_queue const *);
 
 /** Asserts even in release mode. Run code in the second argument if needed. */
 #define check(cond, ...)                                                       \
@@ -272,6 +303,78 @@ formatting, though not required. */
             }                                                                  \
         }                                                                      \
     } while (0)
+
+#define huffman_node_buffer_emplace_back(                                      \
+    huffman_node_buffer_pointer, allocator, compound_literal...                \
+)                                                                              \
+    (__extension__({                                                           \
+        struct Huffman_node_buffer *const                                      \
+            huffman_node_buffer_emplace_back_buffer                            \
+            = (huffman_node_buffer_pointer);                                   \
+        CCC_flat_buffer_emplace_back(                                          \
+            &huffman_node_buffer_emplace_back_buffer->buffer,                  \
+            (allocator),                                                       \
+            compound_literal                                                   \
+        );                                                                     \
+    }))
+
+#define character_frequency_map_increment_entry_or_insert_with(                \
+    character_frequency_map_pointer,                                           \
+    key_pointer,                                                               \
+    allocator,                                                                 \
+    lazy_evaluated_key_value_default_insertion...                              \
+)                                                                              \
+    (__extension__({                                                           \
+        struct Character_frequency_map *const                                  \
+            character_frequency_map_evaluated_pointer                          \
+            = (character_frequency_map_pointer);                               \
+        typeof(*key_pointer) const *const character_frequency_map_key_pointer  \
+            = (key_pointer);                                                   \
+        flat_hash_map_or_insert_with(                                          \
+            flat_hash_map_and_modify_with(                                     \
+                flat_hash_map_entry_wrap(                                      \
+                    &character_frequency_map_evaluated_pointer->map,           \
+                    character_frequency_map_key_pointer,                       \
+                    (allocator)                                                \
+                ),                                                             \
+                struct Character_frequency                                     \
+                    * character_frequency_map_increment_element,               \
+                { ++character_frequency_map_increment_element->freq; }         \
+            ),                                                                 \
+            lazy_evaluated_key_value_default_insertion                         \
+        );                                                                     \
+    }))
+
+#define path_memo_map_entry_and_modify_with(                                   \
+    map_pointer,                                                               \
+    character_key_pointer,                                                     \
+    allocator,                                                                 \
+    occupied_path_memo_entry_declaration,                                      \
+    modification_closure_over_occupied_path_memo_entry...                      \
+)                                                                              \
+    &(struct { CCC_Flat_hash_map_entry private; }){(__extension__({            \
+         struct Path_memo_map *const path_memo_map_pointer = (map_pointer);    \
+         char const *const path_memo_map_character_key                         \
+             = (character_key_pointer);                                        \
+         CCC_Flat_hash_map_entry path_memo_map_entry                           \
+             = *flat_hash_map_and_modify_with(                                 \
+                 flat_hash_map_entry_wrap(                                     \
+                     &path_memo_map_pointer->map,                              \
+                     path_memo_map_character_key,                              \
+                     (allocator)                                               \
+                 ),                                                            \
+                 occupied_path_memo_entry_declaration,                         \
+                 modification_closure_over_occupied_path_memo_entry            \
+             );                                                                \
+         path_memo_map_entry;                                                  \
+     }))}.private
+
+#define path_memo_map_or_insert_with(                                          \
+    entry_pointer, lazy_evaluated_insertion...                                 \
+)                                                                              \
+    (__extension__({                                                           \
+        flat_hash_map_or_insert_with(entry_pointer, lazy_evaluated_insertion); \
+    }))
 
 /*===========================   Argument Handling  ==========================*/
 
@@ -361,21 +464,23 @@ the encoding tree. */
 static struct Huffman_tree
 build_encoding_tree(FILE *const f, CCC_Allocator const *const allocator) {
     struct Huffman_tree ret = {};
-    Flat_priority_queue pairings
+    struct Pair_node_priority_queue pairings
         = build_encoding_priority_queue(f, &ret, allocator);
     defer {
-        (void)clear_and_free(&pairings, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(
+            &pairings.priority_queue, &(CCC_Destructor){}, allocator
+        );
     }
-    while (count(&pairings).count >= 2) {
+    while (count(&pairings.priority_queue).count >= 2) {
         /* Small elements and we need the pair so we can't hold references. */
-        struct Pair_node const zero = *(struct Pair_node *)front(&pairings);
-        CCC_Result r = pop(&pairings, &(struct Pair_node){});
+        struct Pair_node const zero = *pair_priority_queue_front(&pairings);
+        CCC_Result r = pair_priority_queue_pop(&pairings);
         check(r == CCC_RESULT_OK);
-        struct Pair_node const one = *(struct Pair_node *)front(&pairings);
-        r = pop(&pairings, &(struct Pair_node){});
+        struct Pair_node const one = *pair_priority_queue_front(&pairings);
+        r = pair_priority_queue_pop(&pairings);
         check(r == CCC_RESULT_OK);
         struct Huffman_node const *const internal_one
-            = flat_buffer_emplace_back(
+            = huffman_node_buffer_emplace_back(
                 &ret.tree_storage,
                 allocator,
                 (struct Huffman_node){
@@ -383,17 +488,16 @@ build_encoding_tree(FILE *const f, CCC_Allocator const *const allocator) {
                 }
             );
         size_t const pair_root
-            = flat_buffer_index(&ret.tree_storage, internal_one).count;
+            = huffman_node_buffer_index(&ret.tree_storage, internal_one);
         check(internal_one);
         node_at(&ret, zero.node_index)->parent = pair_root;
         node_at(&ret, one.node_index)->parent = pair_root;
-        struct Pair_node const *const pushed = push(
+        struct Pair_node const *const pushed = pair_priority_queue_push(
             &pairings,
             &(struct Pair_node){
                 .frequency = zero.frequency + one.frequency,
                 .node_index = pair_root,
             },
-            &(struct Pair_node){},
             allocator
         );
         check(pushed);
@@ -405,80 +509,82 @@ build_encoding_tree(FILE *const f, CCC_Allocator const *const allocator) {
 /** Returns a min priority queue sorted by frequency meaning the least frequent
 character will be the root. The priority queue is built in O(N) time. It is
 the caller's responsibility to free the priority queue memory when ready. */
-static Flat_priority_queue
+static struct Pair_node_priority_queue
 build_encoding_priority_queue(
     FILE *const f,
     struct Huffman_tree *const tree,
     CCC_Allocator const *const allocator
 ) {
-    Flat_hash_map frequencies = flat_hash_map_default(
+    struct Character_frequency_map frequencies = {flat_hash_map_default(
         struct Character_frequency,
         ch,
         (CCC_Hasher){.hash = hash_char, .compare = char_order}
-    );
+    )};
     defer {
-        (void)clear_and_free(&frequencies, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(&frequencies.map, &(CCC_Destructor){}, allocator);
     }
     foreach_filechar(f, c, {
-        struct Character_frequency *const ins = flat_hash_map_or_insert_with(
-            flat_hash_map_and_modify_with(
-                flat_hash_map_entry_wrap(&frequencies, c, allocator),
-                struct Character_frequency * e,
-                { ++e->freq; }
-            ),
-            (struct Character_frequency){
-                .ch = *c,
-                .freq = 1,
-            }
-        );
+        struct Character_frequency *const ins
+            = character_frequency_map_increment_entry_or_insert_with(
+                &frequencies,
+                c,
+                allocator,
+                (struct Character_frequency){
+                    .ch = *c,
+                    .freq = 1,
+                }
+            );
         check(ins);
     });
-    size_t const leaves = count(&frequencies).count;
+    size_t const leaves = count(&frequencies.map).count;
     check(leaves >= 2);
     tree->num_leaves = leaves;
     tree->num_nodes = (2 * leaves) - 1;
     /* For a Flat_buffer based tree 0 is the NULL node so we can't have actual
        data we want at that index in the tree. */
-    tree->tree_storage = flat_buffer_from(
+    tree->tree_storage = (struct Huffman_node_buffer){flat_buffer_from(
         *allocator, tree->num_nodes + 1, (struct Huffman_node[]){{}}
-    );
-    check(count(&tree->tree_storage).count == 1);
+    )};
+    check(count(&tree->tree_storage.buffer).count == 1);
     /* Use a Flat_buffer to push back elements we will heapify at the end. */
     Flat_buffer flat_priority_queue_storage = flat_buffer_with_capacity(
-        struct Pair_node, *allocator, flat_hash_map_count(&frequencies).count
+        struct Pair_node,
+        *allocator,
+        flat_hash_map_count(&frequencies.map).count
     );
     check(flat_buffer_capacity(&flat_priority_queue_storage).count);
-    for (struct Character_frequency const *i = begin(&frequencies);
-         i != end(&frequencies);
-         i = next(&frequencies, i)) {
-        struct Huffman_node const *const node = flat_buffer_emplace_back(
-            &tree->tree_storage,
-            &(CCC_Allocator){},
-            (struct Huffman_node){.ch = i->ch}
-        );
+    for (struct Character_frequency const *i = begin(&frequencies.map);
+         i != end(&frequencies.map);
+         i = next(&frequencies.map, i)) {
+        struct Huffman_node const *const node
+            = huffman_node_buffer_emplace_back(
+                &tree->tree_storage,
+                &(CCC_Allocator){},
+                (struct Huffman_node){.ch = i->ch}
+            );
         check(node);
-        CCC_Count index = flat_buffer_index(&tree->tree_storage, node);
-        check(!index.error);
+        size_t const index
+            = huffman_node_buffer_index(&tree->tree_storage, node);
         struct Pair_node const *const pushed = flat_buffer_emplace_back(
             &flat_priority_queue_storage,
             &(CCC_Allocator){},
             (struct Pair_node){
                 .frequency = i->freq,
-                .node_index = index.count,
+                .node_index = index,
             }
         );
         check(pushed);
     }
     /* Now we steal the buffer's memory and heapify the data in O(N) time rather
        than pushing each element. */
-    return flat_priority_queue_heapify(
+    return (struct Pair_node_priority_queue){flat_priority_queue_heapify(
         struct Pair_node,
         CCC_ORDER_LESSER,
         (CCC_Comparator){.compare = order_freqs},
         capacity(&flat_priority_queue_storage).count,
         count(&flat_priority_queue_storage).count,
         begin(&flat_priority_queue_storage)
-    );
+    )};
 }
 
 /** Returns the bit queue representing the bit path to every character in the
@@ -498,7 +604,7 @@ build_encoding_bitq(
        alphabets aka trees with many leaves. An array of 0-256 elements as a map
        could achieve the same result faster but it would waste much more space.
        It is rare to have a file use all 256 possible character values. */
-    Flat_hash_map path_memos = CCC_flat_hash_map_with_capacity(
+    struct Path_memo_map path_memos = {CCC_flat_hash_map_with_capacity(
         struct Path_memo,
         ch,
         ((CCC_Hasher){
@@ -507,11 +613,11 @@ build_encoding_bitq(
         }),
         *allocator,
         tree->num_leaves
-    );
+    )};
     defer {
-        (void)clear_and_free(&path_memos, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(&path_memos.map, &(CCC_Destructor){}, allocator);
     }
-    check(capacity(&path_memos).count >= tree->num_leaves);
+    check(capacity(&path_memos.map).count >= tree->num_leaves);
     foreach_filechar(f, c, {
         /* The entry interface allows us to express the complete memoization
            technique with a single query into our hash map. We either find the
@@ -523,19 +629,20 @@ build_encoding_bitq(
            is vacant. This means that logic or expensive function calls execute
            conditionally. For or_insert_with this is important because appending
            the bit queue is a side-effect. */
-        struct Path_memo const *const p = flat_hash_map_or_insert_with(
-            flat_hash_map_and_modify_with(
-                flat_hash_map_entry_wrap(&path_memos, c, allocator),
+        struct Path_memo const *const p = path_memo_map_or_insert_with(
+            path_memo_map_entry_and_modify_with(
+                &path_memos,
+                c,
+                allocator,
                 struct Path_memo const *const memo,
                 {
                     size_t const end = memo->bitq_start_index + memo->path_len;
                     for (size_t i = memo->bitq_start_index; i < end; ++i) {
-                        CCC_Result const pushed = bitq_push_back(
+                        (void)bitq_push_back(
                             &character_paths,
                             bitq_test(&character_paths, i),
                             allocator
                         );
-                        check(pushed == CCC_RESULT_OK);
                     }
                 }
             ),
@@ -881,21 +988,21 @@ reconstruct_tree(
     size_t const bq_count = bitq_count(&blueprint->tree_paths);
     struct Huffman_tree tree = {
         /* 0 index is NULL so real data can't be there. */
-        .tree_storage = CCC_flat_buffer_from(
+        .tree_storage = {CCC_flat_buffer_from(
             *allocator,
             bq_count,
             (struct Huffman_node[]){
                 {}, /* nil */
                 {}, /* root */
             }
-        ),
+        )},
         /* By creating the root outside of the main loop we can be sure we
            always have valid prev node. Don't need to check on every loop
            iteration. */
         .root = 1,
         .num_nodes = bq_count,
     };
-    check(!flat_buffer_is_empty(&tree.tree_storage));
+    check(!flat_buffer_is_empty(&tree.tree_storage.buffer));
     (void)bitq_pop_front(&blueprint->tree_paths);
     size_t parent = tree.root;
     size_t current = 0;
@@ -905,14 +1012,15 @@ reconstruct_tree(
         CCC_Tribool is_internal_node = CCC_TRUE;
         if (!current) {
             is_internal_node = bitq_pop_front(&blueprint->tree_paths);
-            struct Huffman_node *const pushed = flat_buffer_emplace_back(
-                &tree.tree_storage,
-                allocator,
-                (struct Huffman_node){
-                    .parent = parent,
-                }
-            );
-            current = flat_buffer_index(&tree.tree_storage, pushed).count;
+            struct Huffman_node *const pushed
+                = huffman_node_buffer_emplace_back(
+                    &tree.tree_storage,
+                    allocator,
+                    (struct Huffman_node){
+                        .parent = parent,
+                    }
+                );
+            current = huffman_node_buffer_index(&tree.tree_storage, pushed);
             /* Get the parent reference after the buffer push in case the
                buffer resized to accommodate push. */
             struct Huffman_node *const parent_r = node_at(&tree, parent);
@@ -1010,28 +1118,61 @@ readbytes(FILE *const f, void *const destination, size_t const to_read) {
 
 /*=========================      Huffman Helpers    =========================*/
 
+static inline size_t
+huffman_node_buffer_index(
+    struct Huffman_node_buffer const *const buffer,
+    struct Huffman_node const *const node
+) {
+    return CCC_flat_buffer_index(&buffer->buffer, node).count;
+}
+
+static inline struct Pair_node *
+pair_priority_queue_push(
+    struct Pair_node_priority_queue *const queue,
+    struct Pair_node const *const pair,
+    CCC_Allocator const *const allocator
+) {
+    return push(&queue->priority_queue, pair, &(struct Pair_node){}, allocator);
+}
+
+static inline CCC_Result
+pair_priority_queue_pop(struct Pair_node_priority_queue *const queue) {
+    return pop(&queue->priority_queue, &(struct Pair_node){});
+}
+
+static inline struct Pair_node *
+pair_priority_queue_front(struct Pair_node_priority_queue const *const queue) {
+    return front(&queue->priority_queue);
+}
+
 static struct Huffman_node *
 node_at(struct Huffman_tree const *const t, size_t const node) {
-    return ((struct Huffman_node *)flat_buffer_at(&t->tree_storage, node));
+    return (
+        (struct Huffman_node *)flat_buffer_at(&t->tree_storage.buffer, node)
+    );
 }
 
 static size_t
 branch_index(
     struct Huffman_tree const *const t, size_t const node, uint8_t const dir
 ) {
-    return ((struct Huffman_node *)flat_buffer_at(&t->tree_storage, node))
+    return ((struct Huffman_node *)
+                flat_buffer_at(&t->tree_storage.buffer, node))
         ->link[dir];
 }
 
 static size_t
 parent_index(struct Huffman_tree const *const t, size_t node) {
-    return ((struct Huffman_node *)flat_buffer_at(&t->tree_storage, node))
+    return ((struct Huffman_node *)
+                flat_buffer_at(&t->tree_storage.buffer, node))
         ->parent;
 }
 
 static char
 char_index(struct Huffman_tree const *const t, size_t const node) {
-    return ((struct Huffman_node *)flat_buffer_at(&t->tree_storage, node))->ch;
+    return ((struct Huffman_node *)
+                flat_buffer_at(&t->tree_storage.buffer, node))
+        ->ch;
 }
 
 /** Frees all encoding nodes from the tree provided. */
@@ -1039,8 +1180,9 @@ static void
 free_encode_tree(
     struct Huffman_tree *tree, CCC_Allocator const *const allocator
 ) {
-    CCC_Result const r
-        = clear_and_free(&tree->tree_storage, &(CCC_Destructor){}, allocator);
+    CCC_Result const r = clear_and_free(
+        &tree->tree_storage.buffer, &(CCC_Destructor){}, allocator
+    );
     check(r == CCC_RESULT_OK);
     *tree = (struct Huffman_tree){};
 }

--- a/samples/graph.c
+++ b/samples/graph.c
@@ -104,9 +104,21 @@ struct Point {
     int c;
 };
 
+struct Point_double_ended_queue {
+    CCC_Flat_double_ended_queue flat_double_ended_queue;
+};
+
 struct Path_backtrack_cell {
     struct Point current;
     struct Point parent;
+};
+
+struct Path_backtrack_cell_entry {
+    CCC_Entry entry;
+};
+
+struct Path_backtrack_cell_map {
+    CCC_Flat_hash_map map;
 };
 
 /** A cost optimizes the problem so that we can store the path
@@ -119,6 +131,10 @@ struct Cost {
     int cost;
     char name;
     char from;
+};
+
+struct Cost_priority_queue {
+    CCC_Priority_queue priority_queue;
 };
 
 struct Path_request {
@@ -274,7 +290,10 @@ static void find_shortest_paths(struct Graph *);
 static bool
 found_destination(struct Graph *, struct Vertex *, CCC_Allocator const *);
 static void edge_construct(
-    struct Graph *, Flat_hash_map *, struct Vertex *, struct Vertex *
+    struct Graph *,
+    struct Path_backtrack_cell_map const *,
+    struct Vertex *,
+    struct Vertex *
 );
 static int dijkstra_shortest_path(struct Graph *, char, char);
 static void paint_edge(struct Graph *, char, char, char const *);
@@ -316,6 +335,55 @@ static uint64_t hash_parent_cells(Key_arguments);
 static uint64_t hash_64_bits(uint64_t);
 static unsigned count_digits(uintmax_t);
 static void print_str_view(FILE *, SV_Str_view);
+static struct Path_backtrack_cell_entry
+path_backtrack_cell_map_insert_or_assign(
+    struct Path_backtrack_cell_map *,
+    struct Path_backtrack_cell const *,
+    CCC_Allocator const *
+);
+static struct Path_backtrack_cell_entry path_backtrack_cell_map_try_insert(
+    struct Path_backtrack_cell_map *,
+    struct Path_backtrack_cell const *,
+    CCC_Allocator const *
+);
+static struct Path_backtrack_cell *path_backtrack_cell_map_get_key_value(
+    struct Path_backtrack_cell_map const *, struct Point const *
+);
+static struct Point *
+point_double_ended_queue_front(struct Point_double_ended_queue const *);
+static struct Cost *
+cost_priority_queue_front(struct Cost_priority_queue const *);
+static struct Cost *cost_priority_queue_push(
+    struct Cost_priority_queue *, struct Cost *, CCC_Allocator const *
+);
+
+#define cost_priority_queue_decrease_with(                                     \
+    priority_queue_pointer,                                                    \
+    priority_queue_element_name,                                               \
+    closure_over_priority_queue_element...                                     \
+)                                                                              \
+    (__extension__({                                                           \
+        struct Cost_priority_queue *const cost_priority_queue_pointer          \
+            = (priority_queue_pointer);                                        \
+        CCC_priority_queue_decrease_with(                                      \
+            &cost_priority_queue_pointer->priority_queue,                      \
+            priority_queue_element_name,                                       \
+            closure_over_priority_queue_element                                \
+        );                                                                     \
+    }))
+
+#define point_double_ended_queue_emplace_back(                                 \
+    double_ended_queue_pointer, allocator, compound_literal...                 \
+)                                                                              \
+    (__extension__({                                                           \
+        struct Point_double_ended_queue *const                                 \
+            point_double_ended_queue_pointer = (double_ended_queue_pointer);   \
+        CCC_flat_double_ended_queue_emplace_back(                              \
+            &point_double_ended_queue_pointer->flat_double_ended_queue,        \
+            allocator,                                                         \
+            compound_literal                                                   \
+        );                                                                     \
+    }))
 
 /*======================  Main Arg Handling  ===============================*/
 
@@ -442,7 +510,7 @@ found_destination(
     struct Vertex *const source,
     CCC_Allocator const *const allocator
 ) {
-    Flat_hash_map parent_map = flat_hash_map_from(
+    struct Path_backtrack_cell_map parent_map = {flat_hash_map_from(
         current,
         ((CCC_Hasher){
             .hash = hash_parent_cells,
@@ -453,17 +521,19 @@ found_destination(
         (struct Path_backtrack_cell[]){
             {.current = source->pos, .parent = (struct Point){-1, -1}},
         }
-    );
-    Flat_double_ended_queue bfs = flat_double_ended_queue_from(
+    )};
+    struct Point_double_ended_queue bfs = {flat_double_ended_queue_from(
         *allocator, 0, (struct Point[]){source->pos}
-    );
+    )};
     defer {
-        (void)clear_and_free(&bfs, &(CCC_Destructor){}, allocator);
-        (void)clear_and_free(&parent_map, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(
+            &bfs.flat_double_ended_queue, &(CCC_Destructor){}, allocator
+        );
+        (void)clear_and_free(&parent_map.map, &(CCC_Destructor){}, allocator);
     }
-    while (!is_empty(&bfs)) {
-        struct Point const cur = *((struct Point *)front(&bfs));
-        (void)pop_front(&bfs);
+    while (!is_empty(&bfs.flat_double_ended_queue)) {
+        struct Point const cur = *point_double_ended_queue_front(&bfs);
+        (void)flat_double_ended_queue_pop_front(&bfs.flat_double_ended_queue);
         for (size_t i = 0; i < DIRS_SIZE; ++i) {
             struct Point const next = {
                 .r = cur.r + dirs[i].r,
@@ -479,22 +549,27 @@ found_destination(
                     = vertex_at(graph, get_cell_vertex_title(next_cell));
                 if (source->name != nv->name && vertex_degree(nv) < MAX_DEGREE
                     && !has_edge_with(source, nv->name)) {
-                    Entry const in
-                        = insert_or_assign(&parent_map, &push, allocator);
-                    check(!insert_error(&in));
+                    struct Path_backtrack_cell_entry const in
+                        = path_backtrack_cell_map_insert_or_assign(
+                            &parent_map, &push, allocator
+                        );
+                    check(!insert_error(&in.entry));
                     edge_construct(graph, &parent_map, source, nv);
                     return true;
                 }
             }
-            if (!is_path_cell(next_cell)
-                && !occupied(
-                    flat_hash_map_try_insert_wrap(&parent_map, &push, allocator)
-                )) {
-                struct Point const *const n
-                    = flat_double_ended_queue_emplace_back(
-                        &bfs, allocator, (struct Point){next.r, next.c}
+            if (!is_path_cell(next_cell)) {
+                struct Path_backtrack_cell_entry const entry
+                    = path_backtrack_cell_map_try_insert(
+                        &parent_map, &push, allocator
                     );
-                check(n);
+                if (!occupied(&entry.entry)) {
+                    struct Point const *const n
+                        = point_double_ended_queue_emplace_back(
+                            &bfs, allocator, (struct Point){next.r, next.c}
+                        );
+                    check(n);
+                }
             }
         }
     }
@@ -507,13 +582,14 @@ found_destination(
 static void
 edge_construct(
     struct Graph *const g,
-    Flat_hash_map *const parent_map,
+    struct Path_backtrack_cell_map const *const parent_map,
     struct Vertex *const source,
     struct Vertex *const destination
 ) {
     Cell const edge_id = make_edge(source->name, destination->name);
     struct Point cur = destination->pos;
-    struct Path_backtrack_cell const *c = get_key_value(parent_map, &cur);
+    struct Path_backtrack_cell const *c
+        = path_backtrack_cell_map_get_key_value(parent_map, &cur);
     check(c);
     struct Edge edge = {
         .n = {
@@ -523,7 +599,7 @@ edge_construct(
         .pos = destination->pos,
     };
     while (c->parent.r > 0) {
-        c = get_key_value(parent_map, &c->parent);
+        c = path_backtrack_cell_map_get_key_value(parent_map, &c->parent);
         check(c, printf("Cannot find cell parent to rebuild path.\n"););
         ++edge.n.cost;
         *grid_at_mut(g, c->current.r, c->current.c) |= edge_id;
@@ -759,12 +835,12 @@ dijkstra_shortest_path(
        of all, maximum priority_queue/map size is known to be small [A-Z] so
        provide memory on the stack for speed and safety. */
     struct Cost priority_map[MAX_VERTICES] = {};
-    Priority_queue costs = priority_queue_default(
+    struct Cost_priority_queue costs = {priority_queue_default(
         struct Cost,
         node,
         CCC_ORDER_LESSER,
         (CCC_Comparator){.compare = order_priority_queue_costs}
-    );
+    )};
     for (int i = 0, vx = BEGIN_VERTICES; i < graph->vertices; ++i, ++vx) {
         struct Cost *const v = priority_map_at(priority_map, (char)vx);
         *v = (struct Cost){
@@ -772,12 +848,13 @@ dijkstra_shortest_path(
             .from = '\0',
             .cost = (char)vx == source ? 0 : INT_MAX,
         };
-        struct Cost const *const c = push(&costs, &v->node, &(CCC_Allocator){});
+        struct Cost const *const c
+            = cost_priority_queue_push(&costs, v, &(CCC_Allocator){});
         check(c);
     }
-    while (!is_empty(&costs)) {
-        struct Cost const *const u = front(&costs);
-        (void)pop(&costs, &(CCC_Allocator){});
+    while (!is_empty(&costs.priority_queue)) {
+        struct Cost const *const u = cost_priority_queue_front(&costs);
+        (void)priority_queue_pop(&costs.priority_queue, &(CCC_Allocator){});
         if (u->cost == INT_MAX) {
             return INT_MAX;
         }
@@ -790,7 +867,7 @@ dijkstra_shortest_path(
             int const alt = u->cost + edges[i].cost;
             if (alt < v->cost) {
                 /* Build the map with the appropriate best candidate parent. */
-                (void)priority_queue_decrease_with(&costs, v, {
+                (void)cost_priority_queue_decrease_with(&costs, v, {
                     v->cost = alt;
                     v->from = u->name;
                 });
@@ -1076,6 +1153,59 @@ build_path_outline(struct Graph *const graph) {
 }
 
 /*====================    Data Structure Helpers    =========================*/
+
+static inline struct Path_backtrack_cell_entry
+path_backtrack_cell_map_insert_or_assign(
+    struct Path_backtrack_cell_map *const map,
+    struct Path_backtrack_cell const *const cell,
+    CCC_Allocator const *const allocator
+) {
+    return (struct Path_backtrack_cell_entry){
+        CCC_flat_hash_map_insert_or_assign(&map->map, cell, allocator)};
+}
+
+static inline struct Path_backtrack_cell_entry
+path_backtrack_cell_map_try_insert(
+    struct Path_backtrack_cell_map *const map,
+    struct Path_backtrack_cell const *const cell,
+    CCC_Allocator const *const allocator
+) {
+    return (struct Path_backtrack_cell_entry){
+        CCC_flat_hash_map_try_insert(&map->map, cell, allocator)};
+}
+
+static inline struct Path_backtrack_cell *
+path_backtrack_cell_map_get_key_value(
+    struct Path_backtrack_cell_map const *const map,
+    struct Point const *const point
+) {
+    return CCC_flat_hash_map_get_key_value(&map->map, point);
+}
+
+static inline struct Point *
+point_double_ended_queue_front(
+    struct Point_double_ended_queue const *const queue
+) {
+    return CCC_flat_double_ended_queue_front(&queue->flat_double_ended_queue);
+}
+
+static inline struct Cost *
+cost_priority_queue_front(
+    struct Cost_priority_queue const *const priority_queue
+) {
+    return CCC_priority_queue_front(&priority_queue->priority_queue);
+}
+
+static inline struct Cost *
+cost_priority_queue_push(
+    struct Cost_priority_queue *const priority_queue,
+    struct Cost *const cost,
+    CCC_Allocator const *const allocator
+) {
+    return CCC_priority_queue_push(
+        &priority_queue->priority_queue, &cost->node, allocator
+    );
+}
 
 static CCC_Order
 order_parent_cells(Key_comparator_arguments const c) {

--- a/samples/maze.c
+++ b/samples/maze.c
@@ -69,6 +69,18 @@ struct Prim_cell {
     int cost;
 };
 
+struct Prim_map {
+    CCC_Flat_hash_map map;
+};
+
+struct Prim_map_entry {
+    Entry entry;
+};
+
+struct Prim_priority_queue {
+    CCC_Flat_priority_queue priority_queue;
+};
+
 /*======================   Maze Constants   =================================*/
 
 /** Using these half Unicode squares for now because they create symmetrical
@@ -149,6 +161,22 @@ static SV_Str_view const help_flag = SV_from("-h");
         }                                                                      \
     } while (0)
 
+#define prim_map_entry_or_insert_with(                                         \
+    map_pointer, key_pointer, allocator, lazy_evaluated_key_value_insertion... \
+)                                                                              \
+    (__extension__({                                                           \
+        struct Prim_map *const prim_map_entry_or_insert_pointer                \
+            = (map_pointer);                                                   \
+        flat_hash_map_or_insert_with(                                          \
+            flat_hash_map_entry_wrap(                                          \
+                &prim_map_entry_or_insert_pointer->map,                        \
+                (key_pointer),                                                 \
+                (allocator)                                                    \
+            ),                                                                 \
+            lazy_evaluated_key_value_insertion                                 \
+        );                                                                     \
+    }))
+
 static void animate_maze(struct Maze *, CCC_Allocator const *);
 static void fill_maze_with_walls(struct Maze *);
 static void build_wall(struct Maze *, int, int);
@@ -168,6 +196,14 @@ static struct Int_conversion parse_digits(SV_Str_view);
 static CCC_Order prim_cell_key_order(Key_comparator_arguments);
 static uint64_t prim_cell_hash_fn(Key_arguments);
 static uint64_t hash_64_bits(uint64_t);
+static struct Prim_cell *
+prim_priority_queue_front(struct Prim_priority_queue const *);
+static struct Prim_cell *prim_priority_queue_push(
+    struct Prim_priority_queue *,
+    struct Prim_cell const *,
+    CCC_Allocator const *
+);
+static CCC_Result prim_priority_queue_pop(struct Prim_priority_queue *);
 
 /*======================  Main Arg Handling  ===============================*/
 
@@ -257,7 +293,7 @@ animate_maze(struct Maze *maze, CCC_Allocator const *const allocator) {
         .cell = rand_point(maze),
         .cost = rand_range(0, 100),
     };
-    Flat_hash_map cost_map = flat_hash_map_from(
+    struct Prim_map cost_map = {flat_hash_map_from(
         cell,
         ((CCC_Hasher){
             .hash = prim_cell_hash_fn,
@@ -266,22 +302,23 @@ animate_maze(struct Maze *maze, CCC_Allocator const *const allocator) {
         *allocator,
         capacity,
         (struct Prim_cell[]){start}
-    );
-    Flat_priority_queue cell_priority_queue = flat_priority_queue_from(
+    )};
+    struct Prim_priority_queue cell_priority_queue = {flat_priority_queue_from(
         CCC_ORDER_LESSER,
         (CCC_Comparator){.compare = prim_cell_element_order},
         *allocator,
         capacity,
         (struct Prim_cell[]){start}
-    );
+    )};
     defer {
-        (void)clear_and_free(&cost_map, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(&cost_map.map, &(CCC_Destructor){}, allocator);
         (void)clear_and_free(
-            &cell_priority_queue, &(CCC_Destructor){}, allocator
+            &cell_priority_queue.priority_queue, &(CCC_Destructor){}, allocator
         );
     }
-    while (!is_empty(&cell_priority_queue)) {
-        struct Prim_cell const *const c = front(&cell_priority_queue);
+    while (!is_empty(&cell_priority_queue.priority_queue)) {
+        struct Prim_cell const *const c
+            = prim_priority_queue_front(&cell_priority_queue);
         *maze_at_wrap(maze, c->cell.r, c->cell.c) |= CACHE_BIT;
         /* 0 is an invalid row and column in any maze. */
         struct Prim_cell min_cell = {};
@@ -293,8 +330,10 @@ animate_maze(struct Maze *maze, CCC_Allocator const *const allocator) {
             };
             if (can_build_new_square(maze, n.r, n.c)) {
                 struct Prim_cell const *const cell
-                    = flat_hash_map_or_insert_with(
-                        flat_hash_map_entry_wrap(&cost_map, &n, allocator),
+                    = prim_map_entry_or_insert_with(
+                        &cost_map,
+                        &n,
+                        allocator,
                         (struct Prim_cell){
                             .cell = n,
                             .cost = rand_range(0, 100),
@@ -309,19 +348,35 @@ animate_maze(struct Maze *maze, CCC_Allocator const *const allocator) {
         }
         if (min != INT_MAX) {
             join_squares_animated(maze, c->cell, min_cell.cell, speed);
-            (void)push(
-                &cell_priority_queue,
-                &min_cell,
-                &(struct Prim_cell){},
-                allocator
+            (void)prim_priority_queue_push(
+                &cell_priority_queue, &min_cell, allocator
             );
         } else {
-            (void)pop(&cell_priority_queue, &(struct Prim_cell){});
+            (void)prim_priority_queue_pop(&cell_priority_queue);
         }
     }
 }
 
 /*===================     Container Support Code     ========================*/
+
+static inline struct Prim_cell *
+prim_priority_queue_front(struct Prim_priority_queue const *const queue) {
+    return front(&queue->priority_queue);
+}
+
+static inline struct Prim_cell *
+prim_priority_queue_push(
+    struct Prim_priority_queue *const queue,
+    struct Prim_cell const *const cell,
+    CCC_Allocator const *const allocator
+) {
+    return push(&queue->priority_queue, cell, &(struct Prim_cell){}, allocator);
+}
+
+static inline CCC_Result
+prim_priority_queue_pop(struct Prim_priority_queue *const queue) {
+    return pop(&queue->priority_queue, &(struct Prim_cell){});
+}
 
 static CCC_Order
 prim_cell_key_order(Key_comparator_arguments const c) {

--- a/samples/words.c
+++ b/samples/words.c
@@ -51,6 +51,18 @@ typedef struct {
     int freq;
 } Word;
 
+typedef struct {
+    Handle handle;
+} Word_handle;
+
+typedef struct {
+    Array_adaptive_map map;
+} Word_map;
+
+typedef struct {
+    Flat_buffer buffer;
+} Word_buffer;
+
 struct Action_pack {
     SV_Str_view file;
     enum Action_type type;
@@ -112,29 +124,70 @@ static SV_Str_view const directions = SV_from(
         }                                                                      \
     } while (0)
 
+#define foreach_map_word(                                                      \
+    word_map_pointer, word_iterator_type_declaration, code_block...            \
+)                                                                              \
+    for (Handle_index word_map_handle_index = begin(&(word_map_pointer)->map); \
+         word_map_handle_index != end(&(word_map_pointer)->map);               \
+         word_map_handle_index                                                 \
+         = next(&(word_map_pointer)->map, word_map_handle_index)) {            \
+        word_iterator_type_declaration = array_adaptive_map_at(                \
+            &(word_map_pointer)->map, word_map_handle_index                    \
+        );                                                                     \
+        code_block                                                             \
+    }
+
+#define foreach_map_word_reverse(                                              \
+    word_map_pointer, word_iterator_type_declaration, code_block...            \
+)                                                                              \
+    for (Handle_index word_map_handle_index                                    \
+         = reverse_begin(&(word_map_pointer)->map);                            \
+         word_map_handle_index != reverse_end(&(word_map_pointer)->map);       \
+         word_map_handle_index                                                 \
+         = reverse_next(&(word_map_pointer)->map, word_map_handle_index)) {    \
+        word_iterator_type_declaration = array_adaptive_map_at(                \
+            &(word_map_pointer)->map, word_map_handle_index                    \
+        );                                                                     \
+        code_block                                                             \
+    }
+
+#define foreach_buffer_word(                                                   \
+    word_buffer_pointer, word_iterator_type_declaration, code_block...         \
+)                                                                              \
+    for (Word *foreach_buffer_word_iterator                                    \
+         = begin(&(word_buffer_pointer)->buffer);                              \
+         foreach_buffer_word_iterator != end(&(word_buffer_pointer)->buffer);  \
+         foreach_buffer_word_iterator = next(                                  \
+             &(word_buffer_pointer)->buffer, foreach_buffer_word_iterator      \
+         )) {                                                                  \
+        word_iterator_type_declaration = foreach_buffer_word_iterator;         \
+        code_block                                                             \
+    }
+
 static void print_found(FILE *, SV_Str_view, CCC_Allocator const *);
 static void print_top_n(FILE *, size_t, CCC_Allocator const *);
 static void print_last_n(FILE *, size_t, CCC_Allocator const *);
 static void print_alpha_n(FILE *, size_t, CCC_Allocator const *);
 static void print_ralpha_n(FILE *, size_t, CCC_Allocator const *);
-static Flat_buffer
-map_to_buffer(Array_adaptive_map const *, CCC_Allocator const *);
+static Word_buffer map_to_buffer(Word_map const *, CCC_Allocator const *);
 static void print_n(
-    Array_adaptive_map *,
-    CCC_Order,
-    struct String_arena *,
-    size_t,
-    CCC_Allocator const *
+    Word_map *, CCC_Order, struct String_arena *, size_t, CCC_Allocator const *
 );
 static struct Int_conversion parse_n_ranks(SV_Str_view);
 static struct String_offset
 clean_word(struct String_arena *, SV_Str_view, CCC_Allocator const *);
-static Array_adaptive_map
+static Word_map
 create_frequency_map(struct String_arena *, FILE *, CCC_Allocator const *);
 static Order order_string_keys(Key_comparator_arguments);
 static Order order_words(Comparator_arguments);
 static FILE *open_file(SV_Str_view);
 static void print_str_view(FILE *, SV_Str_view);
+static Word_handle
+word_try_insert(Word_map *, Word const *, CCC_Allocator const *);
+static Word *word_at(Word_map const *, Word_handle const *);
+static Word *word_get_key_value(Word_map *, struct String_offset const *);
+static CCC_Result
+word_buffer_sort(Word_buffer const *, CCC_Order, struct String_arena *);
 
 /*=======================     Main         ==================================*/
 
@@ -240,19 +293,18 @@ print_found(
     FILE *const f, SV_Str_view w, CCC_Allocator const *const allocator
 ) {
     struct String_arena a = string_arena_create(ARENA_START_CAP, allocator);
-    Array_adaptive_map map = create_frequency_map(&a, f, allocator);
+    Word_map map = create_frequency_map(&a, f, allocator);
     defer {
         string_arena_free(&a, allocator);
         (void)array_adaptive_map_clear_and_free(
-            &map, &(CCC_Destructor){}, allocator
+            &map.map, &(CCC_Destructor){}, allocator
         );
     }
     check(a.arena);
-    check(!is_empty(&map));
+    check(!is_empty(&map.map));
     struct String_offset wc = clean_word(&a, w, allocator);
     if (!wc.error) {
-        Word const *const found_w
-            = array_adaptive_map_at(&map, get_key_value(&map, &wc));
+        Word const *const found_w = word_get_key_value(&map, &wc);
         if (found_w) {
             printf(
                 "%s %d\n", string_arena_at(&a, &found_w->ofs), found_w->freq
@@ -264,85 +316,82 @@ print_found(
 static void
 print_top_n(FILE *const f, size_t n, CCC_Allocator const *const allocator) {
     struct String_arena a = string_arena_create(ARENA_START_CAP, allocator);
-    Array_adaptive_map map = create_frequency_map(&a, f, allocator);
+    Word_map map = create_frequency_map(&a, f, allocator);
     defer {
-        (void)clear_and_free(&map, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(&map.map, &(CCC_Destructor){}, allocator);
         string_arena_free(&a, allocator);
     }
     check(a.arena);
-    check(!is_empty(&map));
+    check(!is_empty(&map.map));
     print_n(&map, CCC_ORDER_GREATER, &a, n, allocator);
 }
 
 static void
 print_last_n(FILE *const f, size_t n, CCC_Allocator const *const allocator) {
     struct String_arena a = string_arena_create(ARENA_START_CAP, allocator);
-    Array_adaptive_map map = create_frequency_map(&a, f, allocator);
+    Word_map map = create_frequency_map(&a, f, allocator);
     defer {
-        (void)clear_and_free(&map, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(&map.map, &(CCC_Destructor){}, allocator);
         string_arena_free(&a, allocator);
     }
     check(a.arena);
-    check(!is_empty(&map));
+    check(!is_empty(&map.map));
     print_n(&map, CCC_ORDER_LESSER, &a, n, allocator);
 }
 
 static void
 print_alpha_n(FILE *const f, size_t n, CCC_Allocator const *const allocator) {
     struct String_arena a = string_arena_create(ARENA_START_CAP, allocator);
-    Array_adaptive_map map = create_frequency_map(&a, f, allocator);
+    Word_map map = create_frequency_map(&a, f, allocator);
     defer {
-        (void)clear_and_free(&map, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(&map.map, &(CCC_Destructor){}, allocator);
         string_arena_free(&a, allocator);
     }
     check(a.arena);
-    check(!is_empty(&map));
+    check(!is_empty(&map.map));
     if (!n) {
-        n = count(&map).count;
+        n = count(&map.map).count;
     }
     /* The ordered nature of the map comes in handy for alpha printing. */
-    for (CCC_Handle_index iter = begin(&map), i = 0; iter != end(&map) && i < n;
-         iter = next(&map, iter), ++i) {
-        Word const *const w = array_adaptive_map_at(&map, iter);
+    foreach_map_word(&map, Word const *const w, {
         printf("%s %d\n", string_arena_at(&a, &w->ofs), w->freq);
-    }
+    });
 }
 
 static void
 print_ralpha_n(FILE *const f, size_t n, CCC_Allocator const *const allocator) {
     struct String_arena a = string_arena_create(ARENA_START_CAP, allocator);
-    Array_adaptive_map map = create_frequency_map(&a, f, allocator);
+    Word_map map = create_frequency_map(&a, f, allocator);
     defer {
-        (void)clear_and_free(&map, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(&map.map, &(CCC_Destructor){}, allocator);
         string_arena_free(&a, allocator);
     }
     check(a.arena);
-    check(!is_empty(&map));
+    check(!is_empty(&map.map));
     if (!n) {
-        n = count(&map).count;
+        n = count(&map.map).count;
     }
     /* The ordered nature of the map comes in handy for reverse iteration. */
-    for (CCC_Handle_index iter = reverse_begin(&map), i = 0;
-         iter != reverse_end(&map) && i < n;
-         iter = reverse_next(&map, iter), ++i) {
-        Word const *const w = array_adaptive_map_at(&map, iter);
+    foreach_map_word_reverse(&map, Word const *const w, {
         printf("%s %d\n", string_arena_at(&a, &w->ofs), w->freq);
-    }
+    });
 }
 
-static Flat_buffer
-map_to_buffer(
-    Array_adaptive_map const *const map, CCC_Allocator const *const allocator
-) {
-    check(!is_empty(map));
-    Flat_buffer freqs
-        = CCC_flat_buffer_with_capacity(Word, *allocator, count(map).count);
-    size_t const cap = capacity(&freqs).count;
-    for (CCC_Handle_index iter = begin(map), i = 0; iter != end(map) && i < cap;
-         iter = next(map, iter), ++i) {
-        Word const *const w = array_adaptive_map_at(map, iter);
+static Word_buffer
+map_to_buffer(Word_map const *const map, CCC_Allocator const *const allocator) {
+    check(!is_empty(&map->map));
+    Word_buffer freqs = {CCC_flat_buffer_with_capacity(
+        Word, *allocator, count(&map->map).count
+    )};
+    size_t const cap = capacity(&freqs.buffer).count;
+    for (CCC_Handle_index iter = begin(&map->map), i = 0;
+         iter != end(&map->map) && i < cap;
+         iter = next(&map->map, iter), ++i) {
+        Word const *const w = array_adaptive_map_at(&map->map, iter);
         Word const *const pushed = flat_buffer_emplace_back(
-            &freqs, &(CCC_Allocator){}, (Word){.ofs = w->ofs, .freq = w->freq}
+            &freqs.buffer,
+            &(CCC_Allocator){},
+            (Word){.ofs = w->ofs, .freq = w->freq}
         );
         check(pushed);
     }
@@ -351,43 +400,38 @@ map_to_buffer(
 
 static void
 print_n(
-    CCC_Array_adaptive_map *const map,
+    Word_map *const map,
     CCC_Order const order,
     struct String_arena *const arena,
     size_t n,
     CCC_Allocator const *const allocator
 ) {
-    Flat_buffer freqs = map_to_buffer(map, allocator);
+    Word_buffer freqs = map_to_buffer(map, allocator);
     defer {
-        (void)clear_and_free(&freqs, &(CCC_Destructor){}, allocator);
+        (void)clear_and_free(&freqs.buffer, &(CCC_Destructor){}, allocator);
     }
-    check(!flat_buffer_is_empty(&freqs));
+    check(!flat_buffer_is_empty(&freqs.buffer));
     if (!n) {
-        n = count(&freqs).count;
+        n = count(&freqs.buffer).count;
     }
-    CCC_Result const result = CCC_sort_heapsort(
-        &freqs,
-        &(Word){},
-        order,
-        &(CCC_Comparator){
-            .compare = order_words,
-            .context = arena,
-        }
-    );
+    CCC_Result const result = word_buffer_sort(&freqs, order, arena);
     check(result == CCC_RESULT_OK);
     size_t w = 0;
-    for (Word const *i = begin(&freqs); i != end(&freqs) && w < n;
-         i = next(&freqs, i), ++w) {
+    foreach_buffer_word(&freqs, Word const *const i, {
         char const *const arena_str = string_arena_at(arena, &i->ofs);
         if (arena_str) {
             printf("%zu. %s %d\n", w + 1, arena_str, i->freq);
         }
-    }
+        ++w;
+        if (w >= n) {
+            return;
+        }
+    });
 }
 
 /*=====================    Container Construction     =======================*/
 
-static Array_adaptive_map
+static Word_map
 create_frequency_map(
     struct String_arena *const arena,
     FILE *const f,
@@ -399,14 +443,14 @@ create_frequency_map(
     }
     size_t len = 0;
     ptrdiff_t read = 0;
-    Array_adaptive_map array_adaptive_map = array_adaptive_map_default(
+    Word_map map = {array_adaptive_map_default(
         Word,
         ofs,
         (CCC_Key_comparator){
             .compare = order_string_keys,
             .context = arena,
         }
-    );
+    )};
     while ((read = getline(&linepointer, &len, f)) > 0) {
         SV_Str_view const line = {.str = linepointer, .len = (size_t)read - 1};
         for (SV_Str_view word_view = SV_token_begin(line, space);
@@ -417,19 +461,15 @@ create_frequency_map(
             if (cw.error) {
                 continue;
             }
-            CCC_Handle_index const i = array_adaptive_map_or_insert_with(
-                array_adaptive_map_and_modify_with(
-                    array_adaptive_map_handle_wrap(&array_adaptive_map, &cw),
-                    Word * e,
-                    { e->freq++; }
-                ),
-                allocator,
-                (Word){.ofs = cw, .freq = 1}
+            Word_handle const handle = word_try_insert(
+                &map, &(Word){.ofs = cw, .freq = 1}, allocator
             );
-            check(i);
+            if (occupied(&handle.handle)) {
+                word_at(&map, &handle)->freq++;
+            }
         }
     }
-    return array_adaptive_map;
+    return map;
 }
 
 static struct String_offset
@@ -467,6 +507,48 @@ clean_word(
 }
 
 /*=======================   Container Helpers    ============================*/
+
+static inline Word *
+word_get_key_value(Word_map *const map, struct String_offset const *const key) {
+    return array_adaptive_map_at(
+        &map->map, array_adaptive_map_get_key_value(&map->map, key)
+    );
+}
+
+static inline Word_handle
+word_try_insert(
+    Word_map *const map,
+    Word const *const word,
+    CCC_Allocator const *const allocator
+) {
+    return (Word_handle){
+        array_adaptive_map_try_insert(&map->map, word, allocator)};
+}
+
+static inline Word *
+word_at(Word_map const *const map, Word_handle const *const handle) {
+    Word *const word
+        = array_adaptive_map_at(&map->map, unwrap(&handle->handle));
+    check(word);
+    return word;
+}
+
+static inline CCC_Result
+word_buffer_sort(
+    Word_buffer const *const words,
+    CCC_Order const order,
+    struct String_arena *const arena
+) {
+    return CCC_sort_heapsort(
+        &words->buffer,
+        &(Word){},
+        order,
+        &(CCC_Comparator){
+            .compare = order_words,
+            .context = arena,
+        }
+    );
+}
 
 static Order
 order_string_keys(Key_comparator_arguments const c) {


### PR DESCRIPTION
With generic containers using `void *` people complain of no type safety. This is not true. We can wrap every container in a struct and write inline one-line functions that accept only that wrapper and the type that it stores. We get type checking for free at compile time. We do not incur any cost at runtime. We only wrap the functions we use; there is no need to wrap simple getters or functions that do not need type information. Finally, we do not bloat our binary with any additional code or template-style C.

Here is an example from the samples. A large code base using this discipline can be much more manageable.

```c
struct Pair_node {
    size_t frequency;
    size_t node_index;
};

struct Pair_node_priority_queue {
    CCC_Flat_priority_queue priority_queue;
};

static inline struct Pair_node *
pair_priority_queue_push(
    struct Pair_node_priority_queue *const queue,
    struct Pair_node const *const pair,
    CCC_Allocator const *const allocator
) {
    return push(&queue->priority_queue, pair, &(struct Pair_node){}, allocator);
}

static inline CCC_Result
pair_priority_queue_pop(struct Pair_node_priority_queue *const queue) {
    return pop(&queue->priority_queue, &(struct Pair_node){});
}

static inline struct Pair_node *
pair_priority_queue_front(struct Pair_node_priority_queue const *const queue) {
    return front(&queue->priority_queue);
}
```

We can even wrap complex macros that use closures or variadic arguments to enforce type safety with the help of statement expressions.

```c
struct Path_memo {
    char ch;
    size_t bitq_start_index;
    size_t path_len;
};

struct Path_memo_map {
    CCC_Flat_hash_map map;
};

#define path_memo_map_entry_and_modify_with(                                   \
    map_pointer,                                                               \
    character_key_pointer,                                                     \
    allocator,                                                                 \
    occupied_path_memo_entry_declaration,                                      \
    modification_closure_over_occupied_path_memo_entry...                      \
)                                                                              \
    &(struct { CCC_Flat_hash_map_entry private; }){(__extension__({            \
         struct Path_memo_map *const path_memo_map_pointer = (map_pointer);    \
         char const *const path_memo_map_character_key                         \
             = (character_key_pointer);                                        \
         CCC_Flat_hash_map_entry path_memo_map_entry                           \
             = *flat_hash_map_and_modify_with(                                 \
                 flat_hash_map_entry_wrap(                                     \
                     &path_memo_map_pointer->map,                              \
                     path_memo_map_character_key,                              \
                     (allocator)                                               \
                 ),                                                            \
                 occupied_path_memo_entry_declaration,                         \
                 modification_closure_over_occupied_path_memo_entry            \
             );                                                                \
         path_memo_map_entry;                                                  \
     }))}.private

#define path_memo_map_or_insert_with(                                          \
    entry_pointer, lazy_evaluated_insertion...                                 \
)                                                                              \
    (__extension__({                                                           \
        flat_hash_map_or_insert_with(entry_pointer, lazy_evaluated_insertion); \
    }))
```

The usage.

```c
/** Returns the bit queue representing the bit path to every character in the
file. This queue represents each byte of the file in order; the first path
at the front of the queue represents the first character. */
static struct Bit_queue
build_encoding_bitq(
    FILE *const f,
    struct Huffman_tree *const tree,
    CCC_Allocator const *const allocator
) {
    struct Bit_queue character_paths = {
        .bs = flat_bitset_default(),
    };
    struct Path_memo_map path_memos = {CCC_flat_hash_map_with_capacity(
        struct Path_memo,
        ch,
        ((CCC_Hasher){
            .hash = hash_char,
            .compare = path_memo_order,
        }),
        *allocator,
        tree->num_leaves
    )};
    defer {
        (void)clear_and_free(&path_memos.map, &(CCC_Destructor){}, allocator);
    }
    check(capacity(&path_memos.map).count >= tree->num_leaves);
    foreach_filechar(f, c, {
        struct Path_memo const *const p = path_memo_map_or_insert_with(
            path_memo_map_entry_and_modify_with(
                &path_memos,
                c,
                allocator,
                struct Path_memo const *const memo,
                {
                    size_t const end = memo->bitq_start_index + memo->path_len;
                    for (size_t i = memo->bitq_start_index; i < end; ++i) {
                        (void)bitq_push_back(
                            &character_paths,
                            bitq_test(&character_paths, i),
                            allocator
                        );
                    }
                }
            ),
            append_tree_path_to_bitq(tree, &character_paths, *c, allocator)
        );
        check(p);
    });
    return character_paths;
}
```