### PR TITLE
Fix name redundancies in sort.h

### DIFF
--- a/ccc/sort.h
+++ b/ccc/sort.h
@@ -23,7 +23,20 @@ upon initialization because sorting is not the most common use case. Therefore
 comparators are adaptors we can pass while performing an algorithm. They
 then implement this algorithm internally with the passed ordering and
 comparator. A container such as a linked list may also be able to report back
-if it is sorted or insert an element in a sorted position. */
+if it is sorted or insert an element in a sorted position.
+
+For namespace consistency, all sorting algorithms are prefixed with
+`CCC_sort_*`. So `CCC_sort_heap` is heapsort, `CCC_sort_merge` is mergesort,
+etc.
+
+To shorten names in the interface, define the following preprocessor directive
+at the top of your file.
+
+```
+#define SORT_USING_NAMESPACE_CCC
+```
+
+All functions can then be written without the `CCC_` prefix. */
 #ifndef CCC_SORT_H
 #define CCC_SORT_H
 
@@ -61,7 +74,7 @@ as `&(My_type){}`, passed directly as an argument.
 
 The sort is not inherently stable and uses the provided comparison function to
 order the elements. */
-CCC_Result CCC_sort_heapsort(
+CCC_Result CCC_sort_heap(
     CCC_Flat_buffer const *buffer,
     void *temp,
     CCC_Order order,
@@ -82,7 +95,7 @@ because 0 is the first node in the list.
 @param[in] comparator the comparator context for comparing list elements.
 @return the result of the sort, usually OK. An argument error if
 doubly_linked_list is null. */
-CCC_Result CCC_sort_doubly_linked_list_mergesort(
+CCC_Result CCC_sort_merge_doubly_linked_list(
     CCC_Doubly_linked_list *list,
     CCC_Order order,
     CCC_Comparator const *comparator
@@ -102,7 +115,7 @@ because 0 is the first node in the list.
 @param[in] comparator the comparator context for comparing list elements.
 @return the result of the sort, usually OK. An argument error if
 singly_linked_list is null. */
-CCC_Result CCC_sort_singly_linked_list_mergesort(
+CCC_Result CCC_sort_merge_singly_linked_list(
     CCC_Singly_linked_list *list,
     CCC_Order order,
     CCC_Comparator const *comparator
@@ -121,9 +134,9 @@ because 0 is the first node in the list.
 @param[in] comparator_pointer the pointer to the comparator context for
 comparing list elements.
 @return the result of the sort, usually OK. An argument error for bad input. */
-#define CCC_sort_mergesort(list_pointer, order, comparator_pointer)                                                                                             \
-    _Generic((list_pointer), CCC_Singly_linked_list *: CCC_sort_singly_linked_list_mergesort, CCC_Doubly_linked_list *: CCC_sort_doubly_linked_list_mergesort)( \
-        list_pointer, order, comparator_pointer                                                                                                                 \
+#define CCC_sort_merge(list_pointer, order, comparator_pointer)                                                                                         \
+    _Generic((list_pointer), CCC_Singly_linked_list *: CCC_sort_merge_singly_linked_list, CCC_Doubly_linked_list *: CCC_sort_merge_doubly_linked_list)( \
+        list_pointer, order, comparator_pointer                                                                                                         \
     )
 
 /**@}*/
@@ -132,12 +145,12 @@ comparing list elements.
  no namespace clashes occur before shortening. */
 #ifdef SORT_USING_NAMESPACE_CCC
 /* NOLINTBEGIN(readability-identifier-naming) */
-#    define sort_heapsort(args...) CCC_sort_heapsort(args)
-#    define sort_singly_linked_list_mergesort(args...)                         \
-        CCC_sort_singly_linked_list_mergesort(args)
-#    define sort_doubly_linked_list_mergesort(args...)                         \
-        CCC_sort_doubly_linked_list_mergesort(args)
-#    define sort_mergesort(args...) CCC_sort_mergesort(args)
+#    define sort_heap(args...) CCC_sort_heap(args)
+#    define sort_merge_singly_linked_list(args...)                             \
+        CCC_sort_merge_singly_linked_list(args)
+#    define sort_merge_doubly_linked_list(args...)                             \
+        CCC_sort_merge_doubly_linked_list(args)
+#    define sort_merge(args...) CCC_sort_merge(args)
 /* NOLINTEND(readability-identifier-naming) */
 #endif /* SORT_USING_NAMESPACE_CCC */
 

--- a/samples/words.c
+++ b/samples/words.c
@@ -546,7 +546,7 @@ word_buffer_sort(
     CCC_Order const order,
     struct String_arena *const arena
 ) {
-    return CCC_sort_heapsort(
+    return CCC_sort_heap(
         &words->buffer,
         &(Word){},
         order,

--- a/source/doubly_linked_list.c
+++ b/source/doubly_linked_list.c
@@ -648,7 +648,7 @@ each merge step. Therefore the number of times we must perform the merge step is
 `O(log(N))`. The most elements we would have to merge in the merge step is all
 `N` elements so together that gives us the runtime of `O(N * log(N))`. */
 CCC_Result
-CCC_sort_doubly_linked_list_mergesort(
+CCC_sort_merge_doubly_linked_list(
     CCC_Doubly_linked_list *const list,
     CCC_Order const order,
     CCC_Comparator const *const comparator

--- a/source/flat_priority_queue.c
+++ b/source/flat_priority_queue.c
@@ -460,7 +460,7 @@ a heap are leaves, or near leaves, the likelihood of finding a heap ordered
 position near the bottom is extremely likely. This means we only require a few
 comparisons on average. */
 CCC_Result
-CCC_sort_heapsort(
+CCC_sort_heap(
     CCC_Flat_buffer const *const buffer,
     void *const temp,
     CCC_Order order,

--- a/source/singly_linked_list.c
+++ b/source/singly_linked_list.c
@@ -487,7 +487,7 @@ each merge step. Therefore the number of times we must perform the merge step is
 `O(log(N))`. The most elements we would have to merge in the merge step is all
 `N` elements so together that gives us the runtime of `O(N * log(N))`. */
 CCC_Result
-CCC_sort_singly_linked_list_mergesort(
+CCC_sort_merge_singly_linked_list(
     CCC_Singly_linked_list *const list,
     CCC_Order const order,
     CCC_Comparator const *const comparator

--- a/tests/doubly_linked_list/test_doubly_linked_list_insert.c
+++ b/tests/doubly_linked_list/test_doubly_linked_list_insert.c
@@ -343,7 +343,7 @@ check_static_begin(doubly_linked_list_test_sort_even) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &doubly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -403,7 +403,7 @@ check_static_begin(doubly_linked_list_test_sort_odd) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &doubly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -460,7 +460,7 @@ check_static_begin(doubly_linked_list_test_sort_reverse) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &doubly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -521,7 +521,7 @@ check_static_begin(doubly_linked_list_test_sort_runs) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &doubly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -584,7 +584,7 @@ check_static_begin(doubly_linked_list_test_sort_halves) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &doubly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -641,7 +641,7 @@ check_static_begin(doubly_linked_list_test_sort_insert) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &doubly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -788,7 +788,7 @@ check_static_begin(doubly_linked_list_test_insert_sorted_allocation) {
     check(
         doubly_linked_list_is_sorted(&list, CCC_ORDER_LESSER, comparator), false
     );
-    CCC_Result r = CCC_sort_mergesort(&list, CCC_ORDER_LESSER, comparator);
+    CCC_Result r = CCC_sort_merge(&list, CCC_ORDER_LESSER, comparator);
     check(
         doubly_linked_list_is_sorted(&list, CCC_ORDER_LESSER, comparator), true
     );
@@ -868,19 +868,19 @@ check_static_begin(doubly_linked_list_test_insert_sorted_allocation) {
 check_static_begin(doubly_linked_list_test_mergesort_errors) {
     Doubly_linked_list list = doubly_linked_list_default(struct Val, e);
     check(
-        CCC_sort_doubly_linked_list_mergesort(
+        CCC_sort_merge_doubly_linked_list(
             NULL, CCC_ORDER_LESSER, &(CCC_Comparator){}
         ),
         CCC_RESULT_ARGUMENT_ERROR
     );
     check(
-        CCC_sort_doubly_linked_list_mergesort(
+        CCC_sort_merge_doubly_linked_list(
             &list, CCC_ORDER_EQUAL, &(CCC_Comparator){}
         ),
         CCC_RESULT_ARGUMENT_ERROR
     );
     check(
-        CCC_sort_doubly_linked_list_mergesort(&list, CCC_ORDER_LESSER, NULL),
+        CCC_sort_merge_doubly_linked_list(&list, CCC_ORDER_LESSER, NULL),
         CCC_RESULT_ARGUMENT_ERROR
     );
     check_end();

--- a/tests/flat_priority_queue/flat_priority_queue_utility.c
+++ b/tests/flat_priority_queue/flat_priority_queue_utility.c
@@ -88,7 +88,7 @@ check_begin(
     CCC_Result r
         = flat_buffer_copy(&copy, &flat_priority_queue->buffer, &std_allocator);
     check(r, CCC_RESULT_OK);
-    r = CCC_sort_heapsort(
+    r = CCC_sort_heap(
         &copy,
         &(struct Val){},
         flat_priority_queue->order,

--- a/tests/flat_priority_queue/test_flat_priority_queue_construct.c
+++ b/tests/flat_priority_queue/test_flat_priority_queue_construct.c
@@ -325,7 +325,7 @@ check_static_begin(flat_priority_queue_test_heapify_copy_fail) {
 
 check_static_begin(flat_priority_queue_test_heapsort_empty) {
     check(
-        CCC_sort_heapsort(
+        CCC_sort_heap(
             &flat_buffer_default(int),
             NULL,
             CCC_ORDER_GREATER,
@@ -334,13 +334,13 @@ check_static_begin(flat_priority_queue_test_heapsort_empty) {
         CCC_RESULT_ARGUMENT_ERROR
     );
     check(
-        CCC_sort_heapsort(
+        CCC_sort_heap(
             &flat_buffer_default(int), &(int){}, CCC_ORDER_GREATER, NULL
         ),
         CCC_RESULT_ARGUMENT_ERROR
     );
     check(
-        CCC_sort_heapsort(
+        CCC_sort_heap(
             &flat_buffer_default(int),
             &(int){},
             CCC_ORDER_EQUAL,
@@ -349,7 +349,7 @@ check_static_begin(flat_priority_queue_test_heapsort_empty) {
         CCC_RESULT_ARGUMENT_ERROR
     );
     check(
-        CCC_sort_heapsort(
+        CCC_sort_heap(
             &flat_buffer_default(int),
             &(int){},
             CCC_ORDER_GREATER,
@@ -362,7 +362,7 @@ check_static_begin(flat_priority_queue_test_heapsort_empty) {
 
 check_static_begin(flat_priority_queue_test_heapsort_one) {
     check(
-        CCC_sort_heapsort(
+        CCC_sort_heap(
             &flat_buffer_with_storage(1, (int[1]){1}),
             &(int){},
             CCC_ORDER_GREATER,
@@ -376,7 +376,7 @@ check_static_begin(flat_priority_queue_test_heapsort_one) {
 check_static_begin(flat_priority_queue_test_heapsort_two) {
     Flat_buffer storage = flat_buffer_with_storage(2, (int[2]){1, 2});
     check(
-        CCC_sort_heapsort(
+        CCC_sort_heap(
             &storage,
             &(int){},
             CCC_ORDER_GREATER,
@@ -400,7 +400,7 @@ check_static_begin(flat_priority_queue_test_heapsort_reversed_lesser) {
     Flat_buffer storage = flat_buffer_with_storage(
         CAP, (int[CAP]){9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
     );
-    CCC_Result const result = CCC_sort_heapsort(
+    CCC_Result const result = CCC_sort_heap(
         &storage,
         &(int){},
         CCC_ORDER_LESSER,
@@ -426,7 +426,7 @@ check_static_begin(flat_priority_queue_test_heapsort_reversed_greater) {
     Flat_buffer storage = flat_buffer_with_storage(
         CAP, (int[CAP]){9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
     );
-    CCC_Result const result = CCC_sort_heapsort(
+    CCC_Result const result = CCC_sort_heap(
         &storage,
         &(int){},
         CCC_ORDER_GREATER,
@@ -452,7 +452,7 @@ check_static_begin(flat_priority_queue_test_heapsort_merge) {
     Flat_buffer storage = flat_buffer_with_storage(
         CAP, (int[CAP]){1, 3, 5, 7, 9, 0, 2, 4, 6, 8}
     );
-    CCC_Result const result = CCC_sort_heapsort(
+    CCC_Result const result = CCC_sort_heap(
         &storage,
         &(int){},
         CCC_ORDER_LESSER,
@@ -480,7 +480,7 @@ check_static_begin(flat_priority_queue_test_heapsort) {
          i = flat_buffer_next(&storage, i)) {
         *i = (int)rand_range(0, CAP);
     }
-    CCC_Result const result = CCC_sort_heapsort(
+    CCC_Result const result = CCC_sort_heap(
         &storage,
         &(int){},
         CCC_ORDER_GREATER,

--- a/tests/singly_linked_list/test_singly_linked_list_insert.c
+++ b/tests/singly_linked_list/test_singly_linked_list_insert.c
@@ -276,7 +276,7 @@ check_static_begin(singly_linked_list_test_sort_reverse) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &singly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -332,7 +332,7 @@ check_static_begin(singly_linked_list_test_sort_even) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &singly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -392,7 +392,7 @@ check_static_begin(singly_linked_list_test_sort_odd) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &singly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -455,7 +455,7 @@ check_static_begin(singly_linked_list_test_sort_runs) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &singly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -518,7 +518,7 @@ check_static_begin(singly_linked_list_test_sort_halves) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &singly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -574,7 +574,7 @@ check_static_begin(singly_linked_list_test_sort_insert) {
         ),
         false
     );
-    CCC_Result const r = CCC_sort_mergesort(
+    CCC_Result const r = CCC_sort_merge(
         &singly_linked_list,
         CCC_ORDER_LESSER,
         &(CCC_Comparator){.compare = val_order}
@@ -701,7 +701,7 @@ check_static_begin(singly_linked_list_test_insert_sorted_allocation) {
     check(
         singly_linked_list_is_sorted(&list, CCC_ORDER_LESSER, comparator), false
     );
-    CCC_Result r = CCC_sort_mergesort(&list, CCC_ORDER_LESSER, comparator);
+    CCC_Result r = CCC_sort_merge(&list, CCC_ORDER_LESSER, comparator);
     check(
         singly_linked_list_is_sorted(&list, CCC_ORDER_LESSER, comparator), true
     );
@@ -781,19 +781,19 @@ check_static_begin(singly_linked_list_test_insert_sorted_allocation) {
 check_static_begin(singly_linked_list_test_mergesort_errors) {
     Singly_linked_list list = singly_linked_list_default(struct Val, e);
     check(
-        CCC_sort_singly_linked_list_mergesort(
+        CCC_sort_merge_singly_linked_list(
             NULL, CCC_ORDER_LESSER, &(CCC_Comparator){}
         ),
         CCC_RESULT_ARGUMENT_ERROR
     );
     check(
-        CCC_sort_singly_linked_list_mergesort(
+        CCC_sort_merge_singly_linked_list(
             &list, CCC_ORDER_EQUAL, &(CCC_Comparator){}
         ),
         CCC_RESULT_ARGUMENT_ERROR
     );
     check(
-        CCC_sort_singly_linked_list_mergesort(&list, CCC_ORDER_LESSER, NULL),
+        CCC_sort_merge_singly_linked_list(&list, CCC_ORDER_LESSER, NULL),
         CCC_RESULT_ARGUMENT_ERROR
     );
     check_end();


### PR DESCRIPTION
Eliminate sort naming redundancy. For example, `CCC_sort_heapsort` has a clunky `sort` redundancy. Mergesort has the same problem. Use the `CCC_sort_*` prefix and then simply name the sort type (`CCC_sort_heap`, `CCC_sort_merge`, etc.).