### PR TITLE
Flat containers check for overflow

### DIFF
--- a/source/array_tree_map.c
+++ b/source/array_tree_map.c
@@ -53,6 +53,7 @@ to that section, in my opinion. */
 /** C23 provided headers. */
 #include <limits.h>
 #include <stdalign.h>
+#include <stdckdint.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -265,7 +266,7 @@ is_22_parent(struct CCC_Array_tree_map const *, size_t, size_t, size_t);
 static CCC_Tribool is_leaf(struct CCC_Array_tree_map const *, size_t);
 static CCC_Tribool parity(struct CCC_Array_tree_map const *, size_t);
 static void set_parity(struct CCC_Array_tree_map const *, size_t, CCC_Tribool);
-static size_t total_bytes(size_t, size_t);
+static CCC_Tribool checked_total_bytes(size_t *, size_t, size_t);
 static size_t block_count(size_t);
 static CCC_Tribool validate(struct CCC_Array_tree_map const *);
 static void init_node(struct CCC_Array_tree_map const *, size_t);
@@ -862,7 +863,11 @@ allocate_slot(
     if (!old_count || old_count == old_cap) {
         assert(!map->free_list);
         if (old_count == old_cap) {
-            if (resize(map, CCC_max(old_cap * 2, PARITY_BLOCK_BITS), allocator)
+            size_t new_cap = 0;
+            if (ckd_mul(&new_cap, old_cap, 2)) {
+                return 0;
+            }
+            if (resize(map, CCC_max(new_cap, PARITY_BLOCK_BITS), allocator)
                 != CCC_RESULT_OK) {
                 return 0;
             }
@@ -900,9 +905,13 @@ resize(
     if (!allocator->allocate) {
         return CCC_RESULT_NO_ALLOCATION_FUNCTION;
     }
+    size_t new_bytes = 0;
+    if (checked_total_bytes(&new_bytes, map->sizeof_type, new_capacity)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
-        .bytes = total_bytes(map->sizeof_type, new_capacity),
+        .bytes = new_bytes,
         .alignment = CCC_max(ALIGNOF_NODE, map->alignof_type),
         .context = allocator->context,
     });
@@ -1133,11 +1142,47 @@ different from the preceding array. In that case it is the preceding array's
 responsibility to add padding bytes to its end such that the next array begins
 on an aligned byte boundary for its own type. This means that the bytes returned
 by this function may be greater than summing the (sizeof(type) * capacity) for
-each array in the conceptual struct. */
-static inline size_t
-total_bytes(size_t const sizeof_type, size_t const capacity) {
-    return data_bytes(sizeof_type, capacity) + nodes_bytes(capacity)
-         + parities_bytes(capacity);
+each array in the conceptual struct.
+
+This functions checks for overflow at every step of calculating the size of
+this contiguous allocation and returns CCC_TRUE if overflow occured, otherwise
+CCC_FALSE. This function should be used when capacity is accepted from an
+external source such as user input. */
+static inline CCC_Tribool
+checked_total_bytes(
+    size_t *const result, size_t const sizeof_type, size_t const capacity
+) {
+    size_t node_byte_count = 0;
+    if (ckd_mul(&node_byte_count, capacity, (size_t)SIZEOF_NODE)) {
+        return CCC_TRUE;
+    }
+    if (CCC_checked_roundup(
+            &node_byte_count, node_byte_count, ALIGNOF_PARITY
+        )) {
+        return CCC_TRUE;
+    }
+    size_t parities_byte_count = 0;
+    if (ckd_add(&parities_byte_count, capacity, PARITY_BLOCK_BITS - 1)) {
+        return CCC_TRUE;
+    }
+    parities_byte_count >>= PARITY_BLOCK_BITS_LOG2;
+    if (ckd_mul(
+            &parities_byte_count, parities_byte_count, (size_t)SIZEOF_PARITY
+        )) {
+        return CCC_TRUE;
+    }
+    *result = 0;
+    if (ckd_mul(result, sizeof_type, capacity)) {
+        return CCC_TRUE;
+    }
+    if (CCC_checked_roundup(result, *result, ALIGNOF_NODE)) {
+        return CCC_TRUE;
+    }
+    if (ckd_add(result, *result, node_byte_count)
+        || ckd_add(result, *result, parities_byte_count)) {
+        return CCC_TRUE;
+    }
+    return CCC_FALSE;
 }
 
 /** Returns the base of the node array relative to the data base pointer. This

--- a/source/flat_bitset.c
+++ b/source/flat_bitset.c
@@ -31,6 +31,7 @@ and bug doubling. */
 /** C23 provided headers. */
 #include <assert.h>
 #include <limits.h>
+#include <stdckdint.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -119,6 +120,8 @@ static Bit_block on(size_t);
 static void fix_end(struct CCC_Flat_bitset *);
 static CCC_Tribool status(Bit_block const *, size_t);
 static size_t block_count(size_t);
+static inline CCC_Tribool
+checked_block_count(Block_count *result, size_t bit_count);
 static CCC_Tribool
 any_or_none_range(struct CCC_Flat_bitset const *, size_t, size_t, CCC_Tribool);
 static CCC_Tribool all_range(struct CCC_Flat_bitset const *, size_t, size_t);
@@ -1043,31 +1046,48 @@ maybe_resize(
     size_t const to_add,
     CCC_Allocator const *const allocator
 ) {
-    size_t bits_needed = bitset->count + to_add;
+    size_t bits_needed = 0;
+    if (ckd_add(&bits_needed, bitset->count, to_add)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
     if (bits_needed <= bitset->capacity) {
         return CCC_RESULT_OK;
     }
     if (!allocator->allocate) {
         return CCC_RESULT_NO_ALLOCATION_FUNCTION;
     }
-    if (to_add == 1) {
-        bits_needed <<= 1;
+    if (to_add == 1 && ckd_mul(&bits_needed, bits_needed, 2)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
     }
     static_assert(
         (BLOCK_BITS & (BLOCK_BITS - 1)) == 0,
         "rounding trick only works for powers of 2"
     );
-    size_t const new_capacity = CCC_roundup(bits_needed, BLOCK_BITS);
-    if (new_capacity <= bitset->capacity) {
-        return CCC_RESULT_ARGUMENT_ERROR;
+    size_t new_capacity = 0;
+    if (CCC_checked_roundup(&new_capacity, bits_needed, BLOCK_BITS)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
     }
-    size_t const new_bytes
-        = block_count(new_capacity - bitset->count) * SIZEOF_BLOCK;
+    size_t new_bytes = 0;
+    if (checked_block_count(&new_bytes, new_capacity - bitset->count)
+        || ckd_mul(&new_bytes, new_bytes, (size_t)SIZEOF_BLOCK)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
+    /* Don't need to check old allocation for overflow because it has already
+       been successfully allocated. */
     size_t const old_bytes
         = bitset->count ? block_count(bitset->count) * SIZEOF_BLOCK : 0;
+    size_t total_allocation_bytes = 0;
+    if (checked_block_count(&total_allocation_bytes, new_capacity)
+        || ckd_mul(
+            &total_allocation_bytes,
+            total_allocation_bytes,
+            (size_t)SIZEOF_BLOCK
+        )) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
     Bit_block *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = bitset->blocks,
-        .bytes = block_count(new_capacity) * SIZEOF_BLOCK,
+        .bytes = total_allocation_bytes,
         .alignment = alignof(*bitset->blocks),
         .context = allocator->context,
     });
@@ -1584,7 +1604,7 @@ bit_count_index(size_t const flat_bitset_index) {
 }
 
 /** Returns the number of blocks required to store the given bits. Assumes bits
-is non-zero. For any bits > 1 the block count is always less than bits.*/
+is non-zero. For any bits > 1 the block count is always less than bits. */
 static inline Block_count
 block_count(size_t const bit_count) {
     static_assert(
@@ -1594,6 +1614,21 @@ block_count(size_t const bit_count) {
     );
     assert(bit_count && "calculating block count for non-empty bitset");
     return (bit_count + (BLOCK_BITS - 1)) >> BLOCK_BITS_LOG2;
+}
+
+/** Returns the number of blocks required to store the given bits. Assumes bits
+is non-zero. For any bits > 1 the block count is always less than bits.
+
+This function checks for overflow when obtaining the count and returns CCC_TRUE
+if overflow occured otherwise CCC_FALSE. */
+static inline CCC_Tribool
+checked_block_count(Block_count *const result, size_t const bit_count) {
+    assert(bit_count && "calculating block count for non-empty bitset");
+    if (ckd_add(result, bit_count, (BLOCK_BITS - 1))) {
+        return CCC_TRUE;
+    }
+    *result >>= BLOCK_BITS_LOG2;
+    return CCC_FALSE;
 }
 
 /** Returns true if the on bit mask is present in the block. All one bits in the

--- a/source/flat_buffer.c
+++ b/source/flat_buffer.c
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 /** C23 provided headers. */
+#include <stdckdint.h>
 #include <stddef.h>
 
 /** CCC provided headers. */
@@ -43,9 +44,13 @@ CCC_flat_buffer_allocate(
     if (!allocator->allocate) {
         return CCC_RESULT_NO_ALLOCATION_FUNCTION;
     }
+    size_t total_bytes = 0;
+    if (ckd_mul(&total_bytes, capacity, buffer->sizeof_type)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = buffer->data,
-        .bytes = buffer->sizeof_type * capacity,
+        .bytes = total_bytes,
         .alignment = buffer->alignof_type,
         .context = allocator->context,
     });
@@ -66,16 +71,23 @@ CCC_flat_buffer_reserve(
     if (!buffer || !allocator || !allocator->allocate || !to_add) {
         return CCC_RESULT_ARGUMENT_ERROR;
     }
-    size_t needed = buffer->count + to_add;
-    if (needed <= buffer->capacity) {
+    size_t new_capacity = 0;
+    if (ckd_add(&new_capacity, buffer->count, to_add)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
+    if (new_capacity <= buffer->capacity) {
         return CCC_RESULT_OK;
     }
-    if (needed < START_CAPACITY) {
-        needed = START_CAPACITY;
+    if (new_capacity < START_CAPACITY) {
+        new_capacity = START_CAPACITY;
+    }
+    size_t total_bytes = 0;
+    if (ckd_mul(&total_bytes, new_capacity, buffer->sizeof_type)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
     }
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = buffer->data,
-        .bytes = buffer->sizeof_type * needed,
+        .bytes = total_bytes,
         .alignment = buffer->alignof_type,
         .context = allocator->context,
     });
@@ -83,7 +95,7 @@ CCC_flat_buffer_reserve(
         return CCC_RESULT_ALLOCATOR_ERROR;
     }
     buffer->data = new_data;
-    buffer->capacity = needed;
+    buffer->capacity = new_capacity;
     return CCC_RESULT_OK;
 }
 
@@ -167,8 +179,12 @@ CCC_flat_buffer_allocate_back(
         return NULL;
     }
     if (buffer->count == buffer->capacity) {
+        size_t new_capacity = 0;
+        if (ckd_mul(&new_capacity, buffer->capacity, 2)) {
+            return NULL;
+        }
         CCC_Result const resize_res = CCC_flat_buffer_allocate(
-            buffer, CCC_max(buffer->capacity * 2, START_CAPACITY), allocator
+            buffer, CCC_max(new_capacity, START_CAPACITY), allocator
         );
         if (resize_res != CCC_RESULT_OK) {
             return NULL;
@@ -284,8 +300,12 @@ CCC_flat_buffer_insert(
         return CCC_flat_buffer_push_back(buffer, data, allocator);
     }
     if (buffer->count == buffer->capacity) {
+        size_t new_capacity = 0;
+        if (ckd_mul(&new_capacity, buffer->count, 2)) {
+            return NULL;
+        }
         CCC_Result const r = CCC_flat_buffer_allocate(
-            buffer, CCC_max(buffer->count * 2, START_CAPACITY), allocator
+            buffer, CCC_max(new_capacity, START_CAPACITY), allocator
         );
         if (r != CCC_RESULT_OK) {
             return NULL;
@@ -445,7 +465,10 @@ CCC_flat_buffer_count_plus(CCC_Flat_buffer *const buffer, size_t const count) {
     if (!buffer) {
         return CCC_RESULT_ARGUMENT_ERROR;
     }
-    size_t const new_count = buffer->count + count;
+    size_t new_count = 0;
+    if (ckd_add(&new_count, buffer->count, count)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
     if (new_count > buffer->capacity) {
         buffer->count = buffer->capacity;
         return CCC_RESULT_ARGUMENT_ERROR;
@@ -485,6 +508,7 @@ CCC_flat_buffer_count_bytes(CCC_Flat_buffer const *buffer) {
     if (!buffer) {
         return (CCC_Count){.error = CCC_RESULT_ARGUMENT_ERROR};
     }
+    /* No overflow check needed if buffer already exists. */
     return (CCC_Count){.count = buffer->count * buffer->sizeof_type};
 }
 
@@ -493,6 +517,7 @@ CCC_flat_buffer_capacity_bytes(CCC_Flat_buffer const *buffer) {
     if (!buffer) {
         return (CCC_Count){.error = CCC_RESULT_ARGUMENT_ERROR};
     }
+    /* No overflow check needed if buffer already exists. */
     return (CCC_Count){
         .count = buffer->capacity * buffer->sizeof_type,
     };

--- a/source/flat_double_ended_queue.c
+++ b/source/flat_double_ended_queue.c
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 /** C23 provided headers. */
 #include <limits.h>
+#include <stdckdint.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -686,11 +687,11 @@ maybe_resize(
     size_t const to_add,
     CCC_Allocator const *const allocator
 ) {
-    size_t required = queue->buffer.count + to_add;
-    if (required < queue->buffer.count) {
-        return CCC_RESULT_ARGUMENT_ERROR;
+    size_t required_capacity = 0;
+    if (ckd_add(&required_capacity, queue->buffer.count, to_add)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
     }
-    if (required <= queue->buffer.capacity) {
+    if (required_capacity <= queue->buffer.capacity) {
         return CCC_RESULT_OK;
     }
     if (!allocator->allocate) {
@@ -698,13 +699,18 @@ maybe_resize(
     }
     size_t const sizeof_type = queue->buffer.sizeof_type;
     if (!queue->buffer.capacity && to_add == 1) {
-        required = START_CAPACITY;
-    } else if (to_add == 1) {
-        required = queue->buffer.capacity * 2;
+        required_capacity = START_CAPACITY;
+    } else if (to_add == 1
+               && ckd_mul(&required_capacity, queue->buffer.capacity, 2)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
+    size_t total_bytes = 0;
+    if (ckd_mul(&total_bytes, required_capacity, sizeof_type)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
     }
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
-        .bytes = sizeof_type * required,
+        .bytes = total_bytes,
         .alignment = queue->buffer.alignof_type,
         .context = allocator->context,
     });
@@ -731,7 +737,7 @@ maybe_resize(
     (void)CCC_flat_buffer_allocate(&queue->buffer, 0, allocator);
     queue->buffer.data = new_data;
     queue->front = 0;
-    queue->buffer.capacity = required;
+    queue->buffer.capacity = required_capacity;
     return CCC_RESULT_OK;
 }
 

--- a/source/specialized/array_adaptive_map.c
+++ b/source/specialized/array_adaptive_map.c
@@ -147,7 +147,7 @@ static void insert(struct CCC_Array_adaptive_map *, size_t n);
 static void *key_in_slot(struct CCC_Array_adaptive_map const *, void const *);
 static size_t
 allocate_slot(struct CCC_Array_adaptive_map *, CCC_Allocator const *);
-static size_t total_bytes(size_t, size_t);
+static CCC_Tribool checked_total_bytes(size_t *, size_t, size_t);
 static CCC_Handle_range equal_range(
     struct CCC_Array_adaptive_map *, void const *, void const *, enum Branch
 );
@@ -794,8 +794,11 @@ allocate_slot(
     if (!old_count || old_count == old_cap) {
         assert(!map->free_list);
         if (old_count == old_cap) {
-            if (resize(map, CCC_max(old_cap * 2, 8U), allocator)
-                != CCC_RESULT_OK) {
+            size_t new_cap = 0;
+            if (ckd_mul(&new_cap, old_cap, 2)) {
+                return 0;
+            }
+            if (resize(map, CCC_max(new_cap, 8U), allocator) != CCC_RESULT_OK) {
                 return 0;
             }
         } else {
@@ -828,9 +831,13 @@ resize(
     if (!allocator->allocate) {
         return CCC_RESULT_NO_ALLOCATION_FUNCTION;
     }
+    size_t new_bytes = 0;
+    if (checked_total_bytes(&new_bytes, map->sizeof_type, new_capacity)) {
+        return CCC_RESULT_ALLOCATOR_ERROR;
+    }
     void *const new_data = allocator->allocate((CCC_Allocator_arguments){
         .input = NULL,
-        .bytes = total_bytes(map->sizeof_type, new_capacity),
+        .bytes = new_bytes,
         .alignment = CCC_max(ALIGNOF_NODE, map->alignof_type),
         .context = allocator->context,
     });
@@ -1096,10 +1103,31 @@ different from the preceding array. In that case it is the preceding array's
 responsibility to add padding bytes to its end such that the next array begins
 on an aligned byte boundary for its own type. This means that the bytes returned
 by this function may be greater than summing the (sizeof(type) * capacity) for
-each array in the conceptual struct. */
-static inline size_t
-total_bytes(size_t sizeof_type, size_t const capacity) {
-    return data_bytes(sizeof_type, capacity) + nodes_bytes(capacity);
+each array in the conceptual struct.
+
+This functions checks for overflow at every step of calculating the size of
+this contiguous allocation and returns CCC_TRUE if overflow occured, otherwise
+CCC_FALSE. This function should be used when capacity is accepted from an
+external source such as user input. */
+static inline CCC_Tribool
+checked_total_bytes(
+    size_t *const result, size_t const sizeof_type, size_t const capacity
+) {
+    size_t node_byte_count = 0;
+    if (ckd_mul(&node_byte_count, capacity, (size_t)SIZEOF_NODE)) {
+        return CCC_TRUE;
+    }
+    *result = 0;
+    if (ckd_mul(result, sizeof_type, capacity)) {
+        return CCC_TRUE;
+    }
+    if (CCC_checked_roundup(result, *result, ALIGNOF_NODE)) {
+        return CCC_TRUE;
+    }
+    if (ckd_add(result, *result, node_byte_count)) {
+        return CCC_TRUE;
+    }
+    return CCC_FALSE;
 }
 
 /** Returns the base of the node array relative to the data base pointer. This

--- a/tests/flat_bitset/test_flat_bitset_insert.c
+++ b/tests/flat_bitset/test_flat_bitset_insert.c
@@ -123,7 +123,7 @@ check_static_begin(flat_bitset_test_reserve_fail) {
     );
     check(
         CCC_flat_bitset_reserve(&bs, SIZE_MAX, &allocator),
-        CCC_RESULT_ARGUMENT_ERROR
+        CCC_RESULT_ALLOCATOR_ERROR
     );
     check_end((void)clear_and_free(&bs, &std_allocator););
 }


### PR DESCRIPTION
All flat containers should make use of `stdckdint.h` checks for adding elements to the container, resizing, and totaling byte counts.