### PR TITLE
Use offsetof over pointer comparison in layout tests

### DIFF
--- a/source/array_tree_map.c
+++ b/source/array_tree_map.c
@@ -133,25 +133,25 @@ a fixed map or heap allocation.
 Use an int because that will force the nodes array to be wary of
 where to start. The nodes are 8 byte aligned but an int is 4. This means the
 nodes need to start after 4 byte buffer of padding at end of data array. */
-static __auto_type const static_data_nodes_parity_layout_test
+[[maybe_unused]] static __auto_type const static_data_nodes_parity_layout_test
     = CCC_private_array_tree_map_storage_for((int const[TCAP]){});
 /** Some assumptions in the code assume that parity array is last so ensure that
 is the case here. Also good to assume user data comes first. */
 static_assert(
-    ((char const *)static_data_nodes_parity_layout_test.data
-     < (char const *)static_data_nodes_parity_layout_test.nodes),
+    (offsetof(typeof(static_data_nodes_parity_layout_test), data)
+     < offsetof(typeof(static_data_nodes_parity_layout_test), nodes)),
     "The order of the arrays in a Struct of Arrays map is user data "
     "first, nodes second."
 );
 static_assert(
-    ((char const *)static_data_nodes_parity_layout_test.nodes
-     < (char const *)static_data_nodes_parity_layout_test.parity),
+    (offsetof(typeof(static_data_nodes_parity_layout_test), nodes)
+     < offsetof(typeof(static_data_nodes_parity_layout_test), parity)),
     "The order of the arrays in a Struct of Arrays map is internal "
     "nodes second, parity third."
 );
 static_assert(
-    (char const *)static_data_nodes_parity_layout_test.data
-        < (char const *)static_data_nodes_parity_layout_test.parity,
+    offsetof(typeof(static_data_nodes_parity_layout_test), data)
+        < offsetof(typeof(static_data_nodes_parity_layout_test), parity),
     "The order of the arrays in a Struct of Arrays map is data, then "
     "nodes, then parity."
 );
