### PR TITLE
Check `CCC_Flat_hash_map` inputs via `stdckdint.h`.

### DIFF
--- a/.github/workflows/sanitizer_build.yml
+++ b/.github/workflows/sanitizer_build.yml
@@ -39,6 +39,8 @@ jobs:
     name: GCC Sanitize ${{ matrix.build == 'debug' && 'Debug' || 'Release' }} - ${{ matrix.portable == 'ON' && 'Portable SRMD Flat Hash Map' || 'Platform SIMD Flat Hash Map' }}
     needs: check-diff
     if: ${{ needs.check-diff.outputs.handle == 'true' }}
+    env:
+      GCC_VERSION: 14
 
     strategy:
       matrix:
@@ -49,7 +51,7 @@ jobs:
     - name: Set up GCC
       uses: egor-tensin/setup-gcc@v2
       with:
-        version: latest
+        version: ${{ env.GCC_VERSION }}
         platform: x64
         
     - name: Checkout code
@@ -60,5 +62,5 @@ jobs:
     - name: Build Address and UB Sanitizers with GCC
       run: |
         make clean
-        cmake --preset=gcc-sanitize-${{ matrix.build }} -DCCC_BUILD_SPECIALIZED=ON -DCCC_FLAT_HASH_MAP_PORTABLE=${{ matrix.portable }} && cmake --build build -j$(nproc) --target ccc tests
+        cmake --preset=gcc-sanitize-${{ matrix.build }} -DCMAKE_C_COMPILER=gcc-${{ env.GCC_VERSION }} -DCCC_BUILD_SPECIALIZED=ON -DCCC_FLAT_HASH_MAP_PORTABLE=${{ matrix.portable }} && cmake --build build -j$(nproc) --target ccc tests
         make test

--- a/.github/workflows/sanitizer_build.yml
+++ b/.github/workflows/sanitizer_build.yml
@@ -40,7 +40,7 @@ jobs:
     needs: check-diff
     if: ${{ needs.check-diff.outputs.handle == 'true' }}
     env:
-      GCC_VERSION: 14
+      GCC_VERSION: 15
 
     strategy:
       matrix:

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -1613,7 +1613,8 @@ total bytes. This means that `size_t` can no longer index the needed bytes for
 the provided mask capacity. If no overflow occurs the function returns false
 and the result of the arithmetic is stored in result. Use this version when
 requesting a new allocation from un-trusted user input. Use the unchecked