@@ -161,9 +161,10 @@ important for the nodes and parity pointer to be set to the correct aligned
 positions and so that we allocate enough bytes for our single allocation if
 the map is dynamic and not a fixed type. */
 static_assert(
-    (char const *)&static_data_nodes_parity_layout_test
-                .parity[CCC_private_array_tree_map_blocks(TCAP)]
-            - (char const *)&static_data_nodes_parity_layout_test.data[0]
+    offsetof(
+        typeof(static_data_nodes_parity_layout_test),
+        parity[CCC_private_array_tree_map_blocks(TCAP)]
+    ) - offsetof(typeof(static_data_nodes_parity_layout_test), data[0])
         == CCC_roundup(
                (sizeof(*static_data_nodes_parity_layout_test.data) * TCAP),
                ALIGNOF_NODE
@@ -174,23 +175,23 @@ static_assert(
     "stored in that range. Alignment of user data must be considered."
 );
 static_assert(
-    (char const *)&static_data_nodes_parity_layout_test.data
+    offsetof(typeof(static_data_nodes_parity_layout_test), data)
             + CCC_roundup(
                 (sizeof(*static_data_nodes_parity_layout_test.data) * TCAP),
                 ALIGNOF_NODE
             )
-        == (char const *)&static_data_nodes_parity_layout_test.nodes,
+        == offsetof(typeof(static_data_nodes_parity_layout_test), nodes),
     "The start of the nodes array must begin at the next aligned "
     "byte given alignment of a node."
 );
 static_assert(
-    (char const *)&static_data_nodes_parity_layout_test.parity
-        == ((char const *)&static_data_nodes_parity_layout_test.data
-            + CCC_roundup(
-                (sizeof(*static_data_nodes_parity_layout_test.data) * TCAP),
-                ALIGNOF_NODE
-            )
-            + CCC_roundup((SIZEOF_NODE * TCAP), ALIGNOF_PARITY)),
+    offsetof(typeof(static_data_nodes_parity_layout_test), parity)
+        == offsetof(typeof(static_data_nodes_parity_layout_test), data)
+               + CCC_roundup(
+                   (sizeof(*static_data_nodes_parity_layout_test.data) * TCAP),
+                   ALIGNOF_NODE
+               )
+               + CCC_roundup((SIZEOF_NODE * TCAP), ALIGNOF_PARITY),
     "The start of the parity array must begin at the next aligned byte given "
     "alignment of both the data and nodes array."
 );

--- a/source/flat_hash_map.c
+++ b/source/flat_hash_map.c
@@ -171,22 +171,22 @@ because that wastes pointless space and has no impact on the following layout
 and pointer arithmetic tests. One behavior we want to ensure is that our manual
 pointer arithmetic at runtime matches the group size aligned position of the tag
 metadata array. */
-static __auto_type const data_tag_layout_test = (struct {
+[[maybe_unused]] static __auto_type const data_tag_layout_test = (struct {
     alignas(GROUP_COUNT) int const data[2 + 1];
     alignas(GROUP_COUNT) struct CCC_Flat_hash_map_tag const tag[2];
 }){};
 static_assert(
-    (char const *)&data_tag_layout_test.tag[2]
-            - (char const *)&data_tag_layout_test.data[0]
+    offsetof(typeof(data_tag_layout_test), tag[2])
+            - offsetof(typeof(data_tag_layout_test), data[0])
         == (CCC_roundup(sizeof(data_tag_layout_test.data), GROUP_COUNT)
             + (sizeof(struct CCC_Flat_hash_map_tag) * 2)),
     "The manually computed offset of the tag array from the start of the data "
     "array must match the offset chosen by compiler alignment rules."
 );
 static_assert(
-    (char const *)&data_tag_layout_test.data
+    offsetof(typeof(data_tag_layout_test), data)
             + CCC_roundup(sizeof(data_tag_layout_test.data), GROUP_COUNT)
-        == (char const *)&data_tag_layout_test.tag,
+        == offsetof(typeof(data_tag_layout_test), tag),
     "We calculate the correct position of the tag array considering it may get "
     "extra padding at start for alignment by group size."
 );

--- a/source/specialized/array_adaptive_map.c
+++ b/source/specialized/array_adaptive_map.c
@@ -83,13 +83,13 @@ correct regardless of backing storage as a fixed map or heap allocation.
 Use an int because that will force the nodes array to be wary of
 where to start. The nodes are 8 byte aligned but an int is 4. This means the
 nodes need to start after a 4 byte buffer of padding at end of data array. */
-static __auto_type const static_data_nodes_layout_test
+[[maybe_unused]] static __auto_type const static_data_nodes_layout_test
     = CCC_array_adaptive_map_storage_for((int const[TCAP]){});
 /** Some assumptions in the code assume that nodes array is last so ensure that
 is the case here. Also good to assume user data comes first. */
 static_assert(
-    (char const *)static_data_nodes_layout_test.data
-        < (char const *)static_data_nodes_layout_test.nodes,
+    offsetof(typeof(static_data_nodes_layout_test), data)
+        < offsetof(typeof(static_data_nodes_layout_test), nodes),
     "The order of the arrays in a Struct of Arrays map is data, then "
     "nodes."
 );
@@ -99,8 +99,8 @@ important for the nodes pointer to be set to the correct aligned position and
 so that we allocate enough bytes for our single allocation if the map is dynamic
 and not a fixed type. */
 static_assert(
-    (char const *)&static_data_nodes_layout_test.nodes[TCAP]
-            - (char const *)&static_data_nodes_layout_test.data[0]
+    offsetof(typeof(static_data_nodes_layout_test), nodes[TCAP])
+            - offsetof(typeof(static_data_nodes_layout_test), data[0])
         == CCC_roundup(
                (sizeof(*static_data_nodes_layout_test.data) * TCAP),
                ALIGNOF_NODE
@@ -110,12 +110,12 @@ static_assert(
     "stored in that range. Alignment of user data must be considered."
 );
 static_assert(
-    (char const *)&static_data_nodes_layout_test.data
+    offsetof(typeof(static_data_nodes_layout_test), data)
             + CCC_roundup(
                 (sizeof(*static_data_nodes_layout_test.data) * TCAP),
                 ALIGNOF_NODE
             )
-        == (char const *)&static_data_nodes_layout_test.nodes,
+        == offsetof(typeof(static_data_nodes_layout_test), nodes),
     "The start of the nodes array must begin at the next aligned "
     "byte given alignment of a node."
 );


### PR DESCRIPTION
Several static assertions use address-of runtime objects cast to `char *` to test layout offset in bytes, the pattern can be converted to the combination of `offsetof` and `typeof`, which is IMHO less hack-y and more portable. The change is unnecessary, but it was the only blocker for [slimcc](https://github.com/fuhsnn/slimcc) to compile-test `ccc`.