-version when a valid allocation has already been established.
+version when a valid allocation has already been established on a valid hash
+map.
 
 This calculation includes the bytes for the user data array (swap index
 included) and the tag array. The tag array also has an duplicate group at the

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -1245,8 +1245,8 @@ for insertion. Rehashing in place repeatedly can be expensive so the user
 should ensure to select an appropriate capacity for fixed size tables. */
 static void
 rehash_in_place(struct CCC_Flat_hash_map *const map) {
-    assert((map->mask + 1) % GROUP_COUNT == 0);
-    assert(map->tag && map->data);
+    assert((map->mask + 1) % GROUP_COUNT == 0 && "Capacity is group aligned.");
+    assert(map->tag && map->data && "Map is initialized.");
     size_t const mask = map->mask;
     for (size_t i = 0; i < mask + 1; i += GROUP_COUNT) {
         group_store_aligned(

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -34,6 +34,7 @@ better capabilities for 128 bit group operations. */
 /** C23 provided headers. */
 #include <limits.h>
 #include <stdalign.h>
+#include <stdckdint.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -315,6 +316,7 @@ static void *key_in_index(struct CCC_Flat_hash_map const *, void const *);
 static void *swap_index(struct CCC_Flat_hash_map const *);
 static CCC_Count data_index(struct CCC_Flat_hash_map const *, void const *);
 static size_t mask_to_total_bytes(size_t, size_t);
+static CCC_Tribool checked_mask_to_total_bytes(size_t *, size_t, size_t);
 static size_t mask_to_tag_bytes(size_t);
 static size_t mask_to_data_bytes(size_t, size_t);
 static void set_insert_tag(
@@ -1212,11 +1214,12 @@ maybe_rehash(
     if (unlikely(!map->mask && !allocator->allocate)) {
         return CCC_RESULT_NO_ALLOCATION_FUNCTION;
     }
-    size_t const required_total_cap
-        = to_power_of_two(((map->count + to_add) * 8) / 7);
-    if (!required_total_cap) {
+    size_t required_total_cap = 0;
+    if (ckd_add(&required_total_cap, map->count, to_add)
+        || ckd_mul(&required_total_cap, required_total_cap, 8)) {
         return CCC_RESULT_ALLOCATOR_ERROR;
     }
+    required_total_cap = to_power_of_two(required_total_cap / 7);
     CCC_Result const init = lazy_initialize(map, required_total_cap, allocator);
     if (init != CCC_RESULT_OK) {
         return init;
@@ -1349,15 +1352,19 @@ rehash_resize(
     CCC_Allocator const *const allocator
 ) {
     assert(((map->mask + 1) & map->mask) == 0);
-    size_t const new_pow2_cap
-        = next_power_of_two((map->mask + 1 + to_add) << 1);
+    size_t new_pow2_cap = 0;
+    if (ckd_add(&new_pow2_cap, (map->mask + 1), to_add)
+        || ckd_mul(&new_pow2_cap, new_pow2_cap, 2)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
+    new_pow2_cap = next_power_of_two(new_pow2_cap);
     if (new_pow2_cap < (map->mask + 1)) {
         return CCC_RESULT_ALLOCATOR_ERROR;
     }
-    size_t const prev_bytes = mask_to_total_bytes(map->sizeof_type, map->mask);
-    size_t const total_bytes
-        = mask_to_total_bytes(map->sizeof_type, new_pow2_cap - 1);
-    if (total_bytes < prev_bytes) {
+    size_t total_bytes = 0;
+    if (checked_mask_to_total_bytes(
+            &total_bytes, map->sizeof_type, new_pow2_cap - 1
+        )) {
         return CCC_RESULT_ALLOCATOR_ERROR;
     }
     void *const new_buf = allocator->allocate((CCC_Allocator_arguments){
@@ -1444,8 +1451,12 @@ lazy_initialize(
     } else {
         /* A dynamic map we can re-size as needed. */
         required_capacity = max_size_t(required_capacity, GROUP_COUNT);
-        size_t const total_bytes
-            = mask_to_total_bytes(map->sizeof_type, required_capacity - 1);
+        size_t total_bytes = 0;
+        if (checked_mask_to_total_bytes(
+                &total_bytes, map->sizeof_type, required_capacity - 1
+            )) {
+            return CCC_RESULT_ALLOCATOR_ERROR;
+        }
         map->data = allocator->allocate((CCC_Allocator_arguments){
             .input = NULL,
             .bytes = total_bytes,
@@ -1594,26 +1605,48 @@ mask_to_total_bytes(size_t const sizeof_type, size_t const mask) {
     return mask_to_data_bytes(sizeof_type, mask) + mask_to_tag_bytes(mask);
 }
 
-/** Returns the bytes needed for the tag metadata array. This includes the
-bytes for the duplicate group that is at the end of the tag array.
+/** Returns true if overflow occurred during necessary arithmetic to determine
+total bytes. This means that `size_t` can no longer index the needed bytes for
+the provided mask capacity. If no overflow occurs the function returns false
+and the result of the arithmetic is stored in result. Use this version when
+requesting a new allocation from un-trusted user input. Use the unchecked
+version when a valid allocation has already been established.
 
-Assumes the mask is non-zero. */
-static inline size_t
-mask_to_tag_bytes(size_t const mask) {
-    static_assert(sizeof(struct CCC_Flat_hash_map_tag) == sizeof(uint8_t));
-    return mask + 1 + GROUP_COUNT;
-}
+This calculation includes the bytes for the user data array (swap index
+included) and the tag array. The tag array also has an duplicate group at the
+end that must be counted.
 
-/** Returns the capacity count that is available with a current load factor of
-87.5% percent. The returned count is the maximum allowable capacity that can
-store user tags and data before the load factor is reached. The total capacity
-of the table is (mask + 1) which is not the capacity that this function
-calculates. For example, if (mask + 1 = 64), then this function returns 56.
+This calculation includes any unusable padding bytes added to the end of the
+user data array. Padding may be required if the alignment of the user type is
+less than that of a group size. This will allow aligned group loads.
 
-Assumes the mask is non-zero. */
-static inline size_t
-mask_to_capacity_with_load_factor(size_t const mask) {
-    return ((mask + 1) / 8) * 7;
+This number of bytes should be consistently correct whether the map we are
+dealing with is fixed size or dynamic. A fixed size map could technically have
+more bytes as padding after the tag array but we never need or access those
+bytes so we are only interested in contiguous bytes from start of user data to
+last byte of tag array. */
+static inline CCC_Tribool
+checked_mask_to_total_bytes(
+    size_t *const result, size_t const sizeof_type, size_t const mask
+) {
+    assert(
+        mask + 2 + GROUP_COUNT > mask
+        && "mask is a valid power of 2 meaning adding GROUP_COUNT + 2 will not "
+           "overflow"
+    );
+    *result = 0;
+    if (unlikely(!mask)) {
+        return CCC_FALSE;
+    }
+    if (ckd_mul(result, sizeof_type, (mask + 2))
+        || ckd_add(result, *result, (GROUP_COUNT - 1))) {
+        return CCC_TRUE;
+    }
+    *result &= ~(GROUP_COUNT - 1U);
+    if (ckd_add(result, *result, (mask + 1U + GROUP_COUNT))) {
+        return CCC_TRUE;
+    }
+    return CCC_FALSE;
 }
 
 /** Returns the number of bytes taken by the user data array. This includes the
@@ -1630,8 +1663,30 @@ static inline size_t
 mask_to_data_bytes(size_t const sizeof_type, size_t const mask) {
     /* Add two because there is always a bonus user data type at the last index
        of the data array for swapping purposes. */
-    return ((sizeof_type * (mask + 2)) + GROUP_COUNT - 1)
-         & (size_t)~(GROUP_COUNT - 1);
+    return ((sizeof_type * (mask + 2)) + GROUP_COUNT - 1U)
+         & ~(GROUP_COUNT - 1U);
+}
+
+/** Returns the bytes needed for the tag metadata array. This includes the
+bytes for the duplicate group that is at the end of the tag array.
+
+Assumes the mask is non-zero. */
+static inline size_t
+mask_to_tag_bytes(size_t const mask) {
+    static_assert(sizeof(struct CCC_Flat_hash_map_tag) == sizeof(uint8_t));
+    return mask + 1U + GROUP_COUNT;
+}
+
+/** Returns the capacity count that is available with a current load factor of
+87.5% percent. The returned count is the maximum allowable capacity that can
+store user tags and data before the load factor is reached. The total capacity
+of the table is (mask + 1) which is not the capacity that this function
+calculates. For example, if (mask + 1 = 64), then this function returns 56.
+
+Assumes the mask is non-zero. */
+static inline size_t
+mask_to_capacity_with_load_factor(size_t const mask) {
+    return ((mask + 1) / 8) * 7;
 }
 
 /** Returns the correct position of the start of the tag array given the base

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -1204,7 +1204,8 @@ may be needed. While containers normally remember their own allocation
 permissions, this function may be called in a variety of scenarios; one of which
 is when the user wants to reserve the necessary space dynamically at runtime
 but only once and for a container that is not given permission to resize
-arbitrarily. */
+arbitrarily. If overflow of addition or multiplication occurs an allocator error
+is returned. */
 static CCC_Result
 maybe_rehash(
     struct CCC_Flat_hash_map *const map,

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -1346,6 +1346,8 @@ is_same_group(
         == (((new_index - (hash & mask)) & mask) / GROUP_COUNT);
 }
 
+/** Handles resizing and rehashing of a hash table to allow for to_add elements.
+If overflow occurs and allocator error is returned. */
 static CCC_Result
 rehash_resize(
     struct CCC_Flat_hash_map *const map,

--- a/tests/checkers.c
+++ b/tests/checkers.c
@@ -1,8 +1,10 @@
+#include <stdbool.h>
 #include <stdio.h>
 
 #include "checkers.h"
 
 unsigned check_random_seed = 0;
+enum Check_result check_process_result = CHECK_PASS;
 
 void
 check_print_fail_message(
@@ -15,6 +17,7 @@ check_print_fail_message(
     bool const is_address,
     unsigned const random_seed
 ) {
+    check_process_result = CHECK_FAIL;
     if (is_address) {
         (void)fprintf(
             stderr,

--- a/tests/checkers.c
+++ b/tests/checkers.c
@@ -2,6 +2,8 @@
 
 #include "checkers.h"
 
+unsigned check_random_seed = 0;
+
 void
 check_print_fail_message(
     char const *const function_string,

--- a/tests/checkers.h
+++ b/tests/checkers.h
@@ -9,9 +9,10 @@ file. */
 #ifndef CHECKERS_H
 #define CHECKERS_H
 
-#include <stdint.h>
-#include <stdlib.h> /* IWYU pragma: keep */
-#include <time.h>   /* IWYU pragma: keep */
+#include <stdbool.h> /* IWYU pragma: keep */
+#include <stdint.h>  /* IWYU pragma: keep */
+#include <stdlib.h>  /* IWYU pragma: keep */
+#include <time.h>    /* IWYU pragma: keep */
 
 #define CHECK_RED "\033[38;5;9m"
 #define CHECK_GREEN "\033[38;5;10m"
@@ -61,6 +62,14 @@ void check_print_fail_message(
 /** The global variable seed for the entire test checker harness. This is
 seeded before any tests run in the check_run macro. */
 extern unsigned check_random_seed;
+
+/** The global failure state for this test process. We run tests in
+deterministic order via C expressions within parenthesis. This ensures random
+seed reporting is meaningful across the failure that occurred given the user
+provided test function list. We cannot capture individual return values via the
+user provided variadic test function list when we place them within parentheses
+(test0(), test1()). So we will set the failure state globally, sadly. */
+extern enum Check_result check_process_result;
 
 /** Provides the correct type to the union for a check expression while
 silencing compiler warnings for non-compiled generic branches. Substitution
@@ -383,17 +392,8 @@ individual test that failed with CHECK_FAIL or CHECK_ERROR. */
            first. */                                                           \
         check_random_seed = (unsigned)time(NULL); /* NOLINT */                 \
         srand(check_random_seed);                 /* NOLINT */                 \
-        enum Check_result const check_private_all_checks[] = {test_fn_list};   \
-        enum Check_result check_private_all_checks_res = CHECK_PASS;           \
-        for (unsigned long long check_run_index = 0;                           \
-             check_run_index                                                   \
-             < sizeof(check_private_all_checks) / sizeof(enum Check_result);   \
-             ++check_run_index) {                                              \
-            if (check_private_all_checks[check_run_index] != CHECK_PASS) {     \
-                check_private_all_checks_res = CHECK_FAIL;                     \
-            }                                                                  \
-        }                                                                      \
-        check_private_all_checks_res;                                          \
+        (void)(test_fn_list + 0);                                              \
+        check_process_result;                                                  \
     }))
 
 #endif /* CHECKERS_H */

--- a/tests/checkers.h
+++ b/tests/checkers.h
@@ -58,9 +58,9 @@ void check_print_fail_message(
     unsigned random_seed
 );
 
-/** The static variable seed for the entire test checker harness. This is
+/** The global variable seed for the entire test checker harness. This is
 seeded before any tests run in the check_run macro. */
-static unsigned check_static_random_seed;
+extern unsigned check_random_seed;
 
 /** Provides the correct type to the union for a check expression while
 silencing compiler warnings for non-compiled generic branches. Substitution
@@ -180,7 +180,7 @@ though the braces are not required. */
                 check_to_bytes(check_private_result),                          \
                 check_to_bytes(check_private_expected),                        \
                 check_is_address(check_private_result),                        \
-                check_static_random_seed                                       \
+                check_random_seed                                              \
             );                                                                 \
             check_private_macro_res = CHECK_FAIL;                              \
             __VA_OPT__((void)(__extension__({__VA_ARGS__}));)                  \
@@ -227,7 +227,7 @@ though the braces are not required. */
                 check_to_bytes(check_private_result),                          \
                 check_to_bytes(check_private_expected),                        \
                 check_is_address(check_private_result),                        \
-                check_static_random_seed                                       \
+                check_random_seed                                              \
             );                                                                 \
             check_private_macro_res = CHECK_ERROR;                             \
             __VA_OPT__((void)(__extension__({__VA_ARGS__}));)                  \
@@ -381,8 +381,8 @@ individual test that failed with CHECK_FAIL or CHECK_ERROR. */
            functions before the array initializer function calls because the   \
            observable behavior must be maintained. Critical that seed occurs   \
            first. */                                                           \
-        check_static_random_seed = (unsigned)time(NULL); /* NOLINT */          \
-        srand(check_static_random_seed);                 /* NOLINT */          \
+        check_random_seed = (unsigned)time(NULL); /* NOLINT */                 \
+        srand(check_random_seed);                 /* NOLINT */                 \
         enum Check_result const check_private_all_checks[] = {test_fn_list};   \
         enum Check_result check_private_all_checks_res = CHECK_PASS;           \
         for (unsigned long long check_run_index = 0;                           \


### PR DESCRIPTION
Validation of inputs and overflow checks are critical for additions and multiplications within the flat hash map implementation